### PR TITLE
Migrate obvious loaders onto shared dataset registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 2026-07-31
 
-1. Documented the study history and refreshed the README, and checked in canonical Phase 2 raw CSVs under `shared/data/raw/` so experiments share one consistent narrative and dataset source. [PR #34](https://github.com/METResearchGroup/mirrorView-task/pull/34)
-2. Added a shared dataset registry and raw-only `load_dataset` API so callers load Phase 2 study CSVs by stable name instead of hardcoding paths under `shared/data/raw/`. [PR #35](https://github.com/METResearchGroup/mirrorView-task/pull/35)
+1. Migrated thirteen Phase 1 experiment entry points to load Part 1 pilot results and Part 2 stimuli through the shared dataset registry instead of hardcoded `scripts/` or `combined_flips` paths. [PR #36](https://github.com/METResearchGroup/mirrorView-task/pull/36)
+2. Documented the study history and refreshed the README, and checked in canonical Phase 2 raw CSVs under `shared/data/raw/` so experiments share one consistent narrative and dataset source. [PR #34](https://github.com/METResearchGroup/mirrorView-task/pull/34)
+3. Added a shared dataset registry and raw-only `load_dataset` API so callers load Phase 2 study CSVs by stable name instead of hardcoding paths under `shared/data/raw/`. [PR #35](https://github.com/METResearchGroup/mirrorView-task/pull/35)
 
 ## 2026-07-28
 

--- a/docs/plans/2026-07-31_migrate_dataloader_dropins_013142/plan.md
+++ b/docs/plans/2026-07-31_migrate_dataloader_dropins_013142/plan.md
@@ -1,0 +1,55 @@
+# Migrate obvious experiment loaders onto the shared dataset registry
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Thirteen experiment entry points still read study CSVs via hardcoded paths under `scripts/` or experiment-local flip files. The shared registry and raw loader from the prior shared-data work already cover those tables. This plan swaps only the obvious drop-ins: same frame shape, no transforms. Rebuilds of slim keep/remove exports, modal aggregates, attrition timestamp logic, producers, and unfinished experiments stay out of scope (see `strategy_planning/migrate_to_single_dataloader_2026_07_31/migration_plan.md` Phases 2–3).
+
+## Happy flow
+
+An analysis or generation script asks the shared loader for a named pilot-results or Part 2 stimuli dataset and receives the same DataFrame it previously got from a pinned path.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    E1[Experiment script] --> P1[Hardcoded CSV path]
+    P1 --> DF1[DataFrame]
+  end
+  subgraph after [After]
+    E2[Experiment script] -->|registry name| L[Shared loader]
+    L --> R[Registry]
+    R --> RAW[shared/data/raw CSV]
+    L --> DF2[DataFrame]
+  end
+```
+
+## Approach
+
+Two batches only: Part 1 pilot results consumers, then Part 2 stimuli consumers. Each change is a path-for-name substitution; existing post-load filters stay local. No new shared transforms, no registry expansion, no deletion of legacy CSVs.
+
+## Steps
+
+### Step 1: Point Part 1 pilot-results callers at the shared loader
+
+Update free-response, mirrors content analysis, basic summary stats (including toxicity breakdown), and the keep/remove metrics fallback so they load the registered Part 1 pilot results table instead of `scripts/` or pinned export paths.
+
+### Step 2: Point Part 2 stimuli callers at the shared loader
+
+Update match-lengths runners/ablations, truncate-posts defaults (v1–v3 and v5), and the combined-flips length validator so they load the registered Part 2 stimuli table instead of `combined_flips/flips.csv`.
+
+### Step 3: Smoke-check both registry loads from the migrated call sites
+
+Run short import/load checks that confirm Part 1 pilot results and Part 2 stimuli resolve and return expected shapes, and that one script from each batch no longer depends on the old path constants.
+
+## What "done" looks like
+
+1. All thirteen Phase 1 files from the migration plan use the shared loader for their study CSV ingress.
+2. No new transforms or registry names are added.
+3. Phases 2–3 migration items remain untouched.
+4. Smoke commands succeed when the local raw CSVs under `shared/data/raw/` are present.
+5. Legacy `scripts/` exports and `combined_flips/flips.csv` may still exist on disk; nothing in this plan deletes them.

--- a/docs/plans/2026-07-31_migrate_dataloader_dropins_013142/steps/step1.md
+++ b/docs/plans/2026-07-31_migrate_dataloader_dropins_013142/steps/step1.md
@@ -1,0 +1,133 @@
+# Step 1: Point Part 1 pilot-results callers at the shared loader
+
+## Goal
+
+Replace hardcoded Part 1 pilot results CSV paths with `shared.data.dataloader.load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT)`. Keep every post-load filter and transform that already exists in these files. No reshape of the raw frame beyond what each script already does.
+
+## Caller / unit of work
+
+**Main callers (in this step):**
+
+1. `experiments/free_response_analysis_2026_04_28/main.py` — phase-1 free-response filter/export
+2. `experiments/mirrors_content_analysis_2026_04_24/dataloader.py` — pinned pilot ingress for content analysis
+3. `experiments/basic_summary_stats_2026_04_27/summary_stats.py` — party × condition tables
+4. `experiments/basic_summary_stats_2026_04_27/toxicity_remove_breakdown.py` — toxicity × party removal rates
+5. `experiments/predict_keep_remove_2026_05_07/generate_dataset_metrics.py` — fallback export discovery when preferred dataloader fails
+
+**In scope:** Swap ingress only to the registered Part 1 pilot results dataset. Remove `scripts/mirrorview_pilot_data_*.csv` discovery / pinned-path reads from these five files.
+
+**Out of scope:** Part 2 stimuli migrations (Step 2); `total_attrition.py`; keep/remove slim CSV rebuild; `05_07` label joins redesign; registry/dataloader changes; deleting legacy CSVs.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorview-wt/shared/data/dataloader.py` | Target API: `load_dataset` |
+| `/Users/mark/src/work/mirrorview-wt/shared/data/registry.py` | Constant `STUDY_PHASE_2_PART_1_RESULTS_PILOT` |
+| `/Users/mark/src/work/mirrorview-wt/strategy_planning/migrate_to_single_dataloader_2026_07_31/migration_plan.md` | Phase 1 inventory |
+| `/Users/mark/src/work/mirrorview-wt/docs/plans/2026-07-31_migrate_dataloader_dropins_013142/plan.md` | Parent plan |
+| Each file in “Files allowed to change” | Current path / discovery logic |
+
+## Files allowed to change
+
+- `/Users/mark/src/work/mirrorview-wt/experiments/free_response_analysis_2026_04_28/main.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/mirrors_content_analysis_2026_04_24/dataloader.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/basic_summary_stats_2026_04_27/summary_stats.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/basic_summary_stats_2026_04_27/toxicity_remove_breakdown.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/predict_keep_remove_2026_05_07/generate_dataset_metrics.py`
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorview-wt/shared/data/registry.py`
+- `/Users/mark/src/work/mirrorview-wt/shared/data/dataloader.py`
+- `/Users/mark/src/work/mirrorview-wt/shared/data/raw/**`
+- `/Users/mark/src/work/mirrorview-wt/experiments/basic_summary_stats_2026_04_27/total_attrition.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/predict_keep_remove_2026_05_07/dataloader.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/predict_keep_remove_2026_07_01/**`
+- Any Part 2 stimuli consumers listed in Step 2
+
+## Per-file changes (exact)
+
+### 1. `free_response_analysis_2026_04_28/main.py`
+
+- Remove `SOURCE_CSV = PROJECT_ROOT / "scripts" / "mirrorview_pilot_data_2026_04_28-16:31:47.csv"`.
+- Import `load_dataset` and `STUDY_PHASE_2_PART_1_RESULTS_PILOT`.
+- Change `generate_filtered_dataframe` so it loads the pilot results via `load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT)` instead of `pd.read_csv(source_csv)`. Keep the existing column checks and phase-1 reflection/influence filters. Keep writing `FILTERED_CSV`.
+- If `source_csv: Path` remains as a parameter for tests/overrides, default it unused; preferred: drop the path parameter and always use the shared loader for the raw ingress.
+
+### 2. `mirrors_content_analysis_2026_04_24/dataloader.py`
+
+- In `get_latest_mirrorview_run_data`, replace `pd.read_csv(self.PINNED_EXPORT_PATH, low_memory=False)` with `load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT)`.
+- Remove `PINNED_EXPORT_FILENAME` / `PINNED_EXPORT_PATH` (or leave unused only if something external still references them — prefer delete).
+- Keep `transform_latest_mirrorview_run_data` byte-for-byte in behavior.
+- Update `last_loaded_export_path` if still useful: set it to `registry.resolve_path(STUDY_PHASE_2_PART_1_RESULTS_PILOT)` so prints still show a path.
+
+### 3. `basic_summary_stats_2026_04_27/summary_stats.py`
+
+- Delete `find_latest_export_csv` and `copy_latest_export_csv` and the `SCRIPTS_DIR` / `LOCAL_DATA_CSV` copy workflow.
+- In `main`, load with `load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT)` and print row / prolific counts as today.
+- Do **not** switch to Part 1 full results in this step (product choice deferred to Phase 3 of the migration inventory).
+
+### 4. `basic_summary_stats_2026_04_27/toxicity_remove_breakdown.py`
+
+- Stop importing / calling `find_latest_export_csv` from `summary_stats`.
+- Load `STUDY_PHASE_2_PART_1_RESULTS_PILOT` via `load_dataset` in `main`.
+- Keep `moderation_phase_frame` and all reporting logic unchanged.
+
+### 5. `predict_keep_remove_2026_05_07/generate_dataset_metrics.py`
+
+- Preferred path (`Dataloader().load_training_dataframe()`) stays.
+- Fallback path: replace `_choose_latest_valid_export_csv(...)` + `pd.read_csv(export_path)` with `raw = load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT)`, then keep `pilot.transform_latest_mirrorview_run_data(raw)` and the linked-fate / keep-remove filters.
+- Delete `_choose_latest_valid_export_csv` and the `mirrorview_pilot_data_*.csv` regex helpers **if** nothing else in this file uses them after the swap.
+
+## Exact commands
+
+```bash
+cd /Users/mark/src/work/mirrorview-wt
+
+# Confirm pilot CSV present
+test -f shared/data/raw/study_phase_2_part_1/results/pilot.csv && echo OK_PILOT
+
+# Shared loader shape
+PYTHONPATH=. uv run python - <<'PY'
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_1_RESULTS_PILOT
+df = load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT)
+assert "prolific_id" in df.columns and "phase1_pair_reflection_text" in df.columns
+print("PILOT_ROWS", len(df), "PILOT_COLS", len(df.columns))
+PY
+
+# Mirrors ingress (no transform write required)
+PYTHONPATH=. uv run python - <<'PY'
+from experiments.mirrors_content_analysis_2026_04_24.dataloader import Dataloader
+raw = Dataloader().get_latest_mirrorview_run_data()
+assert len(raw) > 0
+print("MIRRORS_RAW_ROWS", len(raw))
+PY
+```
+
+### Expected outputs (pass signals)
+
+```text
+OK_PILOT
+PILOT_ROWS 8985 PILOT_COLS 41
+MIRRORS_RAW_ROWS 8985
+```
+
+(Row count must match the on-disk pilot CSV; if the local file differs, print the actual count and assert it equals `len(pd.read_csv("shared/data/raw/study_phase_2_part_1/results/pilot.csv"))`.)
+
+## Pass / fail
+
+**Pass:**
+
+- All five allowed files load Part 1 pilot results only through `load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT)` (or via mirrors `get_latest_mirrorview_run_data` which itself uses that call).
+- No remaining references in those five files to `scripts/mirrorview_pilot_data` path strings or `PINNED_EXPORT_PATH` reads.
+- `transform_latest_mirrorview_run_data` and free-response / summary filters unchanged in behavior.
+- Commands above succeed when the pilot CSV is present.
+
+**Fail:**
+
+- Any of the five files still glob `scripts/` for study results.
+- Switching summary stats to Part 1 **full** results.
+- Changing shared registry / loader code.
+- Editing `total_attrition.py` or Phase 2 / 3 migration targets.

--- a/docs/plans/2026-07-31_migrate_dataloader_dropins_013142/steps/step2.md
+++ b/docs/plans/2026-07-31_migrate_dataloader_dropins_013142/steps/step2.md
@@ -1,0 +1,140 @@
+# Step 2: Point Part 2 stimuli callers at the shared loader
+
+## Goal
+
+Replace hardcoded reads of `experiments/scaled_mirrors_generation_2026_06_02/generated_flips/combined_flips/flips.csv` with `load_dataset(STUDY_PHASE_2_PART_2_STIMULI)`. That registry file is column- and key-equivalent to the combined flips CSV (10,000 rows). No truncation / generation logic changes.
+
+## Caller / unit of work
+
+**Main callers (in this step):**
+
+1. `experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths.py` — defines the shared input for v1/v2/ablations
+2. `experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths_v2.py`
+3. `experiments/match_lengths_original_mirrors_2026_06_19/run_ablations.py`
+4. `experiments/truncate_posts_2026_06_19/truncate_flips.py` — default input imported by v2/v3
+5. `experiments/truncate_posts_2026_06_19/truncate_flips_v2.py`
+6. `experiments/truncate_posts_2026_06_19/truncate_flips_v3.py`
+7. `experiments/truncate_posts_2026_06_19/truncation_v5/generate_flips.py`
+8. `experiments/scaled_mirrors_generation_2026_06_02/validate_mirrors_equal_lengths.py`
+
+**In scope:** Default / hardcoded stimuli ingress only. CLI overrides that already accept an explicit path may remain if present, but the **default** must be the shared loader.
+
+**Out of scope:** Part 1 results migrations (Step 1); producers under `scaled_mirrors_generation` other than the validator; deleting `combined_flips/flips.csv`; registry changes.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorview-wt/shared/data/dataloader.py` | `load_dataset` |
+| `/Users/mark/src/work/mirrorview-wt/shared/data/registry.py` | `STUDY_PHASE_2_PART_2_STIMULI` |
+| `/Users/mark/src/work/mirrorview-wt/strategy_planning/migrate_to_single_dataloader_2026_07_31/migration_plan.md` | Phase 1 stimuli rows |
+| `/Users/mark/src/work/mirrorview-wt/docs/plans/2026-07-31_migrate_dataloader_dropins_013142/plan.md` | Parent plan |
+| Each file in “Files allowed to change” | Current `INPUT_CSV` / `FLIPS_CSV` / `DEFAULT_INPUT_CSV` usage |
+
+## Files allowed to change
+
+- `/Users/mark/src/work/mirrorview-wt/experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths_v2.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/match_lengths_original_mirrors_2026_06_19/run_ablations.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/truncate_posts_2026_06_19/truncate_flips.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/truncate_posts_2026_06_19/truncate_flips_v2.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/truncate_posts_2026_06_19/truncate_flips_v3.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/truncate_posts_2026_06_19/truncation_v5/generate_flips.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/scaled_mirrors_generation_2026_06_02/validate_mirrors_equal_lengths.py`
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorview-wt/shared/data/registry.py`
+- `/Users/mark/src/work/mirrorview-wt/shared/data/dataloader.py`
+- `/Users/mark/src/work/mirrorview-wt/shared/data/raw/**`
+- `/Users/mark/src/work/mirrorview-wt/experiments/scaled_mirrors_generation_2026_06_02/balance_flips.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/scaled_mirrors_generation_2026_06_02/generate_flips.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/match_lengths_original_mirrors_2026_06_19/README.md` (docs optional; not required this step)
+- Any Step 1 Part 1 results files (unless already finished in Step 1)
+
+## Per-file changes (exact)
+
+### Shared pattern (both experiment families)
+
+Prefer a small helper in the **parent** module so siblings do not re-pin paths:
+
+```python
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_2_STIMULI
+
+def load_default_stimuli() -> pd.DataFrame:
+    return load_dataset(STUDY_PHASE_2_PART_2_STIMULI)
+```
+
+Remove `Path(.../combined_flips/flips.csv)` constants used as the default input. Replace `INPUT_CSV.exists()` / `pd.read_csv(INPUT_CSV)` with the helper (missing file → `FileNotFoundError` from `load_dataset`). For log lines that printed the path, use `registry.resolve_path(STUDY_PHASE_2_PART_2_STIMULI)`.
+
+### 1–3. Match-lengths family
+
+- `run_match_lengths.py`: add `load_default_stimuli()` (name may vary); remove `INPUT_CSV` Path constant; load via helper in `main`.
+- `run_match_lengths_v2.py`: stop importing `INPUT_CSV`; import / call the helper from `run_match_lengths.py`.
+- `run_ablations.py`: same as v2.
+
+### 4–6. Truncate-posts v1–v3
+
+- `truncate_flips.py`: replace `INPUT_CSV` Path with a load helper (or inline `load_dataset`); update the function that currently does `pd.read_csv(source_csv)` so the default path is the shared stimuli load. If the CLI still accepts an optional override path, keep that branch as `pd.read_csv(override)` only when an override is passed.
+- `truncate_flips_v2.py` / `truncate_flips_v3.py`: they import `INPUT_CSV` from `truncate_flips`. After the parent change, import the helper instead and stop treating the default input as a `Path` that must `.exists()`.
+
+### 7. `truncation_v5/generate_flips.py`
+
+- Replace `DEFAULT_INPUT_CSV` Path with `load_dataset(STUDY_PHASE_2_PART_2_STIMULI)` as the default input to the chunked reader path.
+- If the function signature takes `input_csv: Path = DEFAULT_INPUT_CSV`, change the default to `None` meaning “use shared loader”, and only `pd.read_csv` when an explicit path is passed.
+
+### 8. `validate_mirrors_equal_lengths.py`
+
+- Replace `FLIPS_CSV = .../combined_flips/flips.csv` + `pd.read_csv(FLIPS_CSV)` with `load_dataset(STUDY_PHASE_2_PART_2_STIMULI)`.
+
+## Exact commands
+
+```bash
+cd /Users/mark/src/work/mirrorview-wt
+
+test -f shared/data/raw/study_phase_2_part_2/stimuli/flips.csv && echo OK_P2_STIM
+
+PYTHONPATH=. uv run python - <<'PY'
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_2_STIMULI
+df = load_dataset(STUDY_PHASE_2_PART_2_STIMULI)
+assert list(df.columns) == [
+    "post_primary_key",
+    "original_text",
+    "sample_toxicity_type",
+    "sampled_stance",
+    "mirrored_text",
+]
+assert len(df) == 10000
+print("STIM_ROWS", len(df))
+PY
+
+# Validator after migration
+PYTHONPATH=. uv run python experiments/scaled_mirrors_generation_2026_06_02/validate_mirrors_equal_lengths.py
+```
+
+### Expected outputs (pass signals)
+
+```text
+OK_P2_STIM
+STIM_ROWS 10000
+```
+
+Plus whatever success / metrics print the validator already emits (must complete without `FileNotFoundError` on `combined_flips/flips.csv`).
+
+## Pass / fail
+
+**Pass:**
+
+- All eight allowed files use `load_dataset(STUDY_PHASE_2_PART_2_STIMULI)` for the default stimuli ingress.
+- No remaining default Path constants pointing at `combined_flips/flips.csv` in those eight files.
+- `v2`/`v3`/`ablations` no longer import a Path `INPUT_CSV` that points at combined flips.
+- Commands above succeed when the Part 2 stimuli CSV is present.
+
+**Fail:**
+
+- Rewriting truncation / LLM generation logic.
+- Deleting or moving `combined_flips/flips.csv`.
+- Changing shared registry / loader.
+- Migrating Part 1 results files in this step (belongs in Step 1).

--- a/docs/plans/2026-07-31_migrate_dataloader_dropins_013142/steps/step3.md
+++ b/docs/plans/2026-07-31_migrate_dataloader_dropins_013142/steps/step3.md
@@ -1,0 +1,103 @@
+# Step 3: Smoke-check both registry loads from the migrated call sites
+
+## Goal
+
+Prove the Step 1 and Step 2 migrations: both registry datasets load with expected shapes, and one representative caller from each batch no longer depends on the old hardcoded path constants.
+
+## Caller / unit of work
+
+**Main callers for verification:**
+
+- Part 1 batch: `experiments.mirrors_content_analysis_2026_04_24.dataloader.Dataloader.get_latest_mirrorview_run_data`
+- Part 2 batch: `experiments.scaled_mirrors_generation_2026_06_02.validate_mirrors_equal_lengths` (module load path) **or** a one-liner that imports the truncate/match-lengths helper added in Step 2
+
+**In scope:** Read-only smoke commands; optional tiny doc fix inside an already-migrated file if a print string still claims `scripts/` or `combined_flips` incorrectly.
+
+**Out of scope:** Implementing Step 1/2 file edits (must already be done); Phase 2/3 migrations; adding unit test packages; changing registry/loader.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| All Step 1 + Step 2 allowed files | Confirm no leftover old path constants |
+| `/Users/mark/src/work/mirrorview-wt/shared/data/registry.py` | Resolve paths for assertions |
+| `/Users/mark/src/work/mirrorview-wt/docs/plans/2026-07-31_migrate_dataloader_dropins_013142/plan.md` | Done criteria |
+
+## Files allowed to change
+
+- None required. Only touch a Step 1/2 allowed file if smoke reveals a leftover path string that was meant to be removed in that step.
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorview-wt/shared/data/registry.py`
+- `/Users/mark/src/work/mirrorview-wt/shared/data/dataloader.py`
+- `/Users/mark/src/work/mirrorview-wt/shared/data/raw/**`
+- `/Users/mark/src/work/mirrorview-wt/experiments/predict_keep_remove_2026_07_01/**`
+- `/Users/mark/src/work/mirrorview-wt/experiments/basic_summary_stats_2026_04_27/total_attrition.py`
+- Phase 2/3 items in `strategy_planning/migrate_to_single_dataloader_2026_07_31/migration_plan.md`
+
+## Exact commands
+
+```bash
+cd /Users/mark/src/work/mirrorview-wt
+
+# 1) Grep gate: migrated files must not retain old default path literals
+rg -n "scripts/mirrorview_pilot_data|PINNED_EXPORT_PATH|combined_flips/flips\.csv" \
+  experiments/free_response_analysis_2026_04_28/main.py \
+  experiments/mirrors_content_analysis_2026_04_24/dataloader.py \
+  experiments/basic_summary_stats_2026_04_27/summary_stats.py \
+  experiments/basic_summary_stats_2026_04_27/toxicity_remove_breakdown.py \
+  experiments/predict_keep_remove_2026_05_07/generate_dataset_metrics.py \
+  experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths.py \
+  experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths_v2.py \
+  experiments/match_lengths_original_mirrors_2026_06_19/run_ablations.py \
+  experiments/truncate_posts_2026_06_19/truncate_flips.py \
+  experiments/truncate_posts_2026_06_19/truncate_flips_v2.py \
+  experiments/truncate_posts_2026_06_19/truncate_flips_v3.py \
+  experiments/truncate_posts_2026_06_19/truncation_v5/generate_flips.py \
+  experiments/scaled_mirrors_generation_2026_06_02/validate_mirrors_equal_lengths.py \
+  && echo "UNEXPECTED_MATCHES" || echo "GREP_CLEAN"
+
+# 2) End-to-end load smoke for both datasets + one caller each
+PYTHONPATH=. uv run python - <<'PY'
+from shared.data.dataloader import load_dataset
+from shared.data import registry
+from experiments.mirrors_content_analysis_2026_04_24.dataloader import Dataloader
+
+pilot = load_dataset(registry.STUDY_PHASE_2_PART_1_RESULTS_PILOT)
+stim = load_dataset(registry.STUDY_PHASE_2_PART_2_STIMULI)
+raw = Dataloader().get_latest_mirrorview_run_data()
+
+assert len(pilot) == len(raw)
+assert len(stim) == 10000
+assert "mirrored_text" in stim.columns
+print("SMOKE_PILOT", len(pilot))
+print("SMOKE_STIM", len(stim))
+print("SMOKE_MIRRORS_CALLER", len(raw))
+print("STEP3_OK")
+PY
+```
+
+### Expected outputs (pass signals)
+
+```text
+GREP_CLEAN
+SMOKE_PILOT 8985
+SMOKE_STIM 10000
+SMOKE_MIRRORS_CALLER 8985
+STEP3_OK
+```
+
+(`8985` is the current local pilot row count; if the on-disk pilot differs, both `SMOKE_PILOT` and `SMOKE_MIRRORS_CALLER` must still match each other and the file.)
+
+**Fail signals:**
+
+- `UNEXPECTED_MATCHES` from the grep (any hit in the listed files).
+- `FileNotFoundError` / `KeyError` from `load_dataset`.
+- Mirrors caller still reading a missing pinned export under the experiment directory.
+
+## Pass / fail
+
+**Pass:** Grep is clean on all thirteen Phase 1 files; smoke script prints `STEP3_OK`; pilot and stimuli shapes match expectations; mirrors caller equals pilot row count.
+
+**Fail:** Any Phase 1 file still hardcodes the old paths; smoke fails; or this step is used to start Phase 2/3 work.

--- a/experiments/basic_summary_stats_2026_04_27/summary_stats.py
+++ b/experiments/basic_summary_stats_2026_04_27/summary_stats.py
@@ -1,28 +1,18 @@
-"""Compute basic mirror-view summary tables from the latest export CSV.
+"""Compute basic mirror-view summary tables from the shared Part 1 pilot results.
 
-This script:
-1) Copies the newest ``scripts/mirrorview_pilot_data_*.csv`` into this folder as
-   ``latest_mirrorview_pilot_data.csv`` (overwrites each run). That export should
-   already reflect the desired cohort (e.g. filename cutoff applied in
-   ``scripts/export_study_results.py``).
-2) Prints three tables:
-   - User counts by political party x condition
-   - Phase 1 keep/remove counts (and proportions within each party x condition) by cell
-   - Phase 2 keep/remove counts (and proportions within each party x condition) by cell
+This script loads ``STUDY_PHASE_2_PART_1_RESULTS_PILOT`` via the shared registry
+and prints three tables:
+- User counts by political party x condition
+- Phase 1 keep/remove counts (and proportions within each party x condition) by cell
+- Phase 2 keep/remove counts (and proportions within each party x condition) by cell
 """
 
 from __future__ import annotations
 
-from pathlib import Path
-import shutil
-
 import pandas as pd
 
-
-SCRIPT_DIR = Path(__file__).resolve().parent
-PROJECT_ROOT = SCRIPT_DIR.parent.parent
-SCRIPTS_DIR = PROJECT_ROOT / "scripts"
-LOCAL_DATA_CSV = SCRIPT_DIR / "latest_mirrorview_pilot_data.csv"
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_1_RESULTS_PILOT
 
 CONDITION_DISPLAY_MAP = {
     "control": "control",
@@ -32,23 +22,6 @@ CONDITION_DISPLAY_MAP = {
 CONDITION_ORDER = ["control", "training", "training-assisted"]
 PARTY_ORDER = ["democrat", "republican"]
 DECISION_ORDER = ["keep", "remove"]
-
-
-def find_latest_export_csv() -> Path:
-    """Return the newest ``mirrorview_pilot_data_*.csv`` under scripts/ by mtime."""
-    candidates = sorted(SCRIPTS_DIR.glob("mirrorview_pilot_data_*.csv"), key=lambda p: p.stat().st_mtime)
-    if not candidates:
-        raise FileNotFoundError(f"No mirrorview_pilot_data_*.csv under {SCRIPTS_DIR}")
-    return candidates[-1]
-
-
-def copy_latest_export_csv() -> Path:
-    """Copy the newest scripts export to ``latest_mirrorview_pilot_data.csv`` here."""
-    SCRIPT_DIR.mkdir(parents=True, exist_ok=True)
-    latest = find_latest_export_csv()
-    shutil.copy2(latest, LOCAL_DATA_CSV)
-    print(f"Copied {latest.name} -> {LOCAL_DATA_CSV} (canonical name for this run)")
-    return LOCAL_DATA_CSV
 
 
 def first_non_empty(series: pd.Series) -> str | None:
@@ -130,9 +103,11 @@ def print_table(title: str, table: pd.DataFrame) -> None:
 
 
 def main() -> None:
-    local_path = copy_latest_export_csv()
-    df = pd.read_csv(local_path)
-    print(f"Loaded {len(df):,} rows, {df['prolific_id'].nunique()} distinct prolific_id(s)")
+    df = load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT)
+    print(
+        f"Loaded {STUDY_PHASE_2_PART_1_RESULTS_PILOT}: "
+        f"{len(df):,} rows, {df['prolific_id'].nunique()} distinct prolific_id(s)"
+    )
 
     user_df = get_user_level_frame(df)
     users_table = format_user_table(user_df)

--- a/experiments/basic_summary_stats_2026_04_27/toxicity_remove_breakdown.py
+++ b/experiments/basic_summary_stats_2026_04_27/toxicity_remove_breakdown.py
@@ -12,7 +12,7 @@ Run from repo root::
 
     PYTHONPATH=. uv run python experiments/basic_summary_stats_2026_04_27/toxicity_remove_breakdown.py
 
-Uses the newest ``scripts/mirrorview_pilot_data_*.csv`` (same discovery rule as
+Loads ``STUDY_PHASE_2_PART_1_RESULTS_PILOT`` via the shared registry (same source as
 ``summary_stats.py``).
 """
 
@@ -20,10 +20,9 @@ from __future__ import annotations
 
 import pandas as pd
 
-from experiments.basic_summary_stats_2026_04_27.summary_stats import (
-    CONDITION_DISPLAY_MAP,
-    find_latest_export_csv,
-)
+from experiments.basic_summary_stats_2026_04_27.summary_stats import CONDITION_DISPLAY_MAP
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_1_RESULTS_PILOT
 
 # Observed pilot label for the middle bucket (see also ``public/main.js`` / post assignments).
 MIDDLE_TOXICITY_CANONICAL = "sample_middle_toxicity"
@@ -164,16 +163,8 @@ def print_empirical(df: pd.DataFrame) -> None:
 
 def main() -> None:
     print_pipeline_finding()
-    try:
-        path = find_latest_export_csv()
-    except FileNotFoundError as err:
-        print(
-            "\nNo export CSV found under scripts/ (run scripts/export_study_results.py). "
-            f"Detail: {err}"
-        )
-        return
-    print(f"\nLoaded export: {path}")
-    df = pd.read_csv(path, low_memory=False)
+    df = load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT, low_memory=False)
+    print(f"\nLoaded dataset: {STUDY_PHASE_2_PART_1_RESULTS_PILOT}")
     print_empirical(df)
 
 

--- a/experiments/free_response_analysis_2026_04_28/main.py
+++ b/experiments/free_response_analysis_2026_04_28/main.py
@@ -22,10 +22,12 @@ from rich import box
 from rich.console import Console
 from rich.table import Table
 
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_1_RESULTS_PILOT
+
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = SCRIPT_DIR.parent.parent
-SOURCE_CSV = PROJECT_ROOT / "scripts" / "mirrorview_pilot_data_2026_04_28-16:31:47.csv"
 FILTERED_CSV = SCRIPT_DIR / "phase1_free_response_filtered.csv"
 PLOTS_DIR = SCRIPT_DIR / "plots"
 
@@ -93,15 +95,11 @@ def safe_divide(numerator: int | float, denominator: int | float) -> float:
 
 
 def generate_filtered_dataframe(
-    source_csv: Path = SOURCE_CSV,
     *,
     export_csv: Path = FILTERED_CSV,
 ) -> pd.DataFrame:
     """Create and export rows with populated phase 1 reflection text and influence rating."""
-    if not source_csv.exists():
-        raise FileNotFoundError(f"Source CSV not found: {source_csv}")
-
-    df = pd.read_csv(source_csv, low_memory=False)
+    df = load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT, low_memory=False)
     required = {
         "prolific_id",
         "party_group",
@@ -207,7 +205,7 @@ def render_overview(console: Console, df: pd.DataFrame) -> None:
     table = make_table("Overview")
     table.add_column("Measure")
     table.add_column("Value", justify="right")
-    table.add_row("Source CSV", SOURCE_CSV.name)
+    table.add_row("Source dataset", STUDY_PHASE_2_PART_1_RESULTS_PILOT)
     table.add_row("Filtered CSV", str(FILTERED_CSV.relative_to(PROJECT_ROOT)))
     table.add_row("Filtered rows", f"{len(df):,}")
     table.add_row("Distinct users", f"{df['prolific_id'].nunique():,}")

--- a/experiments/match_lengths_original_mirrors_2026_06_19/run_ablations.py
+++ b/experiments/match_lengths_original_mirrors_2026_06_19/run_ablations.py
@@ -20,8 +20,8 @@ from experiments.match_lengths_original_mirrors_2026_06_19.ablation_lib import (
     generate_ablation,
 )
 from experiments.match_lengths_original_mirrors_2026_06_19.run_match_lengths import (
-    INPUT_CSV,
     _output_timestamp,
+    load_default_stimuli,
 )
 
 EXPERIMENT_DIR = Path(__file__).resolve().parent
@@ -33,7 +33,7 @@ RANDOM_SEED = 42
 
 
 def _load_sample() -> pd.DataFrame:
-    df = pd.read_csv(INPUT_CSV)
+    df = load_default_stimuli()
     if len(df) < SAMPLE_SIZE:
         raise ValueError(f"Input has {len(df)} rows; need at least {SAMPLE_SIZE}.")
     return df.sample(n=SAMPLE_SIZE, random_state=RANDOM_SEED).reset_index(drop=True)
@@ -65,7 +65,7 @@ def _write_ablations_md(rows: list[str]) -> None:
 
 Character parity (≥10% relative diff) is the **primary** metric. Token parity is **diagnostic**.
 
-Each ablation uses **25 posts** sampled from `combined_flips/flips.csv` with `random_state=42`.
+Each ablation uses **25 posts** sampled from the shared Part 2 stimuli registry with `random_state=42`.
 
 | Ablation | Changes | Char fail | Token fail | Too long | Too short | Parse fail | Avg chars (mirr/orig) | Avg tokens (mirr/orig) | Output CSV |
 |---|---|---:|---:|---:|---:|---:|---|---:|---|
@@ -129,9 +129,6 @@ def main() -> None:
         ablation_ids = args.ablation
     else:
         parser.error("Specify --ablation ID or --all")
-
-    if not INPUT_CSV.exists():
-        raise FileNotFoundError(f"Input CSV not found: {INPUT_CSV}")
 
     for ablation_id in ablation_ids:
         run_ablation(ablation_id, skip_existing=args.skip_existing)

--- a/experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths.py
+++ b/experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths.py
@@ -20,15 +20,11 @@ from tqdm import tqdm
 
 from experiments.scaled_mirrors_generation_2026_06_02.prompts import FLIP_PROMPT
 from lib.constants import BEDROCK_REGION, DEFAULT_BEDROCK_SONNET_MODEL
+from shared.data import registry
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_2_STIMULI
 
 EXPERIMENT_DIR = Path(__file__).resolve().parent
-INPUT_CSV = (
-    Path(__file__).resolve().parents[1]
-    / "scaled_mirrors_generation_2026_06_02"
-    / "generated_flips"
-    / "combined_flips"
-    / "flips.csv"
-)
 OUTPUT_DIR = EXPERIMENT_DIR / "outputs" / "match_lengths"
 
 SAMPLE_SIZE = 50
@@ -49,6 +45,16 @@ OUTPUT_COLUMNS = [
 class FlipResponse(BaseModel):
     flipped_text: str
     explanation: str
+
+
+def load_default_stimuli() -> pd.DataFrame:
+    """Load the registered Part 2 stimuli table via the shared registry."""
+    return load_dataset(STUDY_PHASE_2_PART_2_STIMULI)
+
+
+def default_stimuli_source_path() -> Path:
+    """Absolute path to the canonical Part 2 stimuli CSV."""
+    return registry.resolve_path(STUDY_PHASE_2_PART_2_STIMULI)
 
 
 def get_llm(
@@ -161,10 +167,8 @@ def _validate_equal_lengths(df: pd.DataFrame, *, flips_csv: Path) -> None:
 
 
 def main() -> None:
-    if not INPUT_CSV.exists():
-        raise FileNotFoundError(f"Input CSV not found: {INPUT_CSV}")
-
-    df = pd.read_csv(INPUT_CSV)
+    stimuli_path = default_stimuli_source_path()
+    df = load_default_stimuli()
     required_cols = [
         "post_primary_key",
         "original_text",
@@ -173,10 +177,10 @@ def main() -> None:
     ]
     missing_cols = [col for col in required_cols if col not in df.columns]
     if missing_cols:
-        raise KeyError(f"Missing required columns in {INPUT_CSV}: {missing_cols}")
+        raise KeyError(f"Missing required columns in {stimuli_path}: {missing_cols}")
 
     sampled = _sample_posts(df)
-    print(f"Sampled {len(sampled)} posts from {INPUT_CSV} (seed={RANDOM_SEED}).")
+    print(f"Sampled {len(sampled)} posts from {stimuli_path} (seed={RANDOM_SEED}).")
 
     results = _generate_flips(sampled)
 

--- a/experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths_v2.py
+++ b/experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths_v2.py
@@ -18,14 +18,15 @@ from tqdm import tqdm
 
 from experiments.match_lengths_original_mirrors_2026_06_19.prompts import FLIP_PROMPT_V2
 from experiments.match_lengths_original_mirrors_2026_06_19.run_match_lengths import (
-    INPUT_CSV,
     LENGTH_DIFF_THRESHOLD,
     RANDOM_SEED,
     _compute_target_group,
     _output_timestamp,
     _sample_posts,
     _validate_equal_lengths,
+    default_stimuli_source_path,
     get_llm,
+    load_default_stimuli,
 )
 
 EXPERIMENT_DIR = Path(__file__).resolve().parent
@@ -109,10 +110,8 @@ def _validate_token_lengths(df: pd.DataFrame) -> None:
 
 
 def main() -> None:
-    if not INPUT_CSV.exists():
-        raise FileNotFoundError(f"Input CSV not found: {INPUT_CSV}")
-
-    df = pd.read_csv(INPUT_CSV)
+    stimuli_path = default_stimuli_source_path()
+    df = load_default_stimuli()
     required_cols = [
         "post_primary_key",
         "original_text",
@@ -121,10 +120,10 @@ def main() -> None:
     ]
     missing_cols = [col for col in required_cols if col not in df.columns]
     if missing_cols:
-        raise KeyError(f"Missing required columns in {INPUT_CSV}: {missing_cols}")
+        raise KeyError(f"Missing required columns in {stimuli_path}: {missing_cols}")
 
     sampled = _sample_posts(df)
-    print(f"Sampled {len(sampled)} posts from {INPUT_CSV} (seed={RANDOM_SEED}).")
+    print(f"Sampled {len(sampled)} posts from {stimuli_path} (seed={RANDOM_SEED}).")
 
     results = _generate_flips(sampled)
 

--- a/experiments/mirrors_content_analysis_2026_04_24/dataloader.py
+++ b/experiments/mirrors_content_analysis_2026_04_24/dataloader.py
@@ -7,6 +7,9 @@ from pathlib import Path
 import pandas as pd
 
 from lib.timestamp_utils import get_current_timestamp
+from shared.data import registry
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_1_RESULTS_PILOT
 
 pd.set_option("display.max_columns", None)
 pd.set_option("display.width", None)
@@ -14,15 +17,10 @@ pd.set_option("display.expand_frame_repr", False)
 
 
 class Dataloader:
-    """Load a pinned export CSV and produce the curated trial-level table."""
+    """Load Part 1 pilot results via the shared registry and produce the trial-level table."""
 
     EXPERIMENT_DIR = Path(__file__).resolve().parent
     PROJECT_ROOT = EXPERIMENT_DIR.parent.parent
-    SCRIPTS_DIR = PROJECT_ROOT / "scripts"
-
-    # Pinned export used for reproducible analysis across experiments.
-    PINNED_EXPORT_FILENAME = "mirrorview_pilot_data_2026_04_28-16:31:47.csv"
-    PINNED_EXPORT_PATH = EXPERIMENT_DIR / PINNED_EXPORT_FILENAME
 
     @property
     def last_loaded_export_path(self) -> Path | None:
@@ -30,15 +28,9 @@ class Dataloader:
         return getattr(self, "_last_loaded_export_path", None)
 
     def get_latest_mirrorview_run_data(self) -> pd.DataFrame:
-        """Load the pinned export CSV as a DataFrame."""
-        if not self.PINNED_EXPORT_PATH.exists():
-            raise FileNotFoundError(
-                f"Pinned export CSV not found at {self.PINNED_EXPORT_PATH}. "
-                "If you intended to use a different export, update PINNED_EXPORT_FILENAME "
-                "and ensure the file is present."
-            )
-        self._last_loaded_export_path = self.PINNED_EXPORT_PATH
-        return pd.read_csv(self.PINNED_EXPORT_PATH, low_memory=False)
+        """Load the registered Part 1 pilot results table as a DataFrame."""
+        self._last_loaded_export_path = registry.resolve_path(STUDY_PHASE_2_PART_1_RESULTS_PILOT)
+        return load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT, low_memory=False)
 
     def transform_latest_mirrorview_run_data(self, df: pd.DataFrame) -> pd.DataFrame:
         """Filter and reshape the raw export frame into the trial-level mirrors table."""

--- a/experiments/predict_keep_remove_2026_05_07/generate_dataset_metrics.py
+++ b/experiments/predict_keep_remove_2026_05_07/generate_dataset_metrics.py
@@ -10,17 +10,13 @@ This prints:
 
 Notes:
 - Metrics are computed on the linked-fate subset with `decision ∈ {keep, remove}`.
-- If the most recent `scripts/mirrorview_pilot_data_*.csv` export is malformed or
-  missing expected columns, the script falls back to the most recent export that
-  has the required schema.
+- If the experiment dataloader fails, the script falls back to the shared Part 1
+  pilot results registry entry and applies the same filtering logic.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
-from pathlib import Path
-import re
 
 import pandas as pd
 
@@ -29,6 +25,8 @@ from experiments.mirrors_content_analysis_2026_04_24.dataloader import (
 )
 from experiments.predict_keep_remove_2026_05_07.dataloader import Dataloader
 from experiments.predict_keep_remove_2026_05_07.embeddings.text_hash import text_hash
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_1_RESULTS_PILOT
 
 
 @dataclass(frozen=True)
@@ -74,57 +72,6 @@ def _distribution_table(df: pd.DataFrame, column: str) -> tuple[pd.DataFrame, Di
     return out, summary
 
 
-_EXPORT_TS_RE = re.compile(
-    r"^mirrorview_pilot_data_(\d{4}_\d{2}_\d{2}-\d{2}:\d{2}:\d{2})\.csv$"
-)
-_EXPORT_DATE_RE = re.compile(r"^mirrorview_pilot_data_(\d{4}-\d{2}-\d{2})\.csv$")
-_EXPORT_TS_FMT = "%Y_%m_%d-%H:%M:%S"
-_EXPORT_DATE_FMT = "%Y-%m-%d"
-
-
-def _parse_export_time(path: Path) -> datetime | None:
-    m = _EXPORT_TS_RE.match(path.name)
-    if m:
-        return datetime.strptime(m.group(1), _EXPORT_TS_FMT)
-    m = _EXPORT_DATE_RE.match(path.name)
-    if m:
-        return datetime.strptime(m.group(1), _EXPORT_DATE_FMT)
-    return None
-
-
-def _choose_latest_valid_export_csv(
-    scripts_dir: Path,
-    *,
-    required_columns: set[str],
-) -> Path:
-    candidates = sorted(scripts_dir.glob("mirrorview_pilot_data_*.csv"))
-    if not candidates:
-        raise FileNotFoundError(f"No mirrorview_pilot_data_*.csv under {scripts_dir}")
-
-    valid: list[tuple[datetime, Path]] = []
-    for p in candidates:
-        try:
-            cols = set(pd.read_csv(p, nrows=0).columns)
-        except Exception:
-            continue
-        if not required_columns.issubset(cols):
-            continue
-
-        ts = _parse_export_time(p)
-        if ts is None:
-            ts = datetime.fromtimestamp(p.stat().st_mtime)
-        valid.append((ts, p))
-
-    if not valid:
-        raise RuntimeError(
-            "Found mirrorview_pilot_data_*.csv files, but none had the required columns: "
-            f"{sorted(required_columns)}"
-        )
-
-    valid.sort(key=lambda t: t[0])
-    return valid[-1][1]
-
-
 def _load_linked_fate_keep_remove_rows() -> pd.DataFrame:
     """Load the decision-row dataset: linked-fate keep/remove trials only."""
     try:
@@ -132,27 +79,9 @@ def _load_linked_fate_keep_remove_rows() -> pd.DataFrame:
         loader = Dataloader()
         return loader.load_training_dataframe()
     except Exception:
-        # Fallback: choose a valid export and apply the same filtering logic.
+        # Fallback: load the shared pilot results and apply the same filtering logic.
         pilot = MirrorViewPilotDataloader()
-        raw_required = {
-            "trial_type",
-            "phase",
-            "prolific_id",
-            "party_group",
-            "condition",
-            "evaluation_mode",
-            "sample_toxicity_type",
-            "sampled_stance",
-            "post_id",
-            "original_text",
-            "mirror_text",
-            "decision",
-        }
-        export_path = _choose_latest_valid_export_csv(
-            pilot.SCRIPTS_DIR,
-            required_columns=raw_required,
-        )
-        raw = pd.read_csv(export_path, low_memory=False)
+        raw = load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT, low_memory=False)
         trials = pilot.transform_latest_mirrorview_run_data(raw)
 
         out = trials.copy()

--- a/experiments/scaled_mirrors_generation_2026_06_02/validate_mirrors_equal_lengths.py
+++ b/experiments/scaled_mirrors_generation_2026_06_02/validate_mirrors_equal_lengths.py
@@ -10,16 +10,19 @@ from pathlib import Path
 
 import pandas as pd
 
-EXPERIMENT_DIR = Path(__file__).resolve().parent
-FLIPS_CSV = EXPERIMENT_DIR / "generated_flips/combined_flips/flips.csv"
+from shared.data import registry
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_2_STIMULI
+
 LENGTH_DIFF_THRESHOLD = 0.10
 
 
 def main() -> None:
-    df = pd.read_csv(FLIPS_CSV)
+    stimuli_path = registry.resolve_path(STUDY_PHASE_2_PART_2_STIMULI)
+    df = load_dataset(STUDY_PHASE_2_PART_2_STIMULI)
     if "original_text" not in df.columns or "mirrored_text" not in df.columns:
         raise ValueError(
-            f"Expected `original_text` and `mirrored_text` columns in {FLIPS_CSV}"
+            f"Expected `original_text` and `mirrored_text` columns in {stimuli_path}"
         )
 
     original_lengths = df["original_text"].fillna("").astype(str).str.len()
@@ -34,7 +37,7 @@ def main() -> None:
     n_length_diff = int(length_diff_mask.sum())
     n_empty_original = int(empty_original.sum())
 
-    print(f"Flips CSV: {FLIPS_CSV}")
+    print(f"Flips CSV: {stimuli_path}")
     print(f"Total posts: {n_posts:,}")
     print()
     print(f"Average original length (chars): {original_lengths.mean():.1f}")

--- a/experiments/truncate_posts_2026_06_19/truncate_flips.py
+++ b/experiments/truncate_posts_2026_06_19/truncate_flips.py
@@ -23,25 +23,37 @@ from experiments.truncate_posts_2026_06_19.paths import (
     flips_csv,
     flips_with_flag_csv,
 )
+from shared.data import registry
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_2_STIMULI
 
 MAX_ORIGINAL_CHARS = 300
 MAX_MIRRORED_CHARS = 300
 LENGTH_DIFF_THRESHOLD = 0.10
 
 EXPERIMENT_DIR = Path(__file__).resolve().parent
-INPUT_CSV = (
-    Path(__file__).resolve().parents[1]
-    / "scaled_mirrors_generation_2026_06_02"
-    / "generated_flips"
-    / "combined_flips"
-    / "flips.csv"
-)
 TRUNCATION_VERSION = TruncationVersion.v1
 OUTPUT_CSV = flips_csv(TRUNCATION_VERSION)
 OUTPUT_WITH_FLAG_CSV = flips_with_flag_csv(TRUNCATION_VERSION)
 STANCE_ORDER = ("left", "right")
 
 app = typer.Typer(add_completion=False)
+
+
+def load_default_stimuli() -> pd.DataFrame:
+    """Load the registered Part 2 stimuli table via the shared registry."""
+    return load_dataset(STUDY_PHASE_2_PART_2_STIMULI)
+
+
+def default_stimuli_source_path() -> Path:
+    """Absolute path to the canonical Part 2 stimuli CSV."""
+    return registry.resolve_path(STUDY_PHASE_2_PART_2_STIMULI)
+
+
+def _load_input_df(source_csv: Path | None = None) -> pd.DataFrame:
+    if source_csv is None:
+        return load_default_stimuli()
+    return pd.read_csv(source_csv)
 
 
 def _char_lengths(series: pd.Series) -> pd.Series:
@@ -132,12 +144,13 @@ def _print_metrics_by_stance(
 
 
 def build_truncated_df(
-    source_csv: Path = INPUT_CSV,
+    source_csv: Path | None = None,
 ) -> tuple[pd.DataFrame, pd.Series, pd.Series, pd.Series]:
-    df = pd.read_csv(source_csv)
+    input_path = source_csv if source_csv is not None else default_stimuli_source_path()
+    df = _load_input_df(source_csv)
     if "original_text" not in df.columns or "mirrored_text" not in df.columns:
         raise ValueError(
-            f"Expected `original_text` and `mirrored_text` columns in {source_csv}"
+            f"Expected `original_text` and `mirrored_text` columns in {input_path}"
         )
 
     original_before = df["original_text"].fillna("").astype(str)
@@ -207,7 +220,7 @@ def main(
             (OUTPUT_WITH_FLAG_CSV, True),
         ]
 
-    print(f"Input CSV: {INPUT_CSV}")
+    print(f"Input CSV: {default_stimuli_source_path()}")
     print(f"Truncation limits: original={MAX_ORIGINAL_CHARS}, mirrored={MAX_MIRRORED_CHARS}")
     print(f"Rows truncated (is_truncated=True): {n_truncated:,} ({n_truncated / n_posts:.1%})")
     print()

--- a/experiments/truncate_posts_2026_06_19/truncate_flips_v2.py
+++ b/experiments/truncate_posts_2026_06_19/truncate_flips_v2.py
@@ -20,7 +20,6 @@ from experiments.truncate_posts_2026_06_19.truncation_v2 import (
     truncate_pair,
 )
 from experiments.truncate_posts_2026_06_19.truncate_flips import (
-    INPUT_CSV,
     LENGTH_DIFF_THRESHOLD,
     STANCE_ORDER,
     _char_lengths,
@@ -28,6 +27,8 @@ from experiments.truncate_posts_2026_06_19.truncate_flips import (
     _print_metrics,
     _print_metrics_by_stance,
     _write_output,
+    _load_input_df,
+    default_stimuli_source_path,
 )
 from experiments.truncate_posts_2026_06_19.paths import (
     TruncationVersion,
@@ -61,12 +62,13 @@ def _catastrophic_truncation_count(
 
 
 def build_truncated_df_v2(
-    source_csv: Path = INPUT_CSV,
+    source_csv: Path | None = None,
 ) -> tuple[pd.DataFrame, pd.Series, pd.Series, pd.Series]:
-    df = pd.read_csv(source_csv)
+    input_path = source_csv if source_csv is not None else default_stimuli_source_path()
+    df = _load_input_df(source_csv)
     if "original_text" not in df.columns or "mirrored_text" not in df.columns:
         raise ValueError(
-            f"Expected `original_text` and `mirrored_text` columns in {source_csv}"
+            f"Expected `original_text` and `mirrored_text` columns in {input_path}"
         )
 
     original_before = df["original_text"].fillna("").astype(str)
@@ -123,7 +125,7 @@ def main(
             (OUTPUT_WITH_FLAG_CSV, True),
         ]
 
-    print(f"Input CSV: {INPUT_CSV}")
+    print(f"Input CSV: {default_stimuli_source_path()}")
     print(
         f"Truncation strategy: v2 boundary cascade "
         f"(max_chars={MAX_CHARS}, min_keep_ratio={MIN_KEEP_RATIO:.0%}, pair-aware mirror)"

--- a/experiments/truncate_posts_2026_06_19/truncate_flips_v3.py
+++ b/experiments/truncate_posts_2026_06_19/truncate_flips_v3.py
@@ -20,12 +20,13 @@ from experiments.truncate_posts_2026_06_19.truncation_v3 import (
     truncate_pair,
 )
 from experiments.truncate_posts_2026_06_19.truncate_flips import (
-    INPUT_CSV,
     STANCE_ORDER,
     _char_lengths,
     _print_metrics,
     _print_metrics_by_stance,
     _write_output,
+    default_stimuli_source_path,
+    _load_input_df,
 )
 from experiments.truncate_posts_2026_06_19.truncate_flips_v2 import (
     _catastrophic_truncation_count,
@@ -57,12 +58,13 @@ def _complete_sentence_counts(
 
 
 def build_truncated_df_v3(
-    source_csv: Path = INPUT_CSV,
+    source_csv: Path | None = None,
 ) -> tuple[pd.DataFrame, pd.Series, pd.Series, pd.Series]:
-    df = pd.read_csv(source_csv)
+    input_path = source_csv if source_csv is not None else default_stimuli_source_path()
+    df = _load_input_df(source_csv)
     if "original_text" not in df.columns or "mirrored_text" not in df.columns:
         raise ValueError(
-            f"Expected `original_text` and `mirrored_text` columns in {source_csv}"
+            f"Expected `original_text` and `mirrored_text` columns in {input_path}"
         )
 
     original_before = df["original_text"].fillna("").astype(str)
@@ -119,7 +121,7 @@ def main(
             (OUTPUT_WITH_FLAG_CSV, True),
         ]
 
-    print(f"Input CSV: {INPUT_CSV}")
+    print(f"Input CSV: {default_stimuli_source_path()}")
     print(
         f"Truncation strategy: v3 sentence-first "
         f"(max_chars={MAX_CHARS}, sentence_overflow={SENTENCE_OVERFLOW}, independent sides)"

--- a/experiments/truncate_posts_2026_06_19/truncation_v5/generate_flips.py
+++ b/experiments/truncate_posts_2026_06_19/truncation_v5/generate_flips.py
@@ -10,8 +10,7 @@ This is the v5 extension of the v4 prompt intervention:
     topic has no natural opposite-stance position.
 
 Inputs
-  - Default input CSV:
-      experiments/scaled_mirrors_generation_2026_06_02/generated_flips/combined_flips/flips.csv
+  - Default input: ``STUDY_PHASE_2_PART_2_STIMULI`` via the shared registry loader.
     Required columns:
       - post_primary_key
       - original_text
@@ -57,20 +56,15 @@ from experiments.truncate_posts_2026_06_19.truncation_v3 import (
     truncate_social_post,
 )
 from lib.constants import BEDROCK_REGION, DEFAULT_BEDROCK_SONNET_MODEL
+from shared.data import registry
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_2_STIMULI
 
 app = typer.Typer(add_completion=False)
 
 EXPERIMENT_DIR = Path(__file__).resolve().parent.parent
 OUTPUT_DIR = EXPERIMENT_DIR / "outputs" / "truncation_v5"
 OUTPUT_CSV = OUTPUT_DIR / "flips.csv"
-
-DEFAULT_INPUT_CSV = (
-    EXPERIMENT_DIR.parent
-    / "scaled_mirrors_generation_2026_06_02"
-    / "generated_flips"
-    / "combined_flips"
-    / "flips.csv"
-)
 
 BATCH_SIZE = 25
 MAX_CONCURRENCY = 10
@@ -155,8 +149,11 @@ def _append_rows(out_fp: Path, rows: list[dict[str, str]], *, write_header: bool
     )
 
 
-def _iter_input_rows(input_csv: Path) -> tuple[int | None, "pd.io.parsers.TextFileReader"]:
-    # TextFileReader supports chunked iteration without loading the full CSV into memory.
+def _iter_input_rows(
+    input_csv: Path | None,
+) -> tuple[int | None, "pd.io.parsers.TextFileReader | list[pd.DataFrame]"]:
+    if input_csv is None:
+        return None, [load_dataset(STUDY_PHASE_2_PART_2_STIMULI)]
     reader = pd.read_csv(input_csv, chunksize=CHUNK_SIZE)
     return None, reader
 
@@ -175,12 +172,17 @@ def _validate_input_cols(df: pd.DataFrame, *, input_csv: Path) -> None:
 
 def generate_flips(
     *,
-    input_csv: Path = DEFAULT_INPUT_CSV,
+    input_csv: Path | None = None,
     output_csv: Path = OUTPUT_CSV,
     max_posts: int | None = None,
     force: bool = False,
 ) -> None:
-    if not input_csv.exists():
+    input_label = (
+        str(registry.resolve_path(STUDY_PHASE_2_PART_2_STIMULI))
+        if input_csv is None
+        else str(input_csv)
+    )
+    if input_csv is not None and not input_csv.exists():
         raise FileNotFoundError(f"Missing input CSV: {input_csv}")
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
@@ -248,7 +250,7 @@ def generate_flips(
     for chunk in reader:
         if chunk.empty:
             continue
-        _validate_input_cols(chunk, input_csv=input_csv)
+        _validate_input_cols(chunk, input_csv=Path(input_label))
 
         # De-dupe within chunk to avoid repeated ids causing duplicate writes inside one run.
         chunk = chunk.drop_duplicates(subset=["post_primary_key"], keep="first")
@@ -302,10 +304,10 @@ def generate_flips(
 
 @app.command()
 def main(
-    input_csv: Path = typer.Option(
-        DEFAULT_INPUT_CSV,
+    input_csv: Path | None = typer.Option(
+        None,
         "--input-csv",
-        help="Source CSV of originals to mirror.",
+        help="Source CSV of originals to mirror (default: shared Part 2 stimuli registry).",
     ),
     max_posts: int | None = typer.Option(
         None,

--- a/strategy_planning/README.md
+++ b/strategy_planning/README.md
@@ -1,0 +1,3 @@
+# Strategy planning
+
+Notes for work that doesn't fit into a single experiment or are higher-level plans and notes.

--- a/strategy_planning/migrate_to_single_dataloader_2026_07_31/migration_plan.md
+++ b/strategy_planning/migrate_to_single_dataloader_2026_07_31/migration_plan.md
@@ -1,0 +1,86 @@
+# Migrate experiments onto the shared dataset loader
+
+Follow-up to [PR #35](https://github.com/METResearchGroup/mirrorView-task/pull/35): callers still pin local / `scripts/` CSVs. This plan migrates them onto `shared.data.dataloader.load_dataset` + registry names.
+
+**Registry names (raw only):**
+
+| Name | Path |
+|---|---|
+| `STUDY_PHASE_2_PART_1_RESULTS_PILOT` | `shared/data/raw/study_phase_2_part_1/results/pilot.csv` |
+| `STUDY_PHASE_2_PART_1_RESULTS_FULL` | `shared/data/raw/study_phase_2_part_1/results/full.csv` |
+| `STUDY_PHASE_2_PART_1_STIMULI` | `shared/data/raw/study_phase_2_part_1/stimuli/claude_generated_mirrors.csv` |
+| `STUDY_PHASE_2_PART_2_RESULTS_FULL` | `shared/data/raw/study_phase_2_part_2/results/full.csv` |
+| `STUDY_PHASE_2_PART_2_STIMULI` | `shared/data/raw/study_phase_2_part_2/stimuli/flips.csv` |
+
+Verified equivalences before planning:
+
+- Part 2 stimuli (`flips.csv`) matches `experiments/scaled_mirrors_generation_2026_06_02/generated_flips/combined_flips/flips.csv` (same columns, same 10k `post_primary_key` set).
+- `keep_remove_results_2026_06_23.csv` is a slim subset of Part 2 results: linked-fate keep/remove rows with non-null `post_id`, columns renamed (`post_id` → `message_id`), five columns only. Exact row match after that filter: 23,560.
+
+---
+
+## Phase 1 — Obvious drop-ins
+
+Swap a hardcoded CSV path for `load_dataset(<registry name>)`. No reshape. Local filtering that already runs *after* `read_csv` can stay as-is.
+
+| File | Change |
+|---|---|
+| `experiments/free_response_analysis_2026_04_28/main.py` | Replace `SOURCE_CSV` (`scripts/mirrorview_pilot_data_2026_04_28-16:31:47.csv`) with `load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT)`. Keep `generate_filtered_dataframe` filtering. |
+| `experiments/mirrors_content_analysis_2026_04_24/dataloader.py` | In `get_latest_mirrorview_run_data`, replace `pd.read_csv(PINNED_EXPORT_PATH)` with `load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT)`. Drop `PINNED_EXPORT_*` path constants (or leave unused). Keep `transform_latest_mirrorview_run_data` unchanged. |
+| `experiments/basic_summary_stats_2026_04_27/summary_stats.py` | Remove `find_latest_export_csv` / `copy_latest_export_csv` / `scripts/` discovery. Load via `load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT)` (pilot-era stats). |
+| `experiments/basic_summary_stats_2026_04_27/toxicity_remove_breakdown.py` | Stop calling `find_latest_export_csv`; load `STUDY_PHASE_2_PART_1_RESULTS_PILOT` the same way as `summary_stats.py`. |
+| `experiments/predict_keep_remove_2026_05_07/generate_dataset_metrics.py` | In `_choose_latest_valid_export_csv` fallback path, replace `scripts/mirrorview_pilot_data_*.csv` discovery + `pd.read_csv` with `load_dataset(STUDY_PHASE_2_PART_1_RESULTS_PILOT)`. Preferred path already goes through `Dataloader` (inherits Phase 1 mirrors swap). |
+| `experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths.py` | Replace `INPUT_CSV` pointing at `combined_flips/flips.csv` with `load_dataset(STUDY_PHASE_2_PART_2_STIMULI)`. |
+| `experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths_v2.py` | Stop reading `INPUT_CSV` from disk; use the shared Part 2 stimuli load (import helper from `run_match_lengths.py` or call `load_dataset` directly). |
+| `experiments/match_lengths_original_mirrors_2026_06_19/run_ablations.py` | Same as v2: load Part 2 stimuli via shared loader instead of `INPUT_CSV`. |
+| `experiments/truncate_posts_2026_06_19/truncate_flips.py` | Replace default `INPUT_CSV` (`combined_flips/flips.csv`) with `load_dataset(STUDY_PHASE_2_PART_2_STIMULI)`. |
+| `experiments/truncate_posts_2026_06_19/truncate_flips_v2.py` | Same default-input swap to `STUDY_PHASE_2_PART_2_STIMULI`. |
+| `experiments/truncate_posts_2026_06_19/truncate_flips_v3.py` | Same default-input swap to `STUDY_PHASE_2_PART_2_STIMULI`. |
+| `experiments/truncate_posts_2026_06_19/truncation_v5/generate_flips.py` | Replace `DEFAULT_INPUT_CSV` (`combined_flips/flips.csv`) with `load_dataset(STUDY_PHASE_2_PART_2_STIMULI)`. |
+| `experiments/scaled_mirrors_generation_2026_06_02/validate_mirrors_equal_lengths.py` | Replace `FLIPS_CSV` (`combined_flips/flips.csv`) with `load_dataset(STUDY_PHASE_2_PART_2_STIMULI)`. |
+
+---
+
+## Phase 2 — Needs transformation
+
+Source should become a registry dataset, but the frame callers expect is derived (filters, renames, aggregation, joins). Keep transforms local; only the raw ingress moves to `load_dataset`.
+
+| File | Change |
+|---|---|
+| `experiments/predict_keep_remove_2026_07_01/data/dataloader.py` | Stop reading `keep_remove_results_2026_06_23.csv`. Load `STUDY_PHASE_2_PART_2_RESULTS_FULL`, then rebuild the slim trial frame: `evaluation_mode == linked_fate`, `decision in {keep,remove}`, drop null `post_id`, set `message_id = post_id`, keep columns `prolific_id, message_id, original_text, mirror_text, decision`. Keep existing modal training aggregation in `load_training_dataframe`. |
+| `experiments/predict_keep_remove_2026_05_07/dataloader.py` | After Phase 1 mirrors swap works, optionally load `STUDY_PHASE_2_PART_1_RESULTS_PILOT` directly (skip `MirrorViewPilotDataloader` for ingress), then apply: mirrors trial transform (moderation-trial, phase > 0), linked-fate + keep/remove filter, analysis-label CSV joins. Label joins stay local (not registry data). |
+| `experiments/simplified_predict_remove_2026_05_13/dataloader.py` | No new raw path; keep majority aggregation on top of the Phase 2 `05_07` training frame. Confirm it still works after parent ingress changes. |
+| `experiments/predict_keep_remove_2026_07_01/models/modernbert/dataloader.py` | No direct CSV path; confirm `load_classifier_dataframe` still matches after `07_01` rebuilds trials from Part 2 full. |
+| `experiments/predict_keep_remove_2026_07_01/models/llm_api/dataset.py` | Indirect only: still calls `Dataloader().load_training_dataframe()`; verify after Phase 2 `07_01` change. |
+| `experiments/predict_keep_remove_2026_07_01/models/llm_finetuning/api_baselines/dataset.py` | Same indirect verify as `llm_api/dataset.py`. |
+| `experiments/model_errors_analysis_2026_07_15/collect/build_long_csv.py` | Gold texts come from `07_01` `Dataloader().load_training_dataframe()`; re-run / smoke after Phase 2 `07_01` so `message_id` join still holds. |
+
+---
+
+## Phase 3 — All else (your call)
+
+Not a clean swap and not a single obvious transform. Decide case-by-case (or leave alone).
+
+| File | Why it's here / decision needed |
+|---|---|
+| `experiments/basic_summary_stats_2026_04_27/total_attrition.py` | Needs export *filename timestamp* for DynamoDB grace-window logic; shared registry files have no export timestamp in the name. |
+| `scripts/export_study_results.py` | Producer of ad-hoc `scripts/mirrorview_pilot_data_*.csv` exports, not a consumer of the registry. |
+| `experiments/scaled_mirrors_generation_2026_06_02/**` (except `validate_mirrors_equal_lengths.py`) | Producer lineage for Part 2 stimuli; rewriting producers onto the registry is optional / historical. |
+| `experiments/llm_based_feature_generation_2026_07_31/**` | Experiment source largely removed; wire-up to Part 2 results when/if rebuilt. |
+| `experiments/followup_model_error_analysis_2026_07_15/**` | Reads intermediate analysis CSVs, not study raw tables. |
+| `experiments/fetch_reddit_pushshift_dump_2026_06_15/**` | Unrelated corpus pipeline. |
+| `experiments/mirrors_content_analysis_2026_04_24/run_analysis.py` | CLI `--data-path` is caller-supplied; only docstring examples mention `scripts/` paths. |
+| `STUDY_PHASE_2_PART_1_STIMULI` | No current experiment consumer found. |
+| `experiments/basic_summary_stats_2026_04_27/*` PILOT vs FULL | Phase 1 pins pilot for historical continuity; switching summary scripts to `STUDY_PHASE_2_PART_1_RESULTS_FULL` is a product choice. |
+| Delete `experiments/predict_keep_remove_2026_07_01/keep_remove_results_2026_06_23.csv` | Only after Phase 2 `07_01` dataloader is proven equivalent. |
+| Docs / READMEs / WRITEUPs that still cite `scripts/mirrorview_pilot_data_*.csv` or `combined_flips/flips.csv` | Update when convenient; not required for runtime migration. |
+
+---
+
+## Suggested order
+
+1. Phase 1 Part 1 results consumers (free response, mirrors, summary stats, metrics fallback).
+2. Phase 1 Part 2 stimuli consumers (match_lengths, truncate_posts, validate lengths).
+3. Phase 2 `07_01` slim-frame rebuild (unblocks modernbert / llm_api / model_errors).
+4. Phase 2 `05_07` / simplified direct or inherited ingress.
+5. Phase 3 items you pick.


### PR DESCRIPTION
## Problem

Thirteen experiment scripts still read study CSVs from hardcoded paths under `scripts/` or experiment-local `combined_flips/flips.csv`, even though PR #35 added a shared registry and raw loader for those same tables.

## Solution

Swapped default ingress in all thirteen Phase 1 migration targets to `load_dataset()` with `STUDY_PHASE_2_PART_1_RESULTS_PILOT` (five callers) or `STUDY_PHASE_2_PART_2_STIMULI` (eight callers). Post-load filters, transforms, and CLI override paths are unchanged.

## Purpose

Phase 1 of the single-dataloader migration: path-for-name substitution only. No new registry entries, transforms, or deletions of legacy CSVs. Phases 2–3 (slim exports, attrition logic, producers) remain out of scope per `strategy_planning/migrate_to_single_dataloader_2026_07_31/migration_plan.md`.

## How to run

```bash
# Grep gate (expect GREP_CLEAN)
rg -n "scripts/mirrorview_pilot_data|PINNED_EXPORT_PATH|combined_flips/flips\.csv" \
  experiments/free_response_analysis_2026_04_28/main.py \
  experiments/mirrors_content_analysis_2026_04_24/dataloader.py \
  experiments/basic_summary_stats_2026_04_27/summary_stats.py \
  experiments/basic_summary_stats_2026_04_27/toxicity_remove_breakdown.py \
  experiments/predict_keep_remove_2026_05_07/generate_dataset_metrics.py \
  experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths.py \
  experiments/match_lengths_original_mirrors_2026_06_19/run_match_lengths_v2.py \
  experiments/match_lengths_original_mirrors_2026_06_19/run_ablations.py \
  experiments/truncate_posts_2026_06_19/truncate_flips.py \
  experiments/truncate_posts_2026_06_19/truncate_flips_v2.py \
  experiments/truncate_posts_2026_06_19/truncate_flips_v3.py \
  experiments/truncate_posts_2026_06_19/truncation_v5/generate_flips.py \
  experiments/scaled_mirrors_generation_2026_06_02/validate_mirrors_equal_lengths.py \
  && echo UNEXPECTED_MATCHES || echo GREP_CLEAN

# End-to-end smoke (expect STEP3_OK, pilot=8985, stim=10000)
PYTHONPATH=. uv run python - <<'SMOKE'
from shared.data.dataloader import load_dataset
from shared.data import registry
from experiments.mirrors_content_analysis_2026_04_24.dataloader import Dataloader

pilot = load_dataset(registry.STUDY_PHASE_2_PART_1_RESULTS_PILOT)
stim = load_dataset(registry.STUDY_PHASE_2_PART_2_STIMULI)
raw = Dataloader().get_latest_mirrorview_run_data()
assert len(pilot) == len(raw) and len(stim) == 10000
print("STEP3_OK")
SMOKE

# Validator
PYTHONPATH=. uv run python experiments/scaled_mirrors_generation_2026_06_02/validate_mirrors_equal_lengths.py
```

Implementation plan: `docs/plans/2026-07-31_migrate_dataloader_dropins_013142/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Experiment analyses and dataset-generation workflows now use shared, registered datasets by default.
  - Explicit CSV inputs remain supported where applicable.
  - Validation messages and logs now identify the resolved data source.

- **Improvements**
  - Removed reliance on local, hard-coded, or newest-export file paths.
  - Dataset loading and provenance reporting are more consistent across experiments.
  - Summary statistics continue to report row and participant counts before generating results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->