### PR TITLE
Add transformed dataset loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2026-08-03
+
+1. Added a shared transformed keep/remove label dataset for Study Phase 2 Part 2 (modal linked-fate decisions, ties → remove) and extended the registry/`load_dataset` path so callers can load it by name instead of rebuilding labels per experiment. [PR #40](https://github.com/METResearchGroup/mirrorView-task/pull/40)
+
 ## 2026-08-01
 
 1. Completed the 50% production run for the LLM feature-generation and theme-synthesis experiment: 140 stage-1 batches on the frozen subset (4,397 posts), 1,116 keep + 1,120 remove features, and 132 synthesized themes; added sharded stage-2 synthesis, `resume_production.py`, `RESULTS.md`, and checkpoint commit watcher. [PR #33](https://github.com/METResearchGroup/mirrorView-task/pull/33)

--- a/experiments/llm_based_feature_generation_2026_07_31/README.md
+++ b/experiments/llm_based_feature_generation_2026_07_31/README.md
@@ -12,11 +12,10 @@ Once that's done, we'll take that final list as our substantive experimental res
 
 ## Pipeline
 
-1. Load Study Phase 2 Part 2 results via `shared/data/`.
-2. Derive one modal keep/remove label per post (tie → remove).
-3. Sample a configurable fraction without replacement and form mixed keep/remove batches.
-4. Stage 1: feature generation per batch via `research_tools.llm.runner.run`.
-5. Stage 2: thematic commonality synthesis over aggregated stage-1 features.
+1. Load shared modal keep/remove labels via `STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS`.
+2. Sample a configurable fraction without replacement and form mixed keep/remove batches.
+3. Stage 1: feature generation per batch via `research_tools.llm.runner.run`.
+4. Stage 2: thematic commonality synthesis over aggregated stage-1 features.
 
 Outputs are written under `outputs/{timestamp}/` for each stage (metadata plus per-item JSON).
 

--- a/experiments/llm_based_feature_generation_2026_07_31/batching.py
+++ b/experiments/llm_based_feature_generation_2026_07_31/batching.py
@@ -1,4 +1,4 @@
-"""Load Study Phase 2 Part 2 posts, derive modal keep/remove labels, and form batches."""
+"""Load shared Part 2 modal keep/remove labels and form batches."""
 
 from __future__ import annotations
 
@@ -9,81 +9,15 @@ from typing import Any
 import pandas as pd
 
 from shared.data.dataloader import load_dataset
-from shared.data.registry import STUDY_PHASE_2_PART_2_RESULTS_FULL
+from shared.data.registry import STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS
 
-_REQUIRED_COLUMNS = {"post_id", "original_text", "mirror_text", "decision"}
 FROZEN_SUBSET_CSV = Path(__file__).resolve().parent / "data" / "sampled_subset.csv"
 PRODUCTION_SAMPLE_FRACTION = 0.50
 
 
 def load_posts() -> pd.DataFrame:
-    """Load Part 2 results and derive one modal keep/remove row per post."""
-    raw = load_dataset(STUDY_PHASE_2_PART_2_RESULTS_FULL, low_memory=False)
-    return _derive_training_frame(raw)
-
-
-def _derive_training_frame(raw: pd.DataFrame) -> pd.DataFrame:
-    """Aggregate trial rows to one modal keep/remove decision per post."""
-    trials = raw.copy()
-    trials["decision"] = trials["decision"].astype(str).str.lower().str.strip()
-
-    if "evaluation_mode" in trials.columns:
-        trials["evaluation_mode"] = (
-            trials["evaluation_mode"].astype(str).str.lower().str.strip()
-        )
-        trials = trials[trials["evaluation_mode"] == "linked_fate"].copy()
-
-    trials = trials[trials["decision"].isin(["keep", "remove"])].copy()
-
-    missing = _REQUIRED_COLUMNS - set(trials.columns)
-    if missing:
-        raise KeyError(f"Dataset is missing required columns: {sorted(missing)}")
-
-    trials["post_id"] = trials["post_id"].astype(str)
-
-    text_nunique = (
-        trials.groupby("post_id", dropna=False)
-        .agg(
-            original_text_nunique=("original_text", lambda series: series.fillna("").nunique()),
-            mirror_text_nunique=("mirror_text", lambda series: series.fillna("").nunique()),
-        )
-        .reset_index()
-    )
-    unstable = text_nunique[
-        (text_nunique["original_text_nunique"] != 1)
-        | (text_nunique["mirror_text_nunique"] != 1)
-    ]
-    if len(unstable):
-        example_post = str(unstable.iloc[0]["post_id"])
-        raise ValueError(
-            "Expected stable original/mirror text per post_id, but found conflicts. "
-            f"Example problematic post_id={example_post}."
-        )
-
-    counts = (
-        trials.groupby(["post_id", "decision"], dropna=False)
-        .size()
-        .unstack(fill_value=0)
-        .reset_index()
-    )
-    if "keep" not in counts.columns:
-        counts["keep"] = 0
-    if "remove" not in counts.columns:
-        counts["remove"] = 0
-
-    counts["decision"] = counts.apply(
-        lambda row: "keep" if int(row["keep"]) > int(row["remove"]) else "remove",
-        axis=1,
-    )
-
-    texts = trials.drop_duplicates(subset=["post_id"])[
-        ["post_id", "original_text", "mirror_text"]
-    ]
-    out = counts.merge(texts, on="post_id", how="left")
-    out = out.rename(columns={"post_id": "message_id"})
-    return out[["message_id", "original_text", "mirror_text", "decision"]].reset_index(
-        drop=True
-    )
+    """Load shared modal keep/remove labels (one row per post)."""
+    return load_dataset(STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS, low_memory=False)
 
 
 def sample_posts(

--- a/experiments/predict_keep_remove_2026_07_01/data/README.md
+++ b/experiments/predict_keep_remove_2026_07_01/data/README.md
@@ -4,9 +4,10 @@ Dataset loading for the keep/remove experiment.
 
 | File | Purpose |
 | --- | --- |
-| `dataloader.py` | Load `keep_remove_results_2026_06_23.csv` as trial rows or per-post training labels. |
+| `dataloader.py` | Trial rows from `keep_remove_results_2026_06_23.csv`; training labels from shared registry `STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS`. |
 
-The CSV lives at the experiment root: `keep_remove_results_2026_06_23.csv`.
+The slim trial CSV lives at the experiment root: `keep_remove_results_2026_06_23.csv`.
+Training labels are the shared materialized modal keep/remove dataset (8791 rows).
 
 ## Usage
 

--- a/experiments/predict_keep_remove_2026_07_01/data/dataloader.py
+++ b/experiments/predict_keep_remove_2026_07_01/data/dataloader.py
@@ -1,12 +1,13 @@
 """Data loading for keep/remove prediction (2026-07-01 run).
 
-This experiment uses a CSV export `keep_remove_results_2026_06_23.csv` containing
-linked-fate keep/remove trials.
+Trial-level rows come from the experiment CSV
+``keep_remove_results_2026_06_23.csv``. Training labels come from the shared
+registry dataset ``STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS`` (one modal
+keep/remove row per post; ties → remove).
 
 We provide:
-1) `load_trial_dataframe()`: one row per trial (i.e. the raw linked-fate decision rows).
-2) `load_training_dataframe()`: one row per `post_id` with modal decision across raters.
-   If keep/remove counts are tied, we choose `remove`.
+1) `load_trial_dataframe()`: one row per trial (slim linked-fate CSV).
+2) `load_training_dataframe()`: shared materialized modal labels.
 """
 
 from __future__ import annotations
@@ -14,6 +15,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
+
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS
 
 EXPERIMENT_ROOT = Path(__file__).resolve().parents[1]
 CSV_PATH = EXPERIMENT_ROOT / "keep_remove_results_2026_06_23.csv"
@@ -50,70 +54,8 @@ class Dataloader:
         return df
 
     def load_training_dataframe(self) -> pd.DataFrame:
-        """Return one row per post with modal decision (tie => remove)."""
-        trials = self.load_trial_dataframe()
-
-        required_cols = {
-            "post_id",
-            "original_text",
-            "mirror_text",
-            "decision",
-        }
-        missing = required_cols - set(trials.columns)
-        if missing:
-            raise KeyError(f"Dataset is missing required columns: {sorted(missing)}")
-
-        # Validate that each post_id has a stable text pair (otherwise modal decision alone
-        # wouldn't define a unique example).
-        text_nunique = (
-            trials.groupby("post_id", dropna=False)
-            .agg(
-                original_text_nunique=("original_text", lambda s: s.fillna("").nunique()),
-                mirror_text_nunique=("mirror_text", lambda s: s.fillna("").nunique()),
-            )
-            .reset_index()
-        )
-        bad = text_nunique[
-            (text_nunique["original_text_nunique"] != 1)
-            | (text_nunique["mirror_text_nunique"] != 1)
-        ]
-        if len(bad):
-            example_post = str(bad.iloc[0]["post_id"])
-            raise ValueError(
-                "Expected stable original/mirror text per post_id, but found conflicts. "
-                f"Example problematic post_id={example_post}."
-            )
-
-        # Modal decision with explicit tie-breaking: remove wins ties.
-        counts = (
-            trials.groupby(["post_id", "decision"], dropna=False)
-            .size()
-            .unstack(fill_value=0)
-            .reset_index()
-        )
-
-        # Ensure both columns exist.
-        if "keep" not in counts.columns:
-            counts["keep"] = 0
-        if "remove" not in counts.columns:
-            counts["remove"] = 0
-
-        counts["decision"] = counts.apply(
-            lambda r: "keep" if int(r["keep"]) > int(r["remove"]) else "remove", axis=1
-        )
-        counts["keep_remove_label"] = (counts["decision"] == "remove").astype(int)
-
-        # Attach canonical text pair (take first; validated unique above).
-        texts = (
-            trials.drop_duplicates(subset=["post_id"])[["post_id", "original_text", "mirror_text"]]
-        )
-
-        out = counts.merge(texts, on="post_id", how="left")
-
-        # Provide both keys for downstream compatibility.
-        out = out.rename(columns={"post_id": "message_id"})
-        out = out[["message_id", "original_text", "mirror_text", "decision", "keep_remove_label"]]
-        return out
+        """Return one row per post with modal decision from the shared registry."""
+        return load_dataset(STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS, low_memory=False)
 
 
 if __name__ == "__main__":

--- a/shared/data/dataloader.py
+++ b/shared/data/dataloader.py
@@ -1,4 +1,8 @@
-"""Raw-only loader for datasets registered in ``shared.data.registry``."""
+"""Loader for datasets registered in ``shared.data.registry``.
+
+Resolves any registered name (raw or transformed) to its CSV path and reads it
+with no further transforms.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +13,8 @@ from shared.data import registry
 
 def load_dataset(name: str, *, low_memory: bool = False) -> pd.DataFrame:
     """Load a registered study CSV by name with no transforms.
+
+    Works for raw and transformed registry entries alike.
 
     Raises:
         KeyError: If ``name`` is not in the registry.

--- a/shared/data/registry.py
+++ b/shared/data/registry.py
@@ -1,4 +1,4 @@
-"""Named catalog of canonical study datasets under ``shared/data/raw/``."""
+"""Named catalog of canonical study datasets under ``shared/data/``."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-DatasetKind = Literal["results", "stimuli"]
+DatasetKind = Literal["results", "stimuli", "transformed"]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -15,6 +15,7 @@ STUDY_PHASE_2_PART_1_RESULTS_FULL = "STUDY_PHASE_2_PART_1_RESULTS_FULL"
 STUDY_PHASE_2_PART_1_STIMULI = "STUDY_PHASE_2_PART_1_STIMULI"
 STUDY_PHASE_2_PART_2_RESULTS_FULL = "STUDY_PHASE_2_PART_2_RESULTS_FULL"
 STUDY_PHASE_2_PART_2_STIMULI = "STUDY_PHASE_2_PART_2_STIMULI"
+STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS = "STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS"
 
 
 @dataclass(frozen=True)
@@ -56,6 +57,14 @@ DATASETS: dict[str, DatasetEntry] = {
         name=STUDY_PHASE_2_PART_2_STIMULI,
         relative_path=Path("shared/data/raw/study_phase_2_part_2/stimuli/flips.csv"),
         kind="stimuli",
+        study_phase="study_phase_2_part_2",
+    ),
+    STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS: DatasetEntry(
+        name=STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS,
+        relative_path=Path(
+            "shared/data/transformed/study_phase_2_part_2/keep_remove_labels.csv"
+        ),
+        kind="transformed",
         study_phase="study_phase_2_part_2",
     ),
 }

--- a/shared/data/registry.py
+++ b/shared/data/registry.py
@@ -20,6 +20,12 @@ STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS = "STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABE
 
 @dataclass(frozen=True)
 class DatasetEntry:
+    """Immutable catalog record for one registered study CSV.
+
+    ``kind`` is ``results`` or ``stimuli`` for raw inputs, or
+    ``transformed`` for derived artifacts under ``shared/data/transformed/``.
+    """
+
     name: str
     relative_path: Path
     kind: DatasetKind

--- a/shared/data/transformed/study_phase_2_part_2/README.md
+++ b/shared/data/transformed/study_phase_2_part_2/README.md
@@ -1,0 +1,31 @@
+# Study Phase 2 Part 2 — keep/remove modal labels
+
+Materialized post-level training labels derived from the raw Part 2 results.
+
+## Source
+
+- Registry: `STUDY_PHASE_2_PART_2_RESULTS_FULL`
+- Path: `shared/data/raw/study_phase_2_part_2/results/full.csv`
+
+## Transform
+
+1. Keep `evaluation_mode == "linked_fate"` (case-insensitive).
+2. Keep `decision ∈ {keep, remove}` (case-insensitive).
+3. Drop null / empty `post_id` (before stringifying, so NaN never becomes `"nan"`).
+4. Assert each `post_id` has exactly one distinct `original_text` and one distinct `mirror_text`.
+5. Modal decision per `post_id`; **ties → `remove`** (`keep` only if `keep_count > remove_count`).
+6. `keep_remove_label`: `1` = remove, `0` = keep.
+7. Expose `message_id` as an alias of `post_id`.
+
+## Output
+
+- File: `keep_remove_labels.csv`
+- Registry: `STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS`
+- Columns: `message_id`, `original_text`, `mirror_text`, `decision`, `keep_remove_label`
+- Expected size: ~8791 rows (~5978 keep / ~2813 remove)
+
+## Regenerate
+
+```bash
+PYTHONPATH=. uv run python shared/data/transformed/study_phase_2_part_2/transform.py
+```

--- a/shared/data/transformed/study_phase_2_part_2/transform.py
+++ b/shared/data/transformed/study_phase_2_part_2/transform.py
@@ -1,0 +1,132 @@
+"""Materialize modal keep/remove labels for Study Phase 2 Part 2.
+
+Reads the registered raw Part 2 results CSV, filters to linked-fate keep/remove
+trials with non-null ``post_id``, aggregates to one modal decision per post
+(ties → remove), and writes ``keep_remove_labels.csv`` beside this script.
+
+Run from repo root::
+
+    PYTHONPATH=. uv run python shared/data/transformed/study_phase_2_part_2/transform.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from shared.data.dataloader import load_dataset
+from shared.data.registry import STUDY_PHASE_2_PART_2_RESULTS_FULL
+
+OUTPUT_DIR = Path(__file__).resolve().parent
+OUTPUT_CSV = OUTPUT_DIR / "keep_remove_labels.csv"
+
+_OUTPUT_COLUMNS = [
+    "message_id",
+    "original_text",
+    "mirror_text",
+    "decision",
+    "keep_remove_label",
+]
+
+
+def _load_slim_trial_frame(raw: pd.DataFrame) -> pd.DataFrame:
+    """Layer A: linked-fate keep/remove trials with non-null post_id."""
+    trials = raw.copy()
+    trials["decision"] = trials["decision"].astype(str).str.lower().str.strip()
+
+    if "evaluation_mode" not in trials.columns:
+        raise KeyError("Expected `evaluation_mode` column in Part 2 results.")
+    trials["evaluation_mode"] = trials["evaluation_mode"].astype(str).str.lower().str.strip()
+    trials = trials[trials["evaluation_mode"] == "linked_fate"].copy()
+
+    trials = trials[trials["decision"].isin(["keep", "remove"])].copy()
+
+    if "post_id" not in trials.columns:
+        raise KeyError("Expected `post_id` column in Part 2 results.")
+
+    # Drop null/empty post_id before stringifying (avoids "nan" string keys).
+    post_id = trials["post_id"]
+    trials = trials[post_id.notna()].copy()
+    trials["post_id"] = trials["post_id"].astype(str).str.strip()
+    trials = trials[trials["post_id"] != ""].copy()
+    trials = trials[trials["post_id"].str.lower() != "nan"].copy()
+
+    return trials
+
+
+def _aggregate_modal_labels(trials: pd.DataFrame) -> pd.DataFrame:
+    """Layer B: one row per post with modal decision (tie → remove)."""
+    required = {"post_id", "original_text", "mirror_text", "decision"}
+    missing = required - set(trials.columns)
+    if missing:
+        raise KeyError(f"Dataset is missing required columns: {sorted(missing)}")
+
+    text_nunique = (
+        trials.groupby("post_id", dropna=False)
+        .agg(
+            original_text_nunique=("original_text", lambda s: s.fillna("").nunique()),
+            mirror_text_nunique=("mirror_text", lambda s: s.fillna("").nunique()),
+        )
+        .reset_index()
+    )
+    bad = text_nunique[
+        (text_nunique["original_text_nunique"] != 1)
+        | (text_nunique["mirror_text_nunique"] != 1)
+    ]
+    if len(bad):
+        example_post = str(bad.iloc[0]["post_id"])
+        raise ValueError(
+            "Expected stable original/mirror text per post_id, but found conflicts. "
+            f"Example problematic post_id={example_post}."
+        )
+
+    counts = (
+        trials.groupby(["post_id", "decision"], dropna=False)
+        .size()
+        .unstack(fill_value=0)
+        .reset_index()
+    )
+    if "keep" not in counts.columns:
+        counts["keep"] = 0
+    if "remove" not in counts.columns:
+        counts["remove"] = 0
+
+    counts["decision"] = counts.apply(
+        lambda r: "keep" if int(r["keep"]) > int(r["remove"]) else "remove",
+        axis=1,
+    )
+    counts["keep_remove_label"] = (counts["decision"] == "remove").astype(int)
+
+    texts = trials.drop_duplicates(subset=["post_id"])[
+        ["post_id", "original_text", "mirror_text"]
+    ]
+    out = counts.merge(texts, on="post_id", how="left")
+    out = out.rename(columns={"post_id": "message_id"})
+    return out[_OUTPUT_COLUMNS].reset_index(drop=True)
+
+
+def build_keep_remove_labels(
+    raw: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """Build the modal keep/remove training frame from Part 2 results."""
+    if raw is None:
+        raw = load_dataset(STUDY_PHASE_2_PART_2_RESULTS_FULL, low_memory=False)
+    trials = _load_slim_trial_frame(raw)
+    return _aggregate_modal_labels(trials)
+
+
+def write_keep_remove_labels(path: Path = OUTPUT_CSV) -> pd.DataFrame:
+    """Materialize ``keep_remove_labels.csv`` and return the dataframe."""
+    df = build_keep_remove_labels()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+    return df
+
+
+if __name__ == "__main__":
+    frame = write_keep_remove_labels()
+    print(f"Wrote {OUTPUT_CSV}")
+    print(f"rows={len(frame)}")
+    print(frame["decision"].value_counts().to_dict())
+    print(f"columns={list(frame.columns)}")

--- a/shared/data/transformed/study_phase_2_part_2/transform.py
+++ b/shared/data/transformed/study_phase_2_part_2/transform.py
@@ -1,8 +1,8 @@
-"""Materialize modal keep/remove labels for Study Phase 2 Part 2.
+"""Build and materialize modal keep/remove labels from Part 2 raw results.
 
-Reads the registered raw Part 2 results CSV, filters to linked-fate keep/remove
-trials with non-null ``post_id``, aggregates to one modal decision per post
-(ties → remove), and writes ``keep_remove_labels.csv`` beside this script.
+Public entrypoints: ``build_keep_remove_labels`` (in-memory frame) and
+``write_keep_remove_labels`` (persist ``keep_remove_labels.csv`` beside this
+script).
 
 Run from repo root::
 
@@ -31,7 +31,16 @@ _OUTPUT_COLUMNS = [
 
 
 def _load_slim_trial_frame(raw: pd.DataFrame) -> pd.DataFrame:
-    """Layer A: linked-fate keep/remove trials with non-null post_id."""
+    """Select linked-fate keep/remove trials with a usable ``post_id``.
+
+    Normalizes ``decision`` and ``evaluation_mode`` for comparison. Rows with
+    null, empty, or literal ``"nan"`` post IDs are dropped.
+
+    Raises
+    ------
+    KeyError
+        If ``evaluation_mode`` or ``post_id`` is missing from ``raw``.
+    """
     trials = raw.copy()
     trials["decision"] = trials["decision"].astype(str).str.lower().str.strip()
 
@@ -56,7 +65,18 @@ def _load_slim_trial_frame(raw: pd.DataFrame) -> pd.DataFrame:
 
 
 def _aggregate_modal_labels(trials: pd.DataFrame) -> pd.DataFrame:
-    """Layer B: one row per post with modal decision (tie → remove)."""
+    """Aggregate trials to one modal keep/remove label per post.
+
+    Tie votes become ``remove``. ``message_id`` aliases ``post_id``;
+    ``keep_remove_label`` is 1 for remove and 0 for keep.
+
+    Raises
+    ------
+    KeyError
+        If required trial columns are missing.
+    ValueError
+        If a post has conflicting ``original_text`` or ``mirror_text``.
+    """
     required = {"post_id", "original_text", "mirror_text", "decision"}
     missing = required - set(trials.columns)
     if missing:
@@ -109,7 +129,27 @@ def _aggregate_modal_labels(trials: pd.DataFrame) -> pd.DataFrame:
 def build_keep_remove_labels(
     raw: pd.DataFrame | None = None,
 ) -> pd.DataFrame:
-    """Build the modal keep/remove training frame from Part 2 results."""
+    """Build the modal keep/remove training frame from Part 2 results.
+
+    Parameters
+    ----------
+    raw : pandas.DataFrame, optional
+        Part 2 results. When omitted, loads
+        ``STUDY_PHASE_2_PART_2_RESULTS_FULL`` via the shared dataloader.
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per post with ``message_id``, ``original_text``,
+        ``mirror_text``, ``decision``, and ``keep_remove_label``.
+
+    Raises
+    ------
+    KeyError
+        If required columns are missing from the source frame.
+    ValueError
+        If a post has conflicting original or mirror text across trials.
+    """
     if raw is None:
         raw = load_dataset(STUDY_PHASE_2_PART_2_RESULTS_FULL, low_memory=False)
     trials = _load_slim_trial_frame(raw)
@@ -117,7 +157,22 @@ def build_keep_remove_labels(
 
 
 def write_keep_remove_labels(path: Path = OUTPUT_CSV) -> pd.DataFrame:
-    """Materialize ``keep_remove_labels.csv`` and return the dataframe."""
+    """Write modal keep/remove labels to CSV and return the frame.
+
+    Creates parent directories as needed. By default writes
+    ``keep_remove_labels.csv`` next to this script (the path registered as
+    ``STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS``).
+
+    Parameters
+    ----------
+    path : pathlib.Path, optional
+        Destination CSV path.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The same frame written to disk.
+    """
     df = build_keep_remove_labels()
     path.parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(path, index=False)


### PR DESCRIPTION
# Add transformed keep/remove label dataset for Study Phase 2 Part 2

## Summary

Adds a shared, registry-backed transformed dataset of post-level keep/remove labels derived from Part 2 linked-fate trials, so experiments no longer each rebuild modal labels from raw results.

Callers load `STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS` via `load_dataset` after materializing `keep_remove_labels.csv`. Ties resolve to remove; labels are `0` = keep, `1` = remove.

## Purpose

Currently the shared loader is raw-only, and each experiment that needs keep/remove training labels reimplements the same linked-fate filter and modal aggregation over original+mirror posts.

This feature centralizes that transform under `shared/data/transformed/`, registers the output, and lets `load_dataset` resolve transformed entries the same way as raw ones. Migrating individual experiment call sites is out of scope.

## Architecture

Components:

- `shared.data.registry` — catalogs raw and transformed CSVs; new kind `"transformed"` and name `STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS`.
- `shared.data.dataloader.load_dataset` — resolves any registered name to a CSV path and reads it with no further transforms.
- `shared/data/transformed/study_phase_2_part_2/transform.py` — filters Part 2 results, modal-aggregates per post, writes `keep_remove_labels.csv`.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    E1[Experiment] --> R1[Raw Part 2 results]
    E1 --> L1[Local modal keep/remove rebuild]
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    T[transform.py] --> Raw[STUDY_PHASE_2_PART_2_RESULTS_FULL]
    T --> CSV[keep_remove_labels.csv]
    Reg[Registry] --> CSV
    E2[Caller] --> LD[load_dataset]
    LD --> Reg
    LD --> Out[Labeled frame]
  end
```

## Interfaces

### Registry

- Name: `STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS`
- Kind: `transformed`
- Path: `shared/data/transformed/study_phase_2_part_2/keep_remove_labels.csv`

### Data / schema contracts

| Field | Type | Notes |
| ----- | ---- | ----- |
| `message_id` | string | Alias of `post_id` |
| `original_text` | string | Stable per post |
| `mirror_text` | string | Stable per post |
| `decision` | `"keep"` \| `"remove"` | Modal; ties → `remove` |
| `keep_remove_label` | `0` \| `1` | `0` = keep, `1` = remove |

Expected size after materialize: ~8791 rows (~5978 keep / ~2813 remove).

### Loader

```python
from shared.data.dataloader import load_dataset
from shared.data.registry import STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS

df = load_dataset(STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS)
```

## How to run

Materialize the transformed CSV (required before load; artifact is produced locally by the script):

```bash
PYTHONPATH=. uv run python shared/data/transformed/study_phase_2_part_2/transform.py
```

Expected: writes `keep_remove_labels.csv`, prints `rows=8791` and keep/remove counts (~5978 / ~2813).

Load via the shared API:

```bash
PYTHONPATH=. uv run python -c "from shared.data.dataloader import load_dataset; from shared.data.registry import STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS; df=load_dataset(STUDY_PHASE_2_PART_2_KEEP_REMOVE_LABELS); print(len(df), df['decision'].value_counts().to_dict())"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared transformed dataset of keep/remove labels for Study Phase 2 Part 2.
  * Added support for registering and loading transformed datasets.
  * Added processing to aggregate trial decisions into validated post-level labels.

* **Updates**
  * Experiments now use the shared keep/remove label dataset, improving consistency across workflows.
  * Updated data-loading documentation to clarify raw and transformed dataset support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->