### PR TITLE
Add incremental identity skip implementation plan

### DIFF
--- a/docs/plans/2026-09-01_incremental_identity_skip_124df6/plan.md
+++ b/docs/plans/2026-09-01_incremental_identity_skip_124df6/plan.md
@@ -1,0 +1,64 @@
+# Replace skip-set warmup with explicit incremental identity skip
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Ingest and preprocess skip already-written IDs through one session type, but that load is named and documented as a pipeline stage, and one config flag hides two different disk scans (this run directory vs every timestamped run under the stage). This plan makes skip-set load, exclude, and extend three explicit operations, and it stops treating skip-set initialization as a preprocess stage.
+
+## Happy flow
+
+An operator resumes ingest or re-runs preprocess. Known IDs are loaded into an in-memory skip set, incoming rows with those IDs are dropped, remaining rows are persisted as candidates, and the skip set grows only when the same process will see more batches.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    Warm["Warm as a stage"]
+    Flag["One flag, two scans"]
+    Warm --> Flag
+  end
+  subgraph after [After]
+    Load["Load skip set"]
+    Drop["Drop known IDs"]
+    Collapse["Collapse remaining IDs"]
+    Persist["Persist candidates"]
+    Load --> Drop --> Collapse --> Persist
+  end
+```
+
+Preprocess collapse is last-wins within the current batch. Ingest does not collapse; it excludes, persists, then extends the skip set for later batches.
+
+## Approach
+
+Keep one skip-set session type. Add the two load operations as first-class methods, then migrate ingest and preprocess off the old warmup entrypoint, then delete the flag and warmup name. Preprocess keeps pandas for dropping known IDs and gets a named collapse helper in the preprocess runner. YAML policy tokens stay; they only choose which load to call. Feature-generation unlabeled skip stays on the backlog.
+
+## Steps
+
+### Step 1: Add explicit skip-set load and row helpers next to the existing warmup API
+
+Introduce this-run and all-runs load methods, plus exclude and extend helpers for list-of-dict ingest. Keep the current warmup method and prior-runs flag working so existing callers still compile. Prove the new methods with unit tests.
+
+### Step 2: Switch ingest to the explicit skip-set loads
+
+Bluesky, Twitter, and Reddit ingest pick one load from YAML policy, then exclude → persist → extend. Stop passing the prior-runs flag from ingest. Storage persist uses the new exclude and extend helpers.
+
+### Step 3: Switch preprocess to skip then collapse
+
+Load the all-runs skip set before creating the new preprocess run directory. Drop known IDs with pandas. Collapse remaining IDs last-wins in a named helper on the preprocess runner. Delete the helper that combined those two jobs. Skip-count print stays “already in a prior preprocessed run.”
+
+### Step 4: Remove the warmup API and rewrite the stimuli runbook
+
+Delete the warmup method and the prior-runs flag. Rename tests that still say warm. Update the stimuli runbook so skip-set load is not a mermaid node or named stage.
+
+## What "done" looks like
+
+1. One skip-set session type remains. There is no warmup method and no prior-runs flag on its config.
+2. Ingest loads either this run or all runs from YAML policy, then excludes known IDs, persists, and extends the skip set.
+3. Preprocess loads all prior preprocessed runs before creating the new run directory, never treating the stage root as a fake run directory.
+4. Preprocess drops known IDs with pandas, then collapses remaining IDs last-wins. The skip count does not include rows removed by collapse.
+5. The stimuli runbook describes load skip set → drop known IDs → collapse candidates → transform → filter → save.
+6. Feature-generation unlabeled skip and YAML policy token rename are still out of this work.

--- a/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/step1.md
+++ b/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/step1.md
@@ -1,0 +1,125 @@
+# Step 1: Add explicit skip-set load and row helpers next to the existing warmup API
+
+## Goal
+
+Add the agreed skip-set methods on `DedupeSession` without breaking existing callers. `warm`, `filter_rows`, `note_appended`, and `DedupeConfig.include_prior_runs` stay and delegate to the new methods. Ingest and preprocess callers are not migrated in this PR.
+
+## Caller / unit of work
+
+**Main caller:** unit tests in `/Users/mark/src/work/mirrorview-wt/tests/data_platform/utils/test_deduplication.py` constructing a `DedupeSession` and calling the new methods.
+
+**Slice:** new methods union into `seen_ids`; old methods keep working by delegating.
+
+**Out of scope:** ingest callers (`sync_*.py`); `append_deduped_records`; preprocess runner; runbook; deleting `warm` / `include_prior_runs` / `filter_rows` / `note_appended`; YAML token migration; `FeatureLabelQuery`.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorview-wt/docs/plans/2026-09-01_incremental_identity_skip_124df6/plan.md` | Parent plan |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/utils/deduplication.py` | Current `warm` / `filter_rows` / `note_appended` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/utils/storage.py` | `load_seen_ids_from_disk` and `load_seen_ids_from_all_runs` already exist |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/utils/test_deduplication.py` | Existing warm/filter/note tests that must stay green |
+
+## Files allowed to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/deduplication.py`
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/utils/test_deduplication.py`
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/**`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/**`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/storage.py`
+- `/Users/mark/src/work/mirrorview-wt/docs/runbooks/**`
+- `/Users/mark/src/work/mirrorview-wt/backlog.md`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/generate_features/**`
+
+## Contracts to lock
+
+Keep `DedupeConfig(id_column, filename=None, include_prior_runs=False)` unchanged.
+
+Keep `DedupeSession.config` and `DedupeSession.seen_ids`.
+
+Add these methods. Each load **unions** into `seen_ids` (`|=`). Callers of the new API call **only one** load per session setup. `warm` is the compatibility path that may call both.
+
+```text
+load_seen_ids(self, storage: StorageManager, run_dir: Path) -> None
+  storage.load_seen_ids_from_disk(run_dir, self.config.id_column, filename=self.config.filename)
+  union into seen_ids
+
+load_seen_ids_from_all_runs(self, storage: StorageManager) -> None
+  storage.load_seen_ids_from_all_runs(self.config.id_column, filename=self.config.filename)
+  union into seen_ids
+
+exclude_seen_ids(self, rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]
+  same behavior as today's filter_rows (keep skipped-count tuple)
+
+add_seen_ids(self, rows: list[dict[str, Any]]) -> None
+  same behavior as today's note_appended
+```
+
+Compatibility (must remain until Step 4):
+
+```text
+warm(self, storage, output_dir) -> None
+  load_seen_ids(storage, output_dir)
+  if config.include_prior_runs: load_seen_ids_from_all_runs(storage)
+
+filter_rows(...) -> exclude_seen_ids(...)
+note_appended(...) -> add_seen_ids(...)
+```
+
+Do not rename `DedupeSession`, `DedupeConfig`, `append_deduped_records`, or `policy_includes_prior_runs`.
+
+## Test design
+
+Pseudocode then real tests. Prefer the public new methods. Existing `test_session_warm_*`, `test_session_filter_rows_skips_seen`, `test_note_appended_updates_seen_ids`, and `test_policy_includes_prior_runs` must stay and stay green.
+
+given storage.load_seen_ids_from_disk returns {"uri-a"}
+when session.load_seen_ids(storage, Path("/tmp/run"))
+then seen_ids == {"uri-a"}
+and load_seen_ids_from_all_runs is not called
+
+given storage.load_seen_ids_from_all_runs returns {"uri-b"}
+when session.load_seen_ids_from_all_runs(storage)
+then seen_ids == {"uri-b"}
+and load_seen_ids_from_disk is not called
+
+given seen_ids already {"uri-a"} and disk returns {"uri-b"}
+when load_seen_ids
+then seen_ids == {"uri-a", "uri-b"}  (union, not replace)
+
+given seen_ids == {"uri-a"}
+when exclude_seen_ids([{"uri": "uri-a"}, {"uri": "uri-b"}])
+then kept == [{"uri": "uri-b"}], skipped == 1
+
+given seen_ids == {"uri-a"}
+when add_seen_ids([{"uri": "uri-b"}])
+then seen_ids == {"uri-a", "uri-b"}
+
+given include_prior_runs=True
+when warm(storage, run_dir)
+then both disk and all-runs loads happen (old test still covers this)
+
+## Implementation notes
+
+Follow implement-from-spec phases in this packet: contracts on `DedupeSession`, failing tests for the new methods, then flesh `load_seen_ids` → `load_seen_ids_from_all_runs` → `exclude_seen_ids` → `add_seen_ids` → rewire `warm`/`filter_rows`/`note_appended` as delegates. One Git commit per phase / unit of work.
+
+Do not convert `warm` into a no-op. Ingest and preprocess still call it after this PR.
+
+## Must pass
+
+```bash
+cd /Users/mark/src/work/mirrorview-wt
+PYTHONPATH=. uv run pytest tests/data_platform/utils/test_deduplication.py tests/data_platform/utils/test_storage.py tests/data_platform/ingestion tests/data_platform/preprocessing -q
+```
+
+Expected: exit 0. Existing warm/filter/note tests still collected and passing. New tests for the four methods passing.
+
+## Must fail / not happen
+
+- Ingest or preprocess files changed in this PR.
+- `include_prior_runs` or `warm` removed.
+- `load_seen_ids` calling `load_seen_ids_from_all_runs` (or the reverse).
+- Either load **replacing** `seen_ids` instead of unioning.

--- a/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/step2.md
+++ b/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/step2.md
@@ -1,0 +1,129 @@
+# Step 2: Switch ingest to the explicit skip-set loads
+
+## Goal
+
+Bluesky, Twitter, and Reddit ingest pick one skip-set load from YAML policy, then exclude → persist → extend. `StorageManager.append_deduped_records` calls `exclude_seen_ids` and `add_seen_ids`. Ingest stops passing `include_prior_runs` on `DedupeConfig`.
+
+## Caller / unit of work
+
+**Main caller:** `run_sync_tasks` in `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_bluesky.py` (same shape in `sync_twitter.py` and `_open_reddit_dedupe_sessions` in `sync_reddit.py`).
+
+**Slice:** construct `DedupeSession` without `include_prior_runs` → one load → `append_deduped_records` uses exclude then add.
+
+**Out of scope:** preprocess runner; deleting `warm` / `include_prior_runs` / `filter_rows` / `note_appended` (preprocess still uses `warm`); runbook; YAML token meanings; feature generation.
+
+**Depends on:** Step 1 (new methods exist). Parallel with Step 3.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorview-wt/docs/plans/2026-09-01_incremental_identity_skip_124df6/plan.md` | Parent plan |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/utils/deduplication.py` | `policy_includes_prior_runs`, new load/exclude/add methods |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_bluesky.py` | `run_sync_tasks` session setup around lines 236–245 |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_twitter.py` | same around lines 119–128 |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_reddit.py` | `_open_reddit_dedupe_sessions` around lines 381–406; comments vs posts policies |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/utils/storage.py` | `append_deduped_records` currently calls `filter_rows` / `note_appended` |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/utils/test_storage.py` | persist tests that currently call `warm` |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/ingestion/test_sync_checkpoint.py` | `test_append_deduped_records_skips_seen_ids` |
+
+## Files allowed to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_bluesky.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_twitter.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_reddit.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/storage.py` (`append_deduped_records` only)
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/utils/test_storage.py`
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/ingestion/test_sync_checkpoint.py`
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/**`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/deduplication.py` (do not delete compatibility methods here)
+- `/Users/mark/src/work/mirrorview-wt/docs/runbooks/**`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/generate_features/**`
+- YAML config files / `dedupe_policy` token strings
+
+## Contracts to lock
+
+Ingest session setup (Bluesky/Twitter; Reddit repeats per comments/posts session):
+
+```text
+session = DedupeSession(DedupeConfig(id_column=..., filename=...))
+  # do not pass include_prior_runs
+
+if policy_includes_prior_runs(policy):
+    session.load_seen_ids_from_all_runs(storage)
+else:
+    session.load_seen_ids(storage, output_dir)
+
+# then existing append_deduped_records(...)
+```
+
+Policy sources (unchanged keys):
+
+- Bluesky/Twitter: `ingestion_params.get("dedupe_policy")`
+- Reddit comments: `ingestion_params.get("comments_dedupe_policy")`
+- Reddit posts: `ingestion_params.get("posts_dedupe_policy")`
+
+`append_deduped_records`:
+
+```text
+kept_rows, skipped = dedupe_session.exclude_seen_ids(rows)
+if kept_rows:
+    append_records(...)
+    dedupe_session.add_seen_ids(kept_rows)
+return AppendResult(kept=len(kept_rows), skipped=skipped)
+```
+
+Do not call `add_seen_ids` when `kept_rows` is empty (same as today's `note_appended` guard).
+
+Do not rename `append_deduped_records`. Do not migrate YAML tokens. `policy_includes_prior_runs` stays the branch.
+
+## Test design
+
+given a current-run CSV already containing id "1"
+when the test session calls load_seen_ids (not warm) then append_deduped_records with ["1", "2"]
+then kept == 1, skipped == 1, disk ids == {"1", "2"}
+
+given a prior run dir with uri X and include-prior policy
+when the test session calls load_seen_ids_from_all_runs then append_deduped_records with [X, new]
+then skipped == 1, kept == 1
+
+given two dataset ids
+when session B loads only B's run
+then id present only in A is not skipped (existing cross-dataset test)
+
+Rewrite `test_storage.py` and `test_sync_checkpoint.py` persist tests to call `load_seen_ids` or `load_seen_ids_from_all_runs` instead of `warm` + `include_prior_runs=True`. Do not delete those tests.
+
+`test_deduplication.py` warm tests stay; they still prove compatibility for preprocess.
+
+## Implementation notes
+
+Follow implement-from-spec in this packet. Flesh in order: `append_deduped_records` → Bluesky `run_sync_tasks` → Twitter `run_sync_tasks` → Reddit `_open_reddit_dedupe_sessions`. Tests first for the storage persist path.
+
+Do not call both load methods on one ingest session.
+
+## Must pass
+
+```bash
+cd /Users/mark/src/work/mirrorview-wt
+PYTHONPATH=. uv run pytest tests/data_platform/utils/test_storage.py tests/data_platform/utils/test_deduplication.py tests/data_platform/ingestion -q
+```
+
+Expected: exit 0.
+
+Grep in ingest files must show no `include_prior_runs=` and no `.warm(`:
+
+```bash
+rg -n "include_prior_runs|\.warm\(" data_platform/ingestion
+```
+
+Expected: no matches.
+
+## Must fail / not happen
+
+- Preprocess still using `warm` is **required** (do not migrate it here).
+- Calling both load methods in one ingest session.
+- Changing `dedupe_policy` YAML token strings.
+- Removing `warm` from `DedupeSession`.

--- a/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/step3.md
+++ b/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/step3.md
@@ -1,0 +1,138 @@
+# Step 3: Switch preprocess to skip then collapse
+
+## Goal
+
+Preprocess loads the all-runs skip set **before** creating the new run directory, drops known IDs with pandas, then collapses remaining IDs last-wins in a named helper. Delete `_drop_already_preprocessed`. Do not convert the DataFrame to `list[dict]` to call `exclude_seen_ids`. Do not call `add_seen_ids` (write once at end).
+
+## Caller / unit of work
+
+**Main caller:** `preprocess_records` in `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/runner.py`.
+
+**Slice:** `load_seen_ids_from_all_runs` → pandas drop via `session.seen_ids` → `collapse_candidates_by_id(..., keep="last")` → existing transform/filter/save.
+
+**Out of scope:** ingest callers; deleting `warm` from `DedupeSession`; runbook mermaid (Step 4); YAML tokens; feature generation.
+
+**Depends on:** Step 1. Parallel with Step 2.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorview-wt/docs/plans/2026-09-01_incremental_identity_skip_124df6/plan.md` | Parent plan |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/runner.py` | `preprocess_records`, `_drop_already_preprocessed`, `save_preprocessed` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/utils/storage.py` | `create_new_run_dir`, `load_seen_ids_from_all_runs` |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/preprocessing/test_preprocess_twitter.py` | `test_second_preprocess_run_skips_already_preprocessed_ids` |
+
+## Files allowed to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/runner.py`
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/preprocessing/test_preprocess_twitter.py` (add collapse / skip-count coverage; keep existing re-run test)
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/preprocessing/test_preprocess_bluesky.py` only if a test would otherwise break
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/preprocessing/test_preprocess_reddit.py` only if a test would otherwise break
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/**`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/deduplication.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/preprocess_bluesky.py` (still calls `preprocess_records`)
+- `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/preprocess_twitter.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/preprocess_reddit.py`
+- `/Users/mark/src/work/mirrorview-wt/docs/runbooks/**`
+
+## Contracts to lock
+
+`collapse_candidates_by_id` lives in `runner.py`, **not** on `DedupeSession`:
+
+```text
+collapse_candidates_by_id(df: pd.DataFrame, id_col: str, keep: str = "last") -> pd.DataFrame
+  drop_duplicates(subset=[id_col], keep=keep).reset_index(drop=True)
+  keep="last": later raw run wins
+```
+
+`preprocess_records` order after the raw-run gate:
+
+```text
+preprocessed_storage = spec.storage_cls(StorageStage.PREPROCESSED, dataset_id)
+session = DedupeSession(DedupeConfig(id_column=spec.columns.records_id_column))
+session.load_seen_ids_from_all_runs(preprocessed_storage)
+  # BEFORE save_preprocessed / create_new_run_dir
+  # never pass preprocessed_storage.root_dir as a fake run directory
+  # never pass include_prior_runs=True
+
+records, source_raw_run_dirs = load_raw_records(...)
+id_col = spec.columns.records_id_column
+is_new = ~records[id_col].isin(list(session.seen_ids))
+skipped = len(records) - int(is_new.sum())   # prior-run skips only
+records = records.loc[is_new].reset_index(drop=True)
+records = collapse_candidates_by_id(records, id_col, keep="last")
+
+then apply_text_transform / filter_records / save_preprocessed as today
+do not call add_seen_ids
+do not call exclude_seen_ids
+```
+
+Print: skipped count is prior-run IDs only, wording **"already in a prior preprocessed run"** (not rows removed by collapse). Example shape:
+
+```text
+preprocess_records: kept {n} of {m} {noun} (skipped {skipped} already in a prior preprocessed run) -> {output_dir}
+```
+
+`m` remains `len(records)` after skip+collapse and before filters (today's `input_count` meaning). Do not change `row_counts.input` semantics.
+
+Delete `_drop_already_preprocessed` entirely.
+
+## Test design
+
+Keep `test_second_preprocess_run_skips_already_preprocessed_ids` green (second run `row_counts.input == 0`).
+
+New unit tests in the twitter preprocess test module (or a small `test_runner.py` next to it if you need to import helpers without a full CLI):
+
+given df with ids [a, a] and different text, keep="last"
+when collapse_candidates_by_id
+then one row, the last text
+
+given seen_ids {a} and df rows [a, b, b]
+when pandas drop then collapse
+then skipped == 1 (only a)
+and surviving ids == [b] (one row)
+
+given no prior preprocessed runs
+when load_seen_ids_from_all_runs then preprocess
+then skipped == 0 and create_new_run_dir still happens inside save (existing write-output tests)
+
+Do not convert records to `list[dict]` in `preprocess_records` for skip.
+
+## Implementation notes
+
+Follow implement-from-spec. Flesh `collapse_candidates_by_id` first, then the pandas drop in `preprocess_records`, then delete `_drop_already_preprocessed`, then print wording.
+
+`create_new_run_dir` is inside `save_preprocessed` today. Keep it there. Load the skip set before that call so the new empty run dir is not part of the all-runs scan.
+
+## Must pass
+
+```bash
+cd /Users/mark/src/work/mirrorview-wt
+PYTHONPATH=. uv run pytest tests/data_platform/preprocessing tests/data_platform/utils/test_deduplication.py -q
+```
+
+Expected: exit 0.
+
+```bash
+rg -n "_drop_already_preprocessed" data_platform tests
+```
+
+Expected: no matches.
+
+```bash
+rg -n "include_prior_runs|\.warm\(" data_platform/preprocessing
+```
+
+Expected: no matches.
+
+## Must fail / not happen
+
+- Passing the stage root as `run_dir` to any load method.
+- Using `exclude_seen_ids` on preprocess rows.
+- Calling `add_seen_ids` from preprocess.
+- Putting `collapse_candidates_by_id` on `DedupeSession`.
+- Skip count including collapse duplicates.

--- a/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/step4.md
+++ b/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/step4.md
@@ -1,0 +1,123 @@
+# Step 4: Remove the warmup API and rewrite the stimuli runbook
+
+## Goal
+
+Delete `warm`, `filter_rows`, `note_appended`, and `DedupeConfig.include_prior_runs`. Rename tests that still say warm. Rewrite the stimuli runbook so skip-set load is not a pipeline stage. This PR is the last code+docs land; it does not ship a product feature of its own beyond finishing the rename.
+
+## Caller / unit of work
+
+**Main caller:** remaining references to `warm` / `include_prior_runs` / `filter_rows` / `note_appended` after Steps 2 and 3. After this PR those names do not exist.
+
+**Slice:** delete compatibility API → rename tests → update `/Users/mark/src/work/mirrorview-wt/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md`.
+
+**Out of scope:** YAML `dedupe_policy` token rename; `FeatureLabelQuery`; renaming `DedupeSession` / `append_deduped_records`.
+
+**Depends on:** Steps 2 and 3 (no remaining production callers of `warm`).
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorview-wt/docs/plans/2026-09-01_incremental_identity_skip_124df6/plan.md` | Done-state and runbook target |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/utils/deduplication.py` | Compatibility methods to delete |
+| `/Users/mark/src/work/mirrorview-wt/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md` | mermaid warm node and `_drop_already_preprocessed` prose |
+| `/Users/mark/src/work/mirrorview-wt/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md` | mentions `append_deduped_records`; do not invent a warm stage |
+
+## Files allowed to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/deduplication.py`
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/utils/test_deduplication.py`
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/utils/test_storage.py` (only if a leftover `warm` remains)
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/ingestion/test_sync_checkpoint.py` (only if a leftover `warm` remains)
+- `/Users/mark/src/work/mirrorview-wt/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md`
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_bluesky.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_twitter.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_reddit.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/runner.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/storage.py`
+- `/Users/mark/src/work/mirrorview-wt/backlog.md` (already lists deferred items)
+- `/Users/mark/src/work/mirrorview-wt/data_platform/generate_features/**`
+
+If ingest/preprocess/storage still call `warm`, **stop** — Steps 2/3 are not done. Do not re-migrate callers in this PR.
+
+## Contracts to lock
+
+`DedupeConfig` after this PR:
+
+```text
+id_column: str
+filename: str | None = None
+# include_prior_runs is gone
+```
+
+`DedupeSession` public methods after this PR:
+
+```text
+load_seen_ids
+load_seen_ids_from_all_runs
+exclude_seen_ids
+add_seen_ids
+```
+
+`policy_includes_prior_runs` remains. `PRIOR_RUN_POLICIES` remains.
+
+Runbook mermaid (Stage 2 extra details) becomes:
+
+```text
+cli → validate → gate → load skip set → load raw → drop known IDs → collapse candidates → transform → filter → save
+```
+
+Prose must say:
+
+- Skip-set load is not a preprocess stage.
+- Load all prior preprocessed IDs before creating the new run directory.
+- Drop known IDs with pandas; collapse remaining IDs last-wins.
+- Do not name `warm` or `_drop_already_preprocessed`.
+
+Keep `policy_includes_prior_runs` / YAML policy discussion out of this runbook unless it already exists there.
+
+## Test design
+
+Rename (do not drop coverage):
+
+- `test_session_warm_loads_current_run_only_by_default` → `test_load_seen_ids_loads_current_run_only`
+- `test_session_warm_unions_prior_runs_when_enabled` → split into all-runs load + union-into-existing-seen_ids if that function still mixes two cases
+- `test_session_filter_rows_skips_seen` → `test_exclude_seen_ids_skips_seen`
+- `test_note_appended_updates_seen_ids` → `test_add_seen_ids_updates_seen_ids`
+
+given no `include_prior_runs` on `DedupeConfig`
+when constructing `DedupeConfig(id_column="uri", include_prior_runs=True)`
+then TypeError (unexpected keyword)
+
+Repo-wide grep after the change must not find production `warm` / `include_prior_runs` / `filter_rows` / `note_appended` except `policy_includes_prior_runs` and comments in `policy_includes_prior_runs` itself.
+
+## Implementation notes
+
+Delete compatibility wrappers first, then fix tests, then runbook. Do not edit `plan.md` or other step files.
+
+Unrelated uses of the word "warm" (HF CLI, LR warmup, climate text) are out of scope — do not grep-replace those.
+
+## Must pass
+
+```bash
+cd /Users/mark/src/work/mirrorview-wt
+PYTHONPATH=. uv run pytest tests/data_platform -q
+```
+
+Expected: exit 0.
+
+```bash
+rg -n "include_prior_runs|\.warm\(|filter_rows|note_appended|_drop_already_preprocessed" data_platform tests docs/runbooks
+```
+
+Expected: matches only `policy_includes_prior_runs` (and its docstring/tests) plus possibly the word "warm" in unrelated docs. No `DedupeSession.warm`. No mermaid node named warm.
+
+## Must fail / not happen
+
+- Reintroducing `include_prior_runs` on `DedupeConfig`.
+- Changing YAML `dedupe_policy` token strings.
+- Touching `FeatureLabelQuery`.
+- Rewriting `DATA_INGESTION_PIPELINE_ARCHITECTURE.md` unless a leftover `warm` reference is found there (today it has none).


### PR DESCRIPTION
## Summary
- Adds the plan package for replacing skip-set warmup with explicit incremental identity skip.
- Tracking epic: #67
- Child issues (one PR each): #68, #69, #70, #71
- Plan and docs files only. No product code.

## Test plan
- [ ] Confirm `docs/plans/2026-09-01_incremental_identity_skip_124df6/plan.md` matches the epic overview
- [ ] Confirm `steps/step1.md`–`step4.md` exist and map 1:1 to #68–#71
- [ ] Confirm this PR contains no `data_platform/` or test code


Made with [Cursor](https://cursor.com)