### PR TITLE
docs(AGENTS): document LAB_* AWS credentials for the remote environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,18 @@ The startup/update script is intentionally minimal: it only verifies that `uv` i
 - `METRESEARCHGROUP_GITHUB_PAT_TOKEN` — the personal access token (PAT) used for accessing GitHub (e.g. authenticated `git`/API operations against `github.com/METResearchGroup`).
 - LLM/experiment scripts read API keys from a repo-root `.env` (`lib/load_env_vars.py`: `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `WANDB_API_KEY`). `HF_TOKEN` and AWS role ARNs (`CURSOR_AWS_ASSUME_IAM_ROLE_ARN`, `SAGEMAKER_ROLE_ARN`) are also available as environment secrets.
 
+### AWS credentials
+
+The repo's boto3 clients (`lib/aws/`, `scripts/export_study_results.py`, etc.) use the default credential chain — they do **not** set a profile explicitly.
+
+- **In the remote Cloud Agent environment, `AWS_PROFILE` is not set.** Instead, IAM user credentials are provided as `LAB_AWS_ACCESS_KEY_ID` and `LAB_AWS_ACCESS_KEY_SECRET`. boto3 and the AWS CLI do not read those prefixed names, so export them as the standard variables before running any AWS-touching code:
+  ```bash
+  export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+  export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+  ```
+  Verified working via `sts get-caller-identity` (IAM user `mark_iam_credentials`).
+- **Locally / outside the remote env**, default to `AWS_PROFILE` (your shared AWS config); the `LAB_*` vars are typically absent there.
+
 ### Python tooling (non-obvious)
 
 - Always prefix commands with `PYTHONPATH=.` — scripts import repo-root packages (`lib/`, etc.). Example: `PYTHONPATH=. uv run python scripts/export_study_results.py --help`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Confirmed AWS access from the remote Cloud Agent environment and documented how future agents should authenticate.

- Verified `LAB_AWS_ACCESS_KEY_ID` and `LAB_AWS_ACCESS_KEY_SECRET` are present in the remote env and that `AWS_PROFILE` is **not** set.
- Confirmed access via a read-only `sts get-caller-identity` call (IAM user `mark_iam_credentials`).
- Added an **AWS credentials** subsection to `AGENTS.md` explaining that boto3/AWS CLI do not read the `LAB_`-prefixed names, so agents must export them as the standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in the remote env, and fall back to `AWS_PROFILE` locally.

No environment/setup changes were required (AWS access already works), so this is a docs-only change.

## Why

The repo's boto3 clients (`lib/aws/`, `scripts/export_study_results.py`, etc.) use the default credential chain with no explicit profile. In the remote env there is no `AWS_PROFILE` and the standard `AWS_*` vars are unset, so AWS-touching code would fail unless the `LAB_*` values are re-exported under the names boto3 recognizes.

## Validation

Ran the exact export procedure from the doc, then a read-only STS identity check (account/user IDs masked below):

```
Documented export procedure -> STS OK: arn:aws:iam::5174****77:user/mark_iam_credentials
```

## Testing notes

Validation was terminal-driven (read-only STS call); no UI is involved, so there are no screen recordings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4397af7a-02b1-4b91-bc07-04623e56e8cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4397af7a-02b1-4b91-bc07-04623e56e8cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

