### PR TITLE
Add explicit pipeline paths implementation plan

### DIFF
--- a/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/plan.md
+++ b/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/plan.md
@@ -1,0 +1,66 @@
+# Make data-platform I/O use explicit file paths and smaller stage metadata
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Pipeline stages infer record file names from platform defaults, rewrite suffixes from the dataset manifest, and duplicate that information in metadata maps and timestamps that already exist as directory names. Operators still run the same per-platform CLIs. After this work, every load and write is given a file path relative to the data-platform package, metadata shrinks to provenance and checkpoint fields that cannot be reconstructed from the tree, and loaders never consult metadata to find a records file.
+
+## Happy flow
+
+An operator runs ingest, preprocess, feature generation, and curation as today. Each stage writes beside its records file a smaller metadata document and never asks that document for the records filename.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    CLI1[Stage CLI] --> Store1[Storage infers name and suffix]
+    Store1 --> Meta1[Metadata names the file]
+    Meta1 --> Load1[Later stage reads metadata to open file]
+  end
+  subgraph after [After]
+    CLI2[Stage CLI] --> Path2[Caller passes package-relative file path]
+    Path2 --> Store2[Storage reads suffix of that path]
+    Store2 --> Meta2[Metadata is provenance or checkpoint only]
+  end
+```
+
+## Approach
+
+Introduce a single constants module and a path helper rooted at the data-platform package. Change storage so run-directory helpers return directories and load/write take file paths. Then slim each stage's new metadata in separate mergeable PRs. Do not migrate old JSON. Do not keep dual readers. Existing local datasets may redo a later stage once because upstream-run path strings get longer.
+
+## Steps
+
+### Step 1: Add package-relative path helpers and file-name constants
+
+Land the constants module and a helper that resolves and validates paths relative to the data-platform package. Tests prove happy paths and reject traversal. No production caller switch yet.
+
+### Step 2: Switch storage and all callers to explicit file paths
+
+Storage no longer infers names or suffixes from the dataset manifest. Callers pass full file names and package-relative file paths. Ingest configs stop declaring output format; new dataset manifests omit format. Feature specs and curation configs use full export names. Upstream-run lists in newly written metadata use package-relative directory paths. Main stays green.
+
+### Step 3: Slim preprocess metadata
+
+New preprocess metadata is only dataset id, the list of raw run directories considered, and input/output row counts. Tests and the preprocess section of the stimuli runbook match.
+
+### Step 4: Resume raw ingest from the run directory name
+
+New raw metadata omits the sync timestamp field. Resume stamps row timestamps from the run directory name. Raw row-count field names stay as they are.
+
+### Step 5: Drop curated file maps and update in-repo readers
+
+New curated metadata omits the files map. Up-to-date checks and experiment scripts that currently read the export name from metadata recompute it from the curation config. Curation specs stop carrying a separate log noun.
+
+## What "done" looks like
+
+1. Load and write of records files always receive an explicit path relative to the data-platform package.
+2. CSV versus parquet is taken from that path's suffix, not from the dataset manifest.
+3. New dataset manifests have identity fields only; they do not record format.
+4. New preprocess metadata has three concerns only: dataset id, raw runs considered, row counts.
+5. New raw metadata is still a checkpoint document; it does not duplicate the run directory name as a timestamp field.
+6. New curated metadata does not name the export file; in-repo readers no longer look it up from JSON.
+7. Historical JSON on disk is untouched. No dual-key compatibility readers.
+8. The stimuli runbook describes preprocess outputs and path conventions that match the new writers.

--- a/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/steps/step1.md
+++ b/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/steps/step1.md
@@ -1,0 +1,101 @@
+# Step 1: Add package-relative path helpers and file-name constants
+
+## Goal
+
+Land `data_platform/constants.py` and a path helper that resolves and validates paths relative to `data_platform/`. Production storage and stage CLIs stay on the old API. This PR only adds unused (except by its tests) building blocks.
+
+## Caller / unit of work
+
+**Main caller:** tests under `tests/data_platform/utils/test_paths.py` (and constants assertions in that file or `tests/data_platform/utils/test_constants.py`).
+
+```bash
+cd /Users/mark/src/work/mirrorview-wt
+PYTHONPATH=. uv run pytest tests/data_platform/utils/test_paths.py -q
+```
+
+Expected: exit 0; all new tests pass.
+
+**In scope:** Constants for full file names; `PACKAGE_ROOT`; resolve/validate/relativize helpers; unit tests including traversal rejection.
+
+**Out of scope:** Any change to `StorageManager`, ingest, preprocess, features, curation, runbooks, or existing tests.
+
+## Decision (locked)
+
+- File names in constants are full names, not stems: `posts.csv`, `comments.csv`, `metadata.json`.
+- Paths passed to the helper are relative to `data_platform/` (example: `data/bluesky/<id>/raw/<ts>/posts.csv`).
+- Resolve against `PACKAGE_ROOT`. Reject absolute inputs, `..` segments, and any resolved path that is not inside `PACKAGE_ROOT`.
+- Do not read `dataset.json` for format. Do not compose suffixes.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorview-wt/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/plan.md` | Parent plan |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/utils/storage.py` | Current `DATA_ROOT` and `METADATA_FILENAME` (do not change this step) |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/utils/dataset.py` | Current `_DATA_ROOT` (do not change this step) |
+| `/Users/mark/src/work/mirrorview-wt/lib/constants.py` | Do not put data-platform file names here |
+
+## Files allowed to change
+
+- Create `/Users/mark/src/work/mirrorview-wt/data_platform/constants.py`
+- Create `/Users/mark/src/work/mirrorview-wt/data_platform/utils/paths.py`
+- Create `/Users/mark/src/work/mirrorview-wt/tests/data_platform/utils/test_paths.py`
+- Optionally create `/Users/mark/src/work/mirrorview-wt/tests/data_platform/utils/test_constants.py` if constants assertions are split out
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/storage.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/dataset.py`
+- `/Users/mark/src/work/mirrorview-wt/lib/constants.py`
+- All ingest, preprocess, feature, curate, and runbook files
+- Existing tests other than the new files above
+
+## Contracts
+
+`data_platform/constants.py`:
+
+- `PACKAGE_ROOT`: `Path` of the `data_platform/` directory (`Path(__file__).resolve().parent`).
+- `POSTS_FILE = "posts.csv"`
+- `COMMENTS_FILE = "comments.csv"`
+- `METADATA_FILE = "metadata.json"`
+
+`data_platform/utils/paths.py`:
+
+- `resolve_package_path(relative: str | Path) -> Path`: join `PACKAGE_ROOT` with `relative`, `resolve()`, return the absolute path. Raise `ValueError` if `relative` is absolute, if any path part is `..`, or if the resolved path is not inside `PACKAGE_ROOT` (`is_relative_to`).
+- `to_package_relative(path: Path) -> str`: `path.resolve().relative_to(PACKAGE_ROOT)` as a POSIX string (`as_posix()`). Raise `ValueError` if `path` is not inside `PACKAGE_ROOT`.
+
+Do not accept a `package_root=` override on the public helpers. Tests monkeypatch `data_platform.constants.PACKAGE_ROOT` (and the same name if `paths.py` imported it by value — import the module attribute so the patch applies).
+
+## Tests (write first; they must fail until helpers exist)
+
+Happy path: monkeypatch `PACKAGE_ROOT` to a `tmp_path`. `resolve_package_path("data/bluesky/x/raw/ts/posts.csv")` equals `tmp_path / "data/bluesky/x/raw/ts/posts.csv"`. Create that file (or just the parent); `to_package_relative` of the resolved path equals `data/bluesky/x/raw/ts/posts.csv`.
+
+Failures that must raise `ValueError`:
+
+- Absolute `relative` (e.g. `/etc/passwd`)
+- `relative` containing `..` (e.g. `data/../secrets`)
+- `to_package_relative` on a path outside the patched root
+
+Constants tests: `POSTS_FILE == "posts.csv"`, `COMMENTS_FILE == "comments.csv"`, `METADATA_FILE == "metadata.json"`. `PACKAGE_ROOT` in an unpatched process ends with `data_platform`.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/utils/test_paths.py -q
+```
+
+Exit 0.
+
+## Must still pass (no regressions)
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform -q
+```
+
+Exit 0. Same failures as before this step, none new.
+
+## Must not happen
+
+- Production callers import the new helpers yet.
+- `POSTS_FILE` includes a parquet variant.
+- Helper restems or reads `dataset.json`.

--- a/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/steps/step2.md
+++ b/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/steps/step2.md
@@ -1,0 +1,153 @@
+# Step 2: Switch storage and all callers to explicit file paths
+
+## Goal
+
+`StorageManager` no longer infers a records file name or suffix. Every load/write takes a file path relative to `data_platform/`. Run-directory helpers return package-relative directory paths. Callers join those dirs with `POSTS_FILE`, `COMMENTS_FILE`, a feature spec filename, or a curation/ingest config filename. New dataset manifests omit `format`. Ingest configs stop using `output_format`. Newly written `source_*_runs` lists use package-relative directory strings. Metadata field *sets* other than those path strings stay as they are (slim in later steps).
+
+## Caller / unit of work
+
+**Main caller:** existing data-platform tests after storage and callers are updated.
+
+```bash
+cd /Users/mark/src/work/mirrorview-wt
+PYTHONPATH=. uv run pytest tests/data_platform -q
+```
+
+Expected: exit 0.
+
+**In scope:** Storage API, dataset manifest writer, `relative_run_path`, ingest yaml + checkpoint manifest, feature spec filenames, curation `output.filename`, all production callers and tests that construct `StorageManager` or join records names.
+
+**Out of scope:** Slimming preprocess metadata keys (Step 3); dropping raw `sync_timestamp` from metadata (Step 4); dropping curated `files` map and experiment `files.export` readers (Step 5); migrating historical JSON.
+
+## Decision (locked)
+
+- No `records_filename` on `StorageManager.__init__`. No subclass defaults. Delete `filename_for`. Delete restem via `load_dataset_format`.
+- `create_new_run_dir` and `latest_run_dir` return a directory path relative to `data_platform/` (POSIX string or `Path` of `data/<platform>/<id>/<stage>/<ts>`). Internally mkdir under `resolve_package_path(...)`.
+- Load/write/append/load-seen-ids take an explicit file path relative to `data_platform/`. CSV vs parquet is that path’s suffix (`.csv` / `.parquet`). Unknown suffix raises `ValueError`.
+- Metadata I/O uses `METADATA_FILE` as sibling of the records file (join run dir with `METADATA_FILE`).
+- `relative_run_path` becomes package-relative (implement via `to_package_relative`). Call sites that pass dataset root as the first argument must be updated.
+- Ingest: remove `output_format` from yaml. `write_dataset_manifest` no longer takes or writes `format`. Parquet Bluesky configs set `records_file: posts.parquet`. All other ingest callers use `POSTS_FILE` or `COMMENTS_FILE`.
+- Feature specs gain an explicit `filename` (e.g. `is_political.csv`). Registry keys stay logical names. Do not `f"{name}.csv"` inside storage.
+- Curation yaml: `output.filename: mirrorview.csv` (and the same full name on the other platform yaml files). `OutputConfig.stem` is removed. This step still *writes* `files.export` using that filename so Step 5 can delete the map separately.
+- Tests: `data_root` fixture monkeypatches `PACKAGE_ROOT` so `PACKAGE_ROOT / "data"` is the isolated data tree (keep pointing storage/dataset data roots at `tmp_path / "data"`).
+
+## Files to inspect (read-only first)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorview-wt/data_platform/utils/storage.py` | API to replace |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/utils/dataset.py` | `relative_run_path`, `write_dataset_manifest`, `load_dataset_format` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/constants.py` | Step 1 constants |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/utils/paths.py` | Step 1 helpers |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/conftest.py` | `data_root` monkeypatch |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_checkpoint.py` | Manifest + filename plumbing |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_bluesky.py` | `storage.records_filename` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_reddit.py` | Two files per run dir |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_twitter.py` | Twitter load dtypes |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/runner.py` | Join run dir + records name |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/generate_features/generate_features.py` | Feature file path |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/generate_features/registry.py` | Every `FeatureSpec` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/generate_features/models.py` | `FeatureSpec` fields |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/utils/feature_labels.py` | `filename_for` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/curate/runner.py` | Glob + `filename_for` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/curate/apply_rules.py` | `OutputConfig.stem` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/configs/bluesky/mirrorview2.yaml` | `output_format: parquet` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/configs/bluesky/trump_econ_iran.yaml` | `output_format: parquet` |
+
+## Files allowed to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/storage.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/dataset.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/feature_labels.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/platform_specific_columns.py` (may keep `records_file_key` until Step 5 if still used as a log noun in preprocess; do not use it as a path)
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/**` (Python + yaml that declare `output_format`)
+- `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/runner.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/generate_features/**` (models, registry, generate_features, platform_cli, metadata, tests’ FeatureSpec constructors)
+- `/Users/mark/src/work/mirrorview-wt/data_platform/curate/runner.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/curate/apply_rules.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/curate/configs/**/*.yaml`
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/**` (call sites of storage, FeatureSpec, `output.stem`, `records_filename`, `DATA_ROOT` / `_DATA_ROOT`)
+- `/Users/mark/src/work/mirrorview-wt/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md` (path/filename convention only; do not slim the preprocess metadata field list yet)
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorview-wt/experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py` (Step 5)
+- `/Users/mark/src/work/mirrorview-wt/experiments/scaled_mirrors_generation_2026_06_02/count_missing_flips.py` (Step 5)
+- Historical JSON under `experiments/**/data/**` and `data_platform/data/**`
+- `/Users/mark/src/work/mirrorview-wt/lib/constants.py`
+
+## Storage contract (replace)
+
+Delete `records_filename` from `__init__` and subclasses. Delete `self.format` and the `load_dataset_format` call. Delete `filename_for`.
+
+`BlueskyStorageManager.__init__(stage, dataset_id)` — no filename kwarg. Same for Twitter. Reddit: drop `records_filename` kwarg; keep `model=` for comments vs posts. `comment_storage()` / `post_storage()` still return two managers that differ by **model**, not by a stored filename. Callers pass `COMMENTS_FILE` vs `POSTS_FILE` at each I/O call.
+
+`create_new_run_dir` return value is package-relative (e.g. `data/twitter/<id>/raw/2026_05_31-12:00:00`). `latest_run_dir` same or `None`.
+
+`load_records(file_path)`, `write_records(rows, file_path)`, `append_records(rows, file_path)`, `write_dataframe(df, file_path)`, `load_seen_ids_from_disk(file_path, id_column)`: `file_path` is package-relative. Resolve with `resolve_package_path`. Branch on suffix.
+
+`write_run_metadata(run_dir, metadata)` / `load_run_metadata(run_dir)`: `run_dir` is package-relative directory; metadata file is `run_dir / METADATA_FILE`.
+
+Twitter `load_records` keeps `dtype={"tweet_id": "string", "author_id": "string"}` for `.csv`. If a Twitter path is `.parquet`, read parquet (no dtype dict required beyond pandas defaults) — Twitter ingest is csv-only today.
+
+Remove `load_dataset_format` if nothing remains that calls it. `ValidDataFormats` may remain only if still referenced; do not use it to name files.
+
+`write_dataset_manifest`: drop `data_format`. Written keys: `dataset_id`, `platform`, `name`, `ingestion_config`, `created_at`. Update `tests/data_platform/utils/test_dataset.py` so a new manifest has no `format` key.
+
+## Ingest yaml
+
+Replace `output_format: parquet` in:
+
+- `data_platform/ingestion/configs/bluesky/mirrorview2.yaml`
+- `data_platform/ingestion/configs/bluesky/trump_econ_iran.yaml`
+
+with `records_file: posts.parquet`. Default configs with no key use `POSTS_FILE` / `COMMENTS_FILE` in Python. `ensure_dataset_manifest` must not read `output_format`.
+
+## Feature filenames
+
+Add `filename: str` to `FeatureSpec`. Registry entries (and every test `FeatureSpec(...)`) set it to `<name>.csv` written as a literal (`"is_political.csv"`), not composed at runtime in storage. `FeatureLabelQuery` takes the filename from the spec (or the caller passes the full file path). `generate_features.py` writes `features_dir` joined with `spec.filename` via `to_package_relative`.
+
+`platform_cli.py` currently constructs `StorageManager(..., records_filename="features")` — that default file is unused for per-feature CSVs; stop passing it.
+
+## Curation
+
+`OutputConfig.filename: str` (required or default `"dataset.csv"`). Yaml:
+
+```yaml
+output:
+  filename: mirrorview.csv
+```
+
+for every file under `data_platform/curate/configs/`. Writer still sets metadata `files.export` to that same string this step.
+
+Preprocess glob: `preprocessed_storage.root_dir / "*" / POSTS_FILE` or `COMMENTS_FILE` from the platform spec’s records file constant — not `storage.records_filename`.
+
+## Preprocess / features source lists
+
+`relative_run_path` output examples: `data/twitter/<id>/raw/<ts>`. Update tests that assert `raw/<ts>` or `source_raw_runs[-1] == source_raw_run` (the equality may still hold). Do not remove `source_raw_run` or `files` from preprocess metadata in this step.
+
+## Tests fixture
+
+`tests/data_platform/conftest.py` `data_root`: monkeypatch `PACKAGE_ROOT` to `tmp_path`, and keep data at `tmp_path / "data"`. Patch every module that captured `DATA_ROOT` / `_DATA_ROOT` at import. `create_new_run_dir` return values are relative; tests that treated them as absolute `Path` for `/` joins must use `resolve_package_path` or `PACKAGE_ROOT / relative`.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform -q
+```
+
+Exit 0.
+
+Assert in `test_write_and_load_dataset_manifest`: `"format" not in loaded`.
+
+At least one storage test writes and reads a `.parquet` path without a dataset manifest.
+
+At least one test shows `create_new_run_dir` return value `as_posix()` starts with `data/`.
+
+## Must not happen
+
+- `StorageManager` calls `load_dataset_format`.
+- `filename_for` remains.
+- Dual API (`records_filename=` still on `__init__`).
+- Changing preprocess metadata keys other than `source_raw_runs` string shape.
+- Editing experiment `files.export` readers (Step 5).

--- a/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/steps/step3.md
+++ b/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/steps/step3.md
@@ -1,0 +1,86 @@
+# Step 3: Slim preprocess metadata
+
+## Goal
+
+New preprocess `metadata.json` documents contain only `dataset_id`, `source_raw_runs`, and `row_counts` (`input` / `output`). Drop `files`, `source_raw_run`, and `preprocess_timestamp`. Update preprocess tests and the preprocess section of the stimuli runbook. Do not migrate old JSON.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/preprocessing/runner.py` `save_preprocessed` → `write_run_metadata`.
+
+Prove with:
+
+```bash
+cd /Users/mark/src/work/mirrorview-wt
+PYTHONPATH=. uv run pytest tests/data_platform/preprocessing -q
+```
+
+Expected: exit 0.
+
+**In scope:** Preprocess writer, preprocess tests, runbook preprocess outputs list, preprocess log noun if it still uses `records_file_key` (print `POSTS_FILE` / `COMMENTS_FILE` instead).
+
+**Out of scope:** Raw checkpoint metadata (Step 4); curated `files` map (Step 5); storage path API (Step 2, already landed).
+
+## Decision (locked)
+
+Exact keys for new preprocess metadata:
+
+- `dataset_id`
+- `source_raw_runs`: list of package-relative run dirs (`data/<platform>/<id>/raw/<ts>`), every raw directory that existed, not only dirs that contributed rows
+- `row_counts.input` (after dedupe, before filters)
+- `row_counts.output` (after filters)
+
+No `files`, no `source_raw_run`, no `preprocess_timestamp`. Loaders still do not read metadata to find the records file.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/runner.py` | `save_preprocessed` metadata dict |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/preprocessing/test_preprocess_twitter.py` | Asserts `files.posts` and `source_raw_run` |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/preprocessing/test_preprocess_reddit.py` | Asserts `files.comments` |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/preprocessing/test_preprocess_bluesky.py` | Metadata assertions if present |
+| `/Users/mark/src/work/mirrorview-wt/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md` | Preprocess outputs list |
+
+## Files allowed to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/runner.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/platform_specific_columns.py` (remove `records_file_key` if nothing else uses it after the log-noun switch)
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/preprocessing/**`
+- `/Users/mark/src/work/mirrorview-wt/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md` (preprocess outputs and column table rows for `records_file_key`)
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/storage.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/**`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/curate/**`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/generate_features/**`
+- Historical `metadata.json` under experiments or `data_platform/data/`
+
+## Implementation
+
+In `save_preprocessed`, build only the locked keys. Delete `source_raw_run = source_raw_runs[-1]`. Print the records filename constant, not `records_file_key`.
+
+Tests:
+
+- `test_preprocess_records_merges_all_raw_runs_and_sets_source_raw_runs`: assert two package-relative raw dirs; **do not** assert `source_raw_run`.
+- Replace `assert metadata["files"]["posts"] == "posts.csv"` (and comments equivalent) with `assert "files" not in metadata`.
+- Assert metadata keys are exactly the locked set (or at least that the dropped keys are absent).
+- `source_raw_runs` entries start with `data/` and include `/raw/`.
+
+Runbook: replace the preprocess metadata bullet list with the locked three concerns. Remove `records_file_key` from the column table; say records files are `posts.csv` / `comments.csv` (or `posts.parquet` when the caller passed that name).
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/preprocessing tests/data_platform/utils -q
+PYTHONPATH=. uv run pytest tests/data_platform -q
+```
+
+Exit 0.
+
+## Must not happen
+
+- Dual-key writer (`source_raw_run` still emitted).
+- Reading metadata to locate `posts.csv`.
+- Rewriting old preprocess JSON on disk.

--- a/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/steps/step4.md
+++ b/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/steps/step4.md
@@ -1,0 +1,80 @@
+# Step 4: Resume raw ingest from the run directory name
+
+## Goal
+
+New raw run metadata omits `sync_timestamp`. Resume stamps each ingested row’s `sync_timestamp` column from the run directory’s name (`output_dir.name`, the timestamp folder). Keep `row_count` and Reddit `post_row_count`. Do not migrate old metadata.
+
+## Caller / unit of work
+
+**Main caller:** ingest resume paths in `sync_twitter.py`, `sync_reddit.py`, and Bluesky task loops that stamp rows.
+
+```bash
+cd /Users/mark/src/work/mirrorview-wt
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
+```
+
+Expected: exit 0.
+
+**In scope:** `build_base_sync_metadata`, resume readers of `metadata["sync_timestamp"]`, tests that assert that key, any Bluesky path that copies metadata timestamp onto rows.
+
+**Out of scope:** Renaming `row_count` to `row_counts`; preprocess/curated metadata; storage path API.
+
+## Decision (locked)
+
+- Drop `sync_timestamp` from new raw `metadata.json`.
+- On resume (and on first run), row-level `sync_timestamp` is the run directory name. After Step 2, `output_dir` is package-relative; `.name` is still the timestamp folder (e.g. `2026_05_31-12:00:00`).
+- Do not use `metadata["sync_timestamp"]`.
+- `row_count` / `post_row_count` unchanged.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_checkpoint.py` | `build_base_sync_metadata` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_twitter.py` | `sync_timestamp = str(metadata["sync_timestamp"])` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_reddit.py` | same |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_bluesky.py` | How Bluesky stamps rows today |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/twitter_client.py` | Row builder takes `sync_timestamp` |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/ingestion/test_sync_checkpoint.py` | Metadata shape |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/ingestion/test_sync_twitter_checkpoint.py` | Resume |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/ingestion/test_sync_reddit_checkpoint.py` | Resume |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py` | Resume |
+
+## Files allowed to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_checkpoint.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_twitter.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_reddit.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/sync_bluesky.py` (if it reads metadata for the stamp)
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/ingestion/**`
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/**`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/curate/**`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/generate_features/**`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/models/sync.py` (row models still have a `sync_timestamp` **column**)
+- Historical raw `metadata.json` on disk
+
+## Implementation
+
+Remove `"sync_timestamp": sync_timestamp` from `build_base_sync_metadata`. `init_metadata_fn` / `prepare_sync_run` still receive the timestamp to **create** the directory; they must not persist it in JSON.
+
+Replace `str(metadata["sync_timestamp"])` with `Path(output_dir).name` (or the existing run-dir Path’s `.name`). Thread that string into row builders as today.
+
+Tests: new metadata must not contain `sync_timestamp`. Resume tests still complete a second wave into the same run dir; row `sync_timestamp` values equal the run folder name. Do not add a reader that falls back to `metadata["sync_timestamp"]`.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
+PYTHONPATH=. uv run pytest tests/data_platform -q
+```
+
+Exit 0.
+
+## Must not happen
+
+- Dual-key (`sync_timestamp` still written “for compatibility”).
+- Changing `row_count` field names.
+- Using the full package-relative path as the row timestamp (must be the folder name only).

--- a/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/steps/step5.md
+++ b/docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/steps/step5.md
@@ -1,0 +1,92 @@
+# Step 5: Drop curated file maps and update in-repo readers
+
+## Goal
+
+New curated metadata omits `files`. Up-to-date checks and in-repo experiment scripts recompute the export path from the curation config filename (Step 2 already set `output.filename`). Remove `CuratePlatformSpec.record_noun`. Logs print the export filename. Do not migrate old curated JSON.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/curate/runner.py` `build_curate_metadata` / `run_curation`, and `data_platform/curate/curate_bluesky.py` `_is_up_to_date`.
+
+```bash
+cd /Users/mark/src/work/mirrorview-wt
+PYTHONPATH=. uv run pytest tests/data_platform/curate -q
+```
+
+Expected: exit 0.
+
+**In scope:** Curate metadata writer, Bluesky skip-if-fresh path, curate platform specs, experiment scripts that index `metadata["files"]["export"]`, curate tests, runbook curated notes if any.
+
+**Out of scope:** Storage API; preprocess metadata; raw `sync_timestamp`; rewriting historical curated JSON.
+
+## Decision (locked)
+
+- Curated metadata keeps `dataset_id`, `name`, `rules_hash`, `source_preprocessed_runs`, `row_counts`, `filter_results`. No `files`.
+- `_is_up_to_date` joins the latest curated run dir with `rules.output.filename` (full name). If that file is missing, treat as not up to date. Do not read `files.export`.
+- `sample_data_to_mirror.py` and `count_missing_flips.py` open `metadata.json`’s parent joined with the yaml filename (same `mirrorview.csv` literal the configs use). Do not dual-read `files`.
+- Delete `record_noun` from `CuratePlatformSpec` and platform CLIs.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorview-wt/data_platform/curate/runner.py` | `files.export`, `record_noun` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/curate/curate_bluesky.py` | `_is_up_to_date` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/curate/curate_reddit.py` | `record_noun` |
+| `/Users/mark/src/work/mirrorview-wt/data_platform/curate/curate_twitter.py` | `record_noun` |
+| `/Users/mark/src/work/mirrorview-wt/tests/data_platform/curate/test_curate_bluesky.py` | Seeds `files.export` |
+| `/Users/mark/src/work/mirrorview-wt/experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py` | `metadata["files"]["export"]` |
+| `/Users/mark/src/work/mirrorview-wt/experiments/scaled_mirrors_generation_2026_06_02/count_missing_flips.py` | same |
+
+## Files allowed to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/curate/runner.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/curate/curate_bluesky.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/curate/curate_reddit.py`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/curate/curate_twitter.py`
+- `/Users/mark/src/work/mirrorview-wt/tests/data_platform/curate/**`
+- `/Users/mark/src/work/mirrorview-wt/experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py`
+- `/Users/mark/src/work/mirrorview-wt/experiments/scaled_mirrors_generation_2026_06_02/count_missing_flips.py`
+- `/Users/mark/src/work/mirrorview-wt/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md` (curation bullets if they mention `files`)
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorview-wt/data_platform/preprocessing/**`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/ingestion/**`
+- `/Users/mark/src/work/mirrorview-wt/data_platform/utils/storage.py`
+- Historical curated `metadata.json` under experiments (readers ignore extra keys; they must not require `files`)
+
+## Implementation
+
+`build_curate_metadata`: drop `export_filename` argument and the `files` key.
+
+`_is_up_to_date`: `output_path = run_dirs[-1] / rules.output.filename` after resolving `run_dirs[-1]` the same way Step 2 storage does (package-relative dir). Compare `source_preprocessed_runs` and `rules_hash` as today.
+
+Experiment scripts: use `mirrorview.csv` (import `POSTS_FILE` is wrong — export name is the yaml filename). Prefer loading the same `OutputConfig` / a module-level `CURATED_EXPORT_FILE = "mirrorview.csv"` constant in the experiment only if you refuse to parse yaml; the curated yaml filename is `mirrorview.csv` on all three platforms today. Do not read `metadata["files"]`.
+
+Tests that write a fake latest curated metadata for the skip path must omit `files`. Assert `"files" not in metadata` on a real `run_curation` result.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/curate -q
+PYTHONPATH=. uv run pytest tests/data_platform -q
+```
+
+Exit 0.
+
+If experiment scripts have no tests, `python -m py_compile` both experiment files:
+
+```bash
+PYTHONPATH=. uv run python -m py_compile \
+  experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py \
+  experiments/scaled_mirrors_generation_2026_06_02/count_missing_flips.py
+```
+
+Exit 0.
+
+## Must not happen
+
+- Writing `files` “so old readers work”.
+- `latest_meta.get("files", {}).get("export")` remaining anywhere under `data_platform/` or those two experiment files.
+- Changing `source_preprocessed_runs` semantics (still all preprocessed dirs; package-relative from Step 2).


### PR DESCRIPTION
## Summary
- Adds the plan package for explicit package-relative file paths and smaller stage metadata.
- Tracking epic: #80
- Child issues (one PR each): #81, #82, #83, #84, #85
- Plan and docs files only. No product code.

## Test plan
- [ ] Confirm `docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae/plan.md` matches the epic overview
- [ ] Confirm `steps/step1.md`–`step5.md` exist and map 1:1 to #81–#85
- [ ] Confirm this PR contains no `data_platform/` or test code


Made with [Cursor](https://cursor.com)