### PR TITLE
Add UUID suffix to save-data filenames

### DIFF
--- a/jobs/mirrorview_scaled_2026_06_18/README.md
+++ b/jobs/mirrorview_scaled_2026_06_18/README.md
@@ -23,3 +23,5 @@ Results:
   - avg processed mirrored chars **200.2**
 - `flips.csv`: avg original chars (**truncated**) **179.2**, avg mirrored chars **200.2**
 - Delta (`flips.csv` − `old_flips.csv`): avg mirrored chars **−126.8**
+
+We take this flips.csv and re-upload to S3 so that our already-validated UI can consume it.

--- a/lambda-save-jspsych-data.mjs
+++ b/lambda-save-jspsych-data.mjs
@@ -1,4 +1,5 @@
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { randomUUID } from "node:crypto";
 
 const AWS_REGION = process.env.AWS_REGION || "us-east-2";
 const BUCKET_NAME = process.env.BUCKET_NAME || "jspsych-mirror-view-4";
@@ -44,7 +45,7 @@ export const handler = async (event) => {
     const prolificId = body.prolific_id;
     const isTest = inferIsTest(prolificId, body.isTest);
     const prefix = isTest ? DATA_PREFIX_TEST : DATA_PREFIX_PROLIFIC;
-    const filename = `data_${Date.now()}.csv`;
+    const filename = `data_${Date.now()}_${randomUUID()}.csv`;
 
     await s3Client.send(
       new PutObjectCommand({

--- a/scripts/export_study_results.py
+++ b/scripts/export_study_results.py
@@ -147,7 +147,9 @@ def load_downloaded_csvs(local_paths: list[Path]) -> pd.DataFrame:
     )
 
     if not filtered_frames:
-        return pd.DataFrame()
+        # Keep the output shape stable so downstream filtering can run even when
+        # no CSVs survive the "valid prolific_id" filter.
+        return pd.DataFrame(columns=["prolific_id"])
     return pd.concat(filtered_frames, ignore_index=True)
 
 

--- a/scripts/export_study_results.py
+++ b/scripts/export_study_results.py
@@ -1,6 +1,6 @@
 """Export mirror view pilot data from S3 into a single filtered CSV.
 
-Only objects named ``data_<epoch_ms>.csv`` (lambda upload time) at or after
+Only objects named ``data_<epoch_ms>.csv`` or ``data_<epoch_ms>_<uuid>.csv`` (lambda upload time) at or after
 ``--since-date`` (UTC midnight) are listed and merged. To run:
 
     - PYTHONPATH=. uv run python scripts/export_study_results.py           # skip existing files
@@ -23,7 +23,9 @@ from lib.timestamp_utils import get_current_timestamp
 BUCKET_NAME = "jspsych-mirror-view-4"
 S3_PREFIX = "data/prolific/"
 EXPECTED_FILE_COUNT = 190
-DATA_CSV_FILENAME_PATTERN = re.compile(r"^data_(\d+)\.csv$")
+DATA_CSV_FILENAME_PATTERN = re.compile(
+    r"^data_(\d+)(?:_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})?\.csv$"
+)
 MANUAL_TEST_PATTERN = re.compile(r"^manual-test-.*$")
 INVALID_PROLIFIC_SUBSTRINGS = ("pid", "manual-test", "dev")
 DEFAULT_SINCE_DATE = date(2026, 4, 20)
@@ -40,7 +42,7 @@ def utc_midnight_ms(d: date) -> int:
 
 
 def list_csv_keys(s3_client: boto3.client, *, min_file_epoch_ms: int) -> list[str]:
-    """Return CSV object keys under the prefix that match ``data_<ms>.csv`` with ``ms >= min_file_epoch_ms``."""
+    """Return CSV object keys under the prefix that match ``data_<ms>.csv`` or ``data_<ms>_<uuid>.csv`` with ``ms >= min_file_epoch_ms``."""
     paginator = s3_client.get_paginator("list_objects_v2")
     csv_keys: list[str] = []
     skipped_non_matching = 0
@@ -171,7 +173,7 @@ def main() -> None:
         default=DEFAULT_SINCE_DATE,
         metavar="YYYY-MM-DD",
         help=(
-            "Only include objects named data_<ms>.csv where ms is at or after UTC midnight on "
+            "Only include objects named data_<ms>.csv or data_<ms>_<uuid>.csv where ms is at or after UTC midnight on "
             f"this date (ISO). Default: {DEFAULT_SINCE_DATE.isoformat()}."
         ),
     )


### PR DESCRIPTION
### Overview
Prevent rare S3 key collisions (overwrites) when participants finish concurrently by adding a UUID suffix to `data_<epoch_ms>.csv` uploads, while preserving downstream export compatibility by keeping the epoch-ms prefix parseable.

### Problem / motivation
The save-data Lambda currently writes to S3 using keys of the form `data_<epoch_ms>.csv` (where `<epoch_ms>` is `Date.now()` in milliseconds). If two invocations occur within the same millisecond in the same prefix (e.g. `data/prolific/`), they can generate the same key and the later write will overwrite the earlier object.

### Solution
Update the save-data Lambda to generate unique S3 keys as `data_<epoch_ms>_<uuid>.csv` and update the export script to accept both the old and new filename shapes while still parsing `<epoch_ms>`.

### Happy Flow
1. Participant finishes the study in `public/main.js` and posts `{ csv, prolific_id, isTest }` to `SAVE_DATA_URL`.
2. `lambda-save-jspsych-data.mjs`:
   - infers test vs prolific prefix (`data/test/` vs `data/prolific/`)
   - generates a unique filename: `data_<epoch_ms>_<uuid>.csv`
   - uploads to S3 with key `${prefix}${filename}`
   - returns `{ key: ".../data_<epoch_ms>_<uuid>.csv" }`
3. Operators can:
   - list S3 objects under `data/prolific/` and see the new suffix
   - run `scripts/export_study_results.py`, which still parses `<epoch_ms>` from the basename prefix and filters by `--since-date` as before.

### Data Flow
The browser save request hits the `save-jspsych-scroll-save-data` API route; the Lambda persists the incoming CSV to `s3://<bucket>/<prefix>/data_<epoch_ms>_<uuid>.csv`. The export script lists keys under `data/prolific/`, uses an anchored regex to extract `<epoch_ms>` from the basename, and then downloads/filters CSVs for `--since-date` before writing the merged output CSV.

### Changes
- `lambda-save-jspsych-data.mjs`: append UUID suffix (`data_<epoch_ms>_<uuid>.csv`) while keeping epoch-ms prefix first.
- `scripts/export_study_results.py`: update filename regex/doc/help to accept both `data_<epoch_ms>.csv` and `data_<epoch_ms>_<uuid>.csv`.

### Manual Verification
- [x] **Static check:** Ensure the new filename keeps the epoch-ms prefix (e.g. `data_1718888888888_<uuid>.csv`), not just a UUID.
- [x] **Unit-level sanity (manual):** In `lambda-save-jspsych-data.mjs`, confirm the key written is under:
  - `data/prolific/` when `prolific_id` is a real ID and `isTest=false`
  - `data/test/` for missing/`UNKNOWN_...`/`TEST_...` or `isTest=true`
- [x] **Terraform apply (Lambda redeploy):**

```bash
cd infra
terraform init
terraform plan  -var-file=../jobs/terraform/mirrorview_scaled_2026_06_18.tfvars
terraform apply -var-file=../jobs/terraform/mirrorview_scaled_2026_06_18.tfvars
```
- [x] **Confirm Lambda updated in AWS (timestamp changes):**

```bash
aws lambda get-function-configuration \
  --region us-east-2 \
  --function-name jspsych-scroll-save-data \
  --query '{function_name:FunctionName,last_modified:LastModified}' \
  --output table
```
- [x] **POST a small save payload to the live API and confirm key shape includes UUID suffix:**

```bash
SAVE_DATA_URL="$(node -e \"const c=require('./public/config.js'); console.log(c.SAVE_DATA_URL)\")"
curl -sS -X POST "$SAVE_DATA_URL" \
  -H 'Content-Type: application/json' \
  -d '{"csv":"trial_type,prolific_id\\nmanual_test,TEST_123\\n","prolific_id":"TEST_123","isTest":true}' \
  | python -m json.tool
```

**Expect:** JSON includes a `key` like `data/test/data_<epoch_ms>_<uuid>.csv`.
- [x] **S3 listing shows the new object under the expected prefix:**

```bash
aws s3 ls s3://jspsych-mirror-view-4/data/test/ --region us-east-2 | tail -n 5
```
- [x] **Export script still works (pattern updated) and produces an output CSV:**

```bash
PYTHONPATH=. uv run python scripts/export_study_results.py --since-date 2026-04-20 --force-download
```

**Expect:** It lists keys successfully (skipping invalid users as before) and writes `scripts/mirrorview_pilot_data_<timestamp>.csv`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data file naming during upload to reduce potential filename collisions.
  * Updated study export behavior when no valid participant IDs are found to avoid downstream errors by returning a consistent empty result.

* **Chores**
  * Enhanced the data export tool to recognize both legacy and newer data filename formats for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->