### PR TITLE
Add explicit skip-set load and row helpers next to the existing warmup API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2026-09-02
+
+1. Skip-set sessions can load this-run or all-runs ids, drop already-seen ingest rows, and extend the skip set after append, while the old warmup path still works for existing callers.
+
 ## 2026-09-01
 
 1. Shared preprocessing, feature, and curation runners now take `PlatformSpecificColumns` on `spec.columns` instead of the overloaded `PlatformIdBinding` name, so per-platform CSV column maps read as what they are. [PR #65](https://github.com/METResearchGroup/mirrorView-task/pull/65)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-02
 
-1. Skip-set sessions can load this-run or all-runs ids, drop already-seen ingest rows, and extend the skip set after append, while the old warmup path still works for existing callers.
+1. Skip-set sessions can load this-run or all-runs ids, drop already-seen ingest rows, and extend the skip set after append, while the old warmup path still works for existing callers. [PR #79](https://github.com/METResearchGroup/mirrorView-task/pull/79)
 
 ## 2026-09-01
 

--- a/data_platform/utils/deduplication.py
+++ b/data_platform/utils/deduplication.py
@@ -31,21 +31,45 @@ class DedupeConfig:
 
 @dataclass
 class DedupeSession:
+    """In-memory skip set of already-written record ids for one pipeline session.
+
+    Load methods add ids into ``seen_ids`` without replacing ids already present.
+    Exclude drops matching rows and leaves ``seen_ids`` unchanged. Extend adds ids
+    after those rows have been persisted.
+    """
+
     config: DedupeConfig
     seen_ids: set[str] = field(default_factory=set)
 
     def warm(self, storage: StorageManager, output_dir: Path) -> None:  # noqa: F821
+        """Load this-run ids, then all-run ids when ``include_prior_runs`` is true.
+
+        Compatibility path for existing ingest and preprocess callers.
+        """
         self.load_seen_ids(storage, output_dir)
         if self.config.include_prior_runs:
             self.load_seen_ids_from_all_runs(storage)
 
     def filter_rows(self, rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
+        """Return unseen rows and a skipped count. Delegates to ``exclude_seen_ids``."""
         return self.exclude_seen_ids(rows)
 
     def note_appended(self, rows: list[dict[str, Any]]) -> None:
+        """Record persisted row ids. Delegates to ``add_seen_ids``."""
         self.add_seen_ids(rows)
 
     def load_seen_ids(self, storage: StorageManager, run_dir: Path) -> None:  # noqa: F821
+        """Add ids from one run directory to ``seen_ids`` without replacing existing ids.
+
+        Does not read other run directories.
+
+        Parameters
+        ----------
+        storage
+            Disk helper that reads the id column from the run file.
+        run_dir
+            Timestamped run directory whose output file is scanned.
+        """
         self.seen_ids |= storage.load_seen_ids_from_disk(
             run_dir,
             self.config.id_column,
@@ -53,6 +77,15 @@ class DedupeSession:
         )
 
     def load_seen_ids_from_all_runs(self, storage: StorageManager) -> None:  # noqa: F821
+        """Add ids from every timestamped run under the storage stage root to ``seen_ids``.
+
+        Does not scan a single run directory by path. Ids already in ``seen_ids`` stay.
+
+        Parameters
+        ----------
+        storage
+            Disk helper whose stage root is walked for timestamped run directories.
+        """
         self.seen_ids |= storage.load_seen_ids_from_all_runs(
             self.config.id_column,
             filename=self.config.filename,
@@ -61,10 +94,20 @@ class DedupeSession:
     def exclude_seen_ids(
         self, rows: list[dict[str, Any]]
     ) -> tuple[list[dict[str, Any]], int]:
+        """Return rows whose id is not in ``seen_ids``, plus how many rows were dropped.
+
+        Does not add ids to ``seen_ids``.
+
+        Returns
+        -------
+        tuple[list[dict[str, Any]], int]
+            Kept rows in original order, then the skipped count.
+        """
         new_rows = [row for row in rows if row[self.config.id_column] not in self.seen_ids]
         skipped = len(rows) - len(new_rows)
         return new_rows, skipped
 
     def add_seen_ids(self, rows: list[dict[str, Any]]) -> None:
+        """Add each row's id to ``seen_ids`` after those rows have been persisted."""
         for row in rows:
             self.seen_ids.add(row[self.config.id_column])

--- a/data_platform/utils/deduplication.py
+++ b/data_platform/utils/deduplication.py
@@ -61,14 +61,16 @@ class DedupeSession:
         for row in rows:
             self.seen_ids.add(row[self.config.id_column])
 
-    def load_seen_ids(self, storage, run_dir):
+    def load_seen_ids(self, storage: StorageManager, run_dir: Path) -> None:  # noqa: F821
         raise NotImplementedError
 
-    def load_seen_ids_from_all_runs(self, storage):
+    def load_seen_ids_from_all_runs(self, storage: StorageManager) -> None:  # noqa: F821
         raise NotImplementedError
 
-    def exclude_seen_ids(self, rows):
+    def exclude_seen_ids(
+        self, rows: list[dict[str, Any]]
+    ) -> tuple[list[dict[str, Any]], int]:
         raise NotImplementedError
 
-    def add_seen_ids(self, rows):
+    def add_seen_ids(self, rows: list[dict[str, Any]]) -> None:
         raise NotImplementedError

--- a/data_platform/utils/deduplication.py
+++ b/data_platform/utils/deduplication.py
@@ -62,7 +62,11 @@ class DedupeSession:
             self.seen_ids.add(row[self.config.id_column])
 
     def load_seen_ids(self, storage: StorageManager, run_dir: Path) -> None:  # noqa: F821
-        raise NotImplementedError
+        self.seen_ids |= storage.load_seen_ids_from_disk(
+            run_dir,
+            self.config.id_column,
+            filename=self.config.filename,
+        )
 
     def load_seen_ids_from_all_runs(self, storage: StorageManager) -> None:  # noqa: F821
         raise NotImplementedError

--- a/data_platform/utils/deduplication.py
+++ b/data_platform/utils/deduplication.py
@@ -35,31 +35,15 @@ class DedupeSession:
     seen_ids: set[str] = field(default_factory=set)
 
     def warm(self, storage: StorageManager, output_dir: Path) -> None:  # noqa: F821
-        seen: set[str] = set()
-        seen.update(
-            storage.load_seen_ids_from_disk(
-                output_dir,
-                self.config.id_column,
-                filename=self.config.filename,
-            )
-        )
+        self.load_seen_ids(storage, output_dir)
         if self.config.include_prior_runs:
-            seen.update(
-                storage.load_seen_ids_from_all_runs(
-                    self.config.id_column,
-                    filename=self.config.filename,
-                )
-            )
-        self.seen_ids |= seen
+            self.load_seen_ids_from_all_runs(storage)
 
     def filter_rows(self, rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
-        new_rows = [row for row in rows if row[self.config.id_column] not in self.seen_ids]
-        skipped = len(rows) - len(new_rows)
-        return new_rows, skipped
+        return self.exclude_seen_ids(rows)
 
     def note_appended(self, rows: list[dict[str, Any]]) -> None:
-        for row in rows:
-            self.seen_ids.add(row[self.config.id_column])
+        self.add_seen_ids(rows)
 
     def load_seen_ids(self, storage: StorageManager, run_dir: Path) -> None:  # noqa: F821
         self.seen_ids |= storage.load_seen_ids_from_disk(

--- a/data_platform/utils/deduplication.py
+++ b/data_platform/utils/deduplication.py
@@ -77,7 +77,9 @@ class DedupeSession:
     def exclude_seen_ids(
         self, rows: list[dict[str, Any]]
     ) -> tuple[list[dict[str, Any]], int]:
-        raise NotImplementedError
+        new_rows = [row for row in rows if row[self.config.id_column] not in self.seen_ids]
+        skipped = len(rows) - len(new_rows)
+        return new_rows, skipped
 
     def add_seen_ids(self, rows: list[dict[str, Any]]) -> None:
         raise NotImplementedError

--- a/data_platform/utils/deduplication.py
+++ b/data_platform/utils/deduplication.py
@@ -69,7 +69,10 @@ class DedupeSession:
         )
 
     def load_seen_ids_from_all_runs(self, storage: StorageManager) -> None:  # noqa: F821
-        raise NotImplementedError
+        self.seen_ids |= storage.load_seen_ids_from_all_runs(
+            self.config.id_column,
+            filename=self.config.filename,
+        )
 
     def exclude_seen_ids(
         self, rows: list[dict[str, Any]]

--- a/data_platform/utils/deduplication.py
+++ b/data_platform/utils/deduplication.py
@@ -60,3 +60,15 @@ class DedupeSession:
     def note_appended(self, rows: list[dict[str, Any]]) -> None:
         for row in rows:
             self.seen_ids.add(row[self.config.id_column])
+
+    def load_seen_ids(self, storage, run_dir):
+        raise NotImplementedError
+
+    def load_seen_ids_from_all_runs(self, storage):
+        raise NotImplementedError
+
+    def exclude_seen_ids(self, rows):
+        raise NotImplementedError
+
+    def add_seen_ids(self, rows):
+        raise NotImplementedError

--- a/data_platform/utils/deduplication.py
+++ b/data_platform/utils/deduplication.py
@@ -82,4 +82,5 @@ class DedupeSession:
         return new_rows, skipped
 
     def add_seen_ids(self, rows: list[dict[str, Any]]) -> None:
-        raise NotImplementedError
+        for row in rows:
+            self.seen_ids.add(row[self.config.id_column])

--- a/docs/plans/2026-09-02_explicit_skip_set_load_helpers_c4e91a/plan.md
+++ b/docs/plans/2026-09-02_explicit_skip_set_load_helpers_c4e91a/plan.md
@@ -1,0 +1,52 @@
+# Add explicit skip-set load and row helpers next to the existing warmup API
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Ingest and preprocess skip already-written record ids through one session type. A skip set is the in-memory set of already-written record ids. Filling the skip set is one warmup call today, and one config flag can trigger a second disk scan. The work adds explicit methods for this-run load, all-runs load, exclude, and extend, and it keeps the warmup call and the prior-runs flag so existing callers still compile. Ingest and preprocess files stay unchanged.
+
+## Happy flow
+
+A unit test constructs a skip-set session and calls the new load, exclude, and extend methods. Known ids are added to the skip set. The session drops incoming rows whose ids are already in the skip set, keeps the rest, and adds appended row ids to the skip set. The old warmup path still loads this-run ids, and it also loads all-run ids when the prior-runs flag is on.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    Warm["Warmup as the only load"]
+    Flag["One flag, two scans"]
+    Warm --> Flag
+  end
+  subgraph after [After]
+    ThisRun["This-run load"]
+    AllRuns["All-runs load"]
+    Exclude["Exclude known ids"]
+    Extend["Extend skip set"]
+    WarmCompat["Warmup still delegates"]
+    ThisRun --> Exclude --> Extend
+    AllRuns --> Exclude
+    WarmCompat --> ThisRun
+    WarmCompat --> AllRuns
+  end
+```
+
+## Approach
+
+Add the new methods on the existing skip-set session. Do not add a second session type. Keep the old methods as delegates so ingest and preprocess keep compiling without edits. Prove the new methods with unit tests that mock storage.
+
+## Steps
+
+### Step 1: Add skip-set load and row helpers next to warmup
+
+Add this-run and all-runs load methods that add disk ids to the skip set without replacing ids already in memory. Add exclude and extend helpers for ingest rows stored as dictionaries. Rewire warmup, filter, and note as delegates. Keep ingest, preprocess, and storage files unchanged.
+
+## What "done" looks like
+
+1. The skip-set session has this-run load, all-runs load, exclude, and extend methods, and each load adds disk ids to the skip set without replacing ids already in memory.
+2. Warmup, filter, and note still exist and delegate to those methods.
+3. `PYTHONPATH=. uv run pytest tests/data_platform/utils/test_deduplication.py tests/data_platform/utils/test_storage.py tests/data_platform/ingestion tests/data_platform/preprocessing -q` exits 0. Existing warmup, filter, and note tests still pass. New tests for the four methods pass.
+4. Ingest and preprocess files are unchanged. Storage is unchanged.

--- a/docs/plans/2026-09-02_explicit_skip_set_load_helpers_c4e91a/steps/step1.md
+++ b/docs/plans/2026-09-02_explicit_skip_set_load_helpers_c4e91a/steps/step1.md
@@ -1,0 +1,147 @@
+# Step 1: Add skip-set load and row helpers next to warmup
+
+## Goal
+
+Add the agreed skip-set methods on `DedupeSession` without breaking existing callers. `warm`, `filter_rows`, `note_appended`, and `DedupeConfig.include_prior_runs` stay and delegate to the new methods. Ingest and preprocess callers are not migrated in this PR.
+
+## Caller / unit of work
+
+**Main caller:** unit tests in `/workspace/tests/data_platform/utils/test_deduplication.py` constructing a `DedupeSession` and calling the new methods.
+
+**Slice:** new methods union into `seen_ids`. Old methods keep working by delegating.
+
+**Out of scope:** ingest callers (`sync_*.py`); `append_deduped_records`; preprocess runner; runbook; deleting `warm` / `include_prior_runs` / `filter_rows` / `note_appended`; YAML token migration; `FeatureLabelQuery`. Sibling GitHub issues #69, #70, and #71.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/plan.md` | Parent epic plan (do not edit) |
+| `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/step1.md` | Source contracts for this slice (do not edit) |
+| `/workspace/data_platform/utils/deduplication.py` | Current `warm` / `filter_rows` / `note_appended` |
+| `/workspace/data_platform/utils/storage.py` | `load_seen_ids_from_disk` and `load_seen_ids_from_all_runs` already exist |
+| `/workspace/tests/data_platform/utils/test_deduplication.py` | Existing warm, filter, and note tests that must stay green |
+
+## Files allowed to change
+
+- `/workspace/data_platform/utils/deduplication.py`
+- `/workspace/tests/data_platform/utils/test_deduplication.py`
+
+Plan package files under `/workspace/docs/plans/2026-09-02_explicit_skip_set_load_helpers_c4e91a/` may already be on the branch. Do not edit them during implementation.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/ingestion/**`
+- `/workspace/data_platform/preprocessing/**`
+- `/workspace/data_platform/utils/storage.py`
+- `/workspace/docs/runbooks/**`
+- `/workspace/backlog.md`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/plan.md`
+- `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/*.md`
+
+## Contracts to lock
+
+Keep `DedupeConfig(id_column, filename=None, include_prior_runs=False)` unchanged.
+
+Keep `DedupeSession.config` and `DedupeSession.seen_ids`.
+
+Add these methods. Each load **unions** into `seen_ids` (`|=`). Callers of the new API call **only one** load per session setup. `warm` is the compatibility path that may call both.
+
+```text
+load_seen_ids(self, storage: StorageManager, run_dir: Path) -> None
+  storage.load_seen_ids_from_disk(run_dir, self.config.id_column, filename=self.config.filename)
+  union into seen_ids
+
+load_seen_ids_from_all_runs(self, storage: StorageManager) -> None
+  storage.load_seen_ids_from_all_runs(self.config.id_column, filename=self.config.filename)
+  union into seen_ids
+
+exclude_seen_ids(self, rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]
+  same behavior as today's filter_rows (keep skipped-count tuple)
+
+add_seen_ids(self, rows: list[dict[str, Any]]) -> None
+  same behavior as today's note_appended
+```
+
+Compatibility (must remain until the later epic step that deletes them):
+
+```text
+warm(self, storage, output_dir) -> None
+  load_seen_ids(storage, output_dir)
+  if config.include_prior_runs: load_seen_ids_from_all_runs(storage)
+
+filter_rows(...) -> exclude_seen_ids(...)
+note_appended(...) -> add_seen_ids(...)
+```
+
+Do not rename `DedupeSession`, `DedupeConfig`, `append_deduped_records`, or `policy_includes_prior_runs`.
+
+Do not convert `warm` into a no-op. Ingest and preprocess still call it after this PR.
+
+## Test design
+
+Pseudocode then real tests. Prefer the public new methods. Existing `test_session_warm_*`, `test_session_filter_rows_skips_seen`, `test_note_appended_updates_seen_ids`, and `test_policy_includes_prior_runs` must stay and stay green. Do not split or rewrite those existing tests.
+
+```text
+given storage.load_seen_ids_from_disk returns {"uri-a"}
+when session.load_seen_ids(storage, Path("/tmp/run"))
+then seen_ids == {"uri-a"}
+and load_seen_ids_from_all_runs is not called
+
+given storage.load_seen_ids_from_all_runs returns {"uri-b"}
+when session.load_seen_ids_from_all_runs(storage)
+then seen_ids == {"uri-b"}
+and load_seen_ids_from_disk is not called
+
+given seen_ids already {"uri-a"} and disk returns {"uri-b"}
+when load_seen_ids
+then seen_ids == {"uri-a", "uri-b"}  (union, not replace)
+
+given seen_ids == {"uri-a"}
+when exclude_seen_ids([{"uri": "uri-a"}, {"uri": "uri-b"}])
+then kept == [{"uri": "uri-b"}], skipped == 1
+
+given seen_ids == {"uri-a"}
+when add_seen_ids([{"uri": "uri-b"}])
+then seen_ids == {"uri-a", "uri-b"}
+
+given include_prior_runs=True
+when warm(storage, run_dir)
+then both disk and all-runs loads happen (old test still covers this)
+```
+
+## Implementation notes (implement-from-spec)
+
+Files already exist. Scaffold means adding stub methods on `DedupeSession`. Do not stub or delete `warm`, `filter_rows`, or `note_appended` until the last Phase 5 unit rewires them as delegates.
+
+Phase order, one Git commit per phase that changes the repo, and one commit per Phase 5 unit:
+
+1. Phase 1 scope. Confirm caller, file tree, and out-of-scope. No product-code commit if nothing on disk changes.
+2. Phase 2 scaffold. Add `load_seen_ids`, `load_seen_ids_from_all_runs`, `exclude_seen_ids`, and `add_seen_ids` with stub bodies (`raise NotImplementedError`). Leave existing method bodies in place.
+3. Phase 3 contracts. Lock the signatures above. Bodies stay stubs. Full auto. Do not wait for approval.
+4. Phase 4 test design. Add the new tests from the pseudocode. They must fail for `NotImplementedError` or wrong result, not missing imports. Existing tests stay green.
+5. Phase 5 units, in this order, one commit each:
+   1. `load_seen_ids`
+   2. `load_seen_ids_from_all_runs`
+   3. `exclude_seen_ids`
+   4. `add_seen_ids`
+   5. Rewire `warm` / `filter_rows` / `note_appended` as delegates
+6. Phase 6. Run the must-pass command. Confirm ingest and preprocess files are unchanged.
+
+## Must pass
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run pytest tests/data_platform/utils/test_deduplication.py tests/data_platform/utils/test_storage.py tests/data_platform/ingestion tests/data_platform/preprocessing -q
+```
+
+Expected: exit 0. Existing warm, filter, and note tests still collected and passing. New tests for the four methods passing.
+
+## Must fail / not happen
+
+- Ingest or preprocess files changed in this PR.
+- `data_platform/utils/storage.py` changed.
+- `include_prior_runs` or `warm` removed.
+- `load_seen_ids` calling `load_seen_ids_from_all_runs` (or the reverse).
+- Either load **replacing** `seen_ids` instead of unioning.

--- a/tests/data_platform/utils/test_deduplication.py
+++ b/tests/data_platform/utils/test_deduplication.py
@@ -80,3 +80,72 @@ def test_note_appended_updates_seen_ids() -> None:
     session.note_appended([{"uri": "uri-b"}, {"uri": "uri-c"}])
 
     assert session.seen_ids == {"uri-a", "uri-b", "uri-c"}
+
+
+def test_load_seen_ids_unions_current_run_only() -> None:
+    storage = MagicMock()
+    storage.load_seen_ids_from_disk.return_value = {"uri-a"}
+    config = DedupeConfig(id_column="uri", filename="posts.csv")
+    session = DedupeSession(config)
+
+    session.load_seen_ids(storage, Path("/tmp/run"))
+
+    assert session.seen_ids == {"uri-a"}
+    storage.load_seen_ids_from_disk.assert_called_once_with(
+        Path("/tmp/run"), "uri", filename="posts.csv"
+    )
+    storage.load_seen_ids_from_all_runs.assert_not_called()
+
+
+def test_load_seen_ids_from_all_runs_does_not_call_disk() -> None:
+    storage = MagicMock()
+    storage.load_seen_ids_from_all_runs.return_value = {"uri-b"}
+    config = DedupeConfig(id_column="uri", filename="posts.csv")
+    session = DedupeSession(config)
+
+    session.load_seen_ids_from_all_runs(storage)
+
+    assert session.seen_ids == {"uri-b"}
+    storage.load_seen_ids_from_all_runs.assert_called_once_with(
+        "uri", filename="posts.csv"
+    )
+    storage.load_seen_ids_from_disk.assert_not_called()
+
+
+def test_load_seen_ids_unions_into_existing_seen_ids() -> None:
+    storage = MagicMock()
+    storage.load_seen_ids_from_disk.return_value = {"uri-b"}
+    config = DedupeConfig(id_column="uri", filename="posts.csv")
+    session = DedupeSession(config)
+    session.seen_ids = {"uri-a"}
+
+    session.load_seen_ids(storage, Path("/tmp/run"))
+
+    assert session.seen_ids == {"uri-a", "uri-b"}
+    storage.load_seen_ids_from_all_runs.assert_not_called()
+
+
+def test_exclude_seen_ids_skips_seen() -> None:
+    config = DedupeConfig(id_column="uri")
+    session = DedupeSession(config)
+    session.seen_ids = {"uri-a"}
+
+    kept, skipped = session.exclude_seen_ids(
+        [
+            {"uri": "uri-a", "text": "dup"},
+            {"uri": "uri-b", "text": "new"},
+        ]
+    )
+
+    assert kept == [{"uri": "uri-b", "text": "new"}]
+    assert skipped == 1
+
+
+def test_add_seen_ids_updates_seen_ids() -> None:
+    config = DedupeConfig(id_column="uri")
+    session = DedupeSession(config)
+    session.seen_ids = {"uri-a"}
+
+    session.add_seen_ids([{"uri": "uri-b"}])
+
+    assert session.seen_ids == {"uri-a", "uri-b"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Add explicit skip-set load and row helpers next to the existing warmup API

## Summary

Adds named skip-set methods so a caller can load this-run ids, load all-runs ids, drop already-seen ingest rows, and extend the skip set after persist.

Each load unions into the in-memory skip set. The existing warmup method and prior-runs flag still work as delegates, so current ingest and preprocess callers still compile.

## Purpose

Skip-set fill is one warmup call today, and one config flag can trigger a second disk scan. Later epic steps migrate ingest and preprocess off that name.

This PR adds the new methods beside the old ones and leaves ingest, preprocess, and storage unchanged.

Plan: `docs/plans/2026-09-02_explicit_skip_set_load_helpers_c4e91a/`

## Architecture

Components:

- `DedupeSession` — owns the in-memory skip set and the new load, exclude, and extend methods.
- `StorageManager` — existing this-run and all-runs disk scans. Unchanged in this PR.
- Unit tests in `tests/data_platform/utils/test_deduplication.py` — main caller for this slice.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    C1[Caller] --> W[warm]
    W --> D[this-run disk]
    W --> A[all-runs disk if flag]
    C1 --> F[filter_rows]
    C1 --> N[note_appended]
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    C2[Caller] --> L1[load_seen_ids]
    C2 --> L2[load_seen_ids_from_all_runs]
    C2 --> E[exclude_seen_ids]
    C2 --> X[add_seen_ids]
    W2[warm] --> L1
    W2 --> L2
    F2[filter_rows] --> E
    N2[note_appended] --> X
  end
```

## Interfaces

### Skip-set session

`DedupeConfig(id_column, filename=None, include_prior_runs=False)` is unchanged.

New methods on `DedupeSession` (each load unions into `seen_ids`):

| Method | Behavior |
| ------ | -------- |
| `load_seen_ids(storage, run_dir)` | Calls `storage.load_seen_ids_from_disk` only |
| `load_seen_ids_from_all_runs(storage)` | Calls `storage.load_seen_ids_from_all_runs` only |
| `exclude_seen_ids(rows)` | Returns `(kept_rows, skipped_count)` |
| `add_seen_ids(rows)` | Adds each row id to `seen_ids` |

Compatibility:

- `warm(storage, output_dir)` calls `load_seen_ids`, then `load_seen_ids_from_all_runs` when `include_prior_runs` is true
- `filter_rows` delegates to `exclude_seen_ids`
- `note_appended` delegates to `add_seen_ids`

## How to run

From the repo root:

```bash
PYTHONPATH=. uv run pytest tests/data_platform/utils/test_deduplication.py tests/data_platform/utils/test_storage.py tests/data_platform/ingestion tests/data_platform/preprocessing -q
```

Expected: exit 0. Existing warmup, filter, and note tests still collected and passing. New tests for the four methods passing.

Fixes #68
Part of #67

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-360d748f-48bd-454a-8236-962ecfa7bde0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-360d748f-48bd-454a-8236-962ecfa7bde0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved duplicate handling so previously processed IDs are consistently excluded while preserving input order.
  - Ensured newly processed IDs are recorded only after successful persistence.

- **Refactor**
  - Added clearer controls for loading IDs from the current run or all previous runs.
  - Improved tracking and filtering of seen IDs without unintentionally altering existing state.

- **Tests**
  - Added coverage for current-run and all-run loading, duplicate exclusion, state merging, and newly recorded IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->