### PR TITLE
Route Bluesky features and curate through the shared platform CLIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2026-09-02
+
+1. Bluesky feature generation and curation now use the same shared platform CLIs as Reddit and Twitter. Bluesky-only completeness checks and skip-if-up-to-date stay as spec flags, and LangChain feature specs no longer register an unused per-row generate function. [PR #89](https://github.com/METResearchGroup/mirrorView-task/pull/89)
+
 ## 2026-09-01
 
 1. Shared preprocessing, feature, and curation runners now take `PlatformSpecificColumns` on `spec.columns` instead of the overloaded `PlatformIdBinding` name, so per-platform CSV column maps read as what they are. [PR #65](https://github.com/METResearchGroup/mirrorView-task/pull/65)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-02
 
-1. Bluesky feature generation and curation now use the same shared platform CLIs as Reddit and Twitter. Bluesky-only completeness checks and skip-if-up-to-date stay as spec flags, and LangChain feature specs no longer register an unused per-row generate function. [PR #89](https://github.com/METResearchGroup/mirrorView-task/pull/89)
+1. Bluesky feature generation and curation now call the same platform command-line scripts as Reddit and Twitter. Bluesky still uses settings flags for its extra completeness checks and for skipping curation when inputs have not changed. LangChain feature settings no longer set a generate_fn that the LangChain engine never calls. [PR #89](https://github.com/METResearchGroup/mirrorView-task/pull/89)
 
 ## 2026-09-01
 

--- a/data_platform/curate/curate_bluesky.py
+++ b/data_platform/curate/curate_bluesky.py
@@ -8,20 +8,13 @@ Run from the repo root:
 
 from __future__ import annotations
 
-import hashlib
-import json
 from pathlib import Path
 
 import typer
 
-from data_platform.curate.runner import CuratePlatformSpec, run_curation
-from data_platform.utils.config_paths import resolve_config_path
-from data_platform.generate_features.metadata import metadata_path
-from data_platform.generate_features.models import FeatureRunMetadata
-from data_platform.utils.dataset import dataset_root, relative_run_path, validate_dataset_id
-from data_platform.utils.gate_checks import require_all_runs_complete, require_features_complete
+from data_platform.curate.runner import CuratePlatformSpec, curate_with_spec, make_curate_cli
 from data_platform.utils.platform_specific_columns import BLUESKY_COLUMNS
-from data_platform.utils.storage import BlueskyStorageManager, StorageStage
+from data_platform.utils.storage import BlueskyStorageManager
 
 CONFIGS_DIR = Path(__file__).resolve().parent / "configs" / "bluesky"
 
@@ -38,88 +31,17 @@ BLUESKY_CURATE_SPEC = CuratePlatformSpec(
 )
 
 
-def _is_up_to_date(
-    curated_storage: BlueskyStorageManager,
-    all_preprocessed_run_dirs: list[Path],
-    root: Path,
-    rules_hash: str,
-    features_meta: FeatureRunMetadata,
-) -> Path | None:
-    """Return the existing output path if curation inputs haven't changed, else None."""
-    current_runs = [relative_run_path(root, d) for d in all_preprocessed_run_dirs]
-    if features_meta.source_preprocessed_runs != current_runs:
-        return None
-    if not curated_storage.root_dir.exists():
-        return None
-    run_dirs = sorted(p for p in curated_storage.root_dir.iterdir() if p.is_dir())
-    if not run_dirs:
-        return None
-    latest_meta = curated_storage.load_run_metadata(run_dirs[-1])
-    if latest_meta.get("source_preprocessed_runs") != current_runs:
-        return None
-    if latest_meta.get("rules_hash") != rules_hash:
-        return None
-    output_filename = latest_meta.get("files", {}).get("export")
-    if not output_filename:
-        return None
-    output_path = run_dirs[-1] / output_filename
-    if not output_path.exists():
-        return None
-    return output_path
-
-
 def curate(config_path: Path, dataset_id: str) -> Path:
-    dataset_id = validate_dataset_id(dataset_id)
-
-    curated_storage = BlueskyStorageManager(StorageStage.CURATED, dataset_id)
-
-    features_meta_path = metadata_path(dataset_root("bluesky", dataset_id) / "features")
-    if not features_meta_path.exists():
-        raise FileNotFoundError(f"No features metadata found for dataset {dataset_id}")
-    with features_meta_path.open(encoding="utf-8") as f:
-        features_meta = FeatureRunMetadata.from_dict(json.load(f))
-    require_features_complete(features_meta, dataset_id)
-
-    preprocessed_storage = BlueskyStorageManager(StorageStage.PREPROCESSED, dataset_id)
-    require_all_runs_complete(preprocessed_storage, dataset_id)
-
-    root = dataset_root("bluesky", dataset_id)
-    all_preprocessed_run_dirs = sorted(
-        p for p in preprocessed_storage.root_dir.iterdir() if p.is_dir()
-    )
-    rules_hash = hashlib.sha256(config_path.read_bytes()).hexdigest()
-
-    existing = _is_up_to_date(
-        curated_storage,
-        all_preprocessed_run_dirs,
-        root,
-        rules_hash,
-        features_meta,
-    )
-    if existing is not None:
-        print(f"curate_bluesky: already up to date, skipping ({existing})")
-        return existing.parent
-
-    output_path = run_curation(config_path, dataset_id, BLUESKY_CURATE_SPEC, rules_hash=rules_hash)
-    return output_path.parent
+    return curate_with_spec(config_path, dataset_id, BLUESKY_CURATE_SPEC)
 
 
-@app.command()
-def main(
-    dataset_id: str = typer.Option(
-        ...,
-        "--dataset-id",
-        help="Dataset identifier from ingestion YAML (bluesky_<uuid>)",
-    ),
-    config: Path = typer.Option(
-        Path("mirrorview.yaml"),
-        "--config",
-        "-c",
-        help="Curate config under data_platform/curate/configs/bluesky/",
-    ),
-) -> None:
-    config_path = resolve_config_path(config, CONFIGS_DIR)
-    curate(config_path, dataset_id)
+main = make_curate_cli(
+    BLUESKY_CURATE_SPEC,
+    CONFIGS_DIR,
+    configs_help="Curate config under data_platform/curate/configs/bluesky/",
+)
+
+app.command()(main)
 
 
 if __name__ == "__main__":

--- a/data_platform/curate/curate_bluesky.py
+++ b/data_platform/curate/curate_bluesky.py
@@ -32,6 +32,9 @@ BLUESKY_CURATE_SPEC = CuratePlatformSpec(
     storage_cls=BlueskyStorageManager,
     columns=BLUESKY_COLUMNS,
     record_noun="posts",
+    require_features_complete=True,
+    require_all_runs_complete=True,
+    skip_if_up_to_date=True,
 )
 
 

--- a/data_platform/curate/curate_reddit.py
+++ b/data_platform/curate/curate_reddit.py
@@ -25,6 +25,9 @@ REDDIT_CURATE_SPEC = CuratePlatformSpec(
     storage_cls=RedditStorageManager,
     columns=REDDIT_COLUMNS,
     record_noun="comments",
+    require_features_complete=False,
+    require_all_runs_complete=False,
+    skip_if_up_to_date=False,
 )
 
 

--- a/data_platform/curate/curate_reddit.py
+++ b/data_platform/curate/curate_reddit.py
@@ -27,9 +27,6 @@ REDDIT_CURATE_SPEC = CuratePlatformSpec(
     record_noun="comments",
 )
 
-ID_COLUMN = REDDIT_COLUMNS.records_id_column
-FEATURE_FILE_ID_COLUMN = REDDIT_COLUMNS.feature_file_id_column
-
 
 def curate(config_path: Path, dataset_id: str) -> Path:
     return curate_with_spec(config_path, dataset_id, REDDIT_CURATE_SPEC)

--- a/data_platform/curate/curate_twitter.py
+++ b/data_platform/curate/curate_twitter.py
@@ -25,6 +25,9 @@ TWITTER_CURATE_SPEC = CuratePlatformSpec(
     storage_cls=TwitterStorageManager,
     columns=TWITTER_COLUMNS,
     record_noun="posts",
+    require_features_complete=False,
+    require_all_runs_complete=False,
+    skip_if_up_to_date=False,
 )
 
 

--- a/data_platform/curate/curate_twitter.py
+++ b/data_platform/curate/curate_twitter.py
@@ -27,9 +27,6 @@ TWITTER_CURATE_SPEC = CuratePlatformSpec(
     record_noun="posts",
 )
 
-ID_COLUMN = TWITTER_COLUMNS.records_id_column
-FEATURE_FILE_ID_COLUMN = TWITTER_COLUMNS.feature_file_id_column
-
 
 def curate(config_path: Path, dataset_id: str) -> Path:
     return curate_with_spec(config_path, dataset_id, TWITTER_CURATE_SPEC)

--- a/data_platform/curate/runner.py
+++ b/data_platform/curate/runner.py
@@ -28,12 +28,13 @@ StorageManagerFactory = Callable[..., StorageManager]
 
 @dataclass(frozen=True)
 class CuratePlatformSpec:
-    """Platform binding for the shared curate CLI.
+    """Settings object for one platform's curate command-line script.
 
-    Completeness gates and skip-if-up-to-date are Bluesky-only on purpose.
-    Reddit and Twitter leave these flags false so every call writes a new
-    curated run. The shared runner applies a true flag the same way on any
-    platform.
+    Bluesky sets the completeness and skip flags to true. Reddit and Twitter
+    leave ``require_features_complete``, ``require_all_runs_complete``, and
+    ``skip_if_up_to_date`` false, so each call writes a new curated run. If you
+    set any of those flags to true on another platform, ``curate_with_spec``
+    honors them the same way.
     """
 
     platform: str
@@ -159,10 +160,12 @@ def curated_export_if_up_to_date(
     rules_hash: str,
     features_meta: FeatureRunMetadata,
 ) -> Path | None:
-    """Return the latest export path when curated inputs have not changed.
+    """Return the path of the latest curated export when the preprocess runs and
+    the rules file have not changed.
 
-    Compares the current preprocessed run list and rules hash against the
-    latest curated run. Returns None when a new curated export is needed.
+    The function compares the current preprocess run list and the rules hash
+    with the latest curated run. It returns None when you need a new curated
+    export.
     """
     root = dataset_root(spec.platform, dataset_id)
     current_runs = [
@@ -200,22 +203,22 @@ def _matching_curated_export(
 
 
 def curate_with_spec(config_path: Path, dataset_id: str, spec: CuratePlatformSpec) -> Path:
-    """Run gated, optionally skipped curation for a platform spec.
+    """Run curation for one platform, using the completeness and skip flags on
+    ``spec``.
 
-    Completeness and skip behavior come from flags on ``spec``. Reddit and
-    Twitter leave those flags false; Bluesky sets them true.
+    Reddit and Twitter leave those flags false. Bluesky sets them true.
 
     Returns
     -------
     Path
-        Path to the curated export CSV.
+        Path of the curated export CSV.
 
     Raises
     ------
     FileNotFoundError
         When required features metadata is missing.
     RuntimeError
-        When a completeness gate fails.
+        When a completeness check fails.
     """
     dataset_id = validate_dataset_id(dataset_id)
     rules_hash = hashlib.sha256(config_path.read_bytes()).hexdigest()
@@ -251,7 +254,7 @@ def run_curate_main(
     dataset_id: str,
     config: Path,
 ) -> None:
-    """Shared Typer main for platform curate CLIs."""
+    """Shared Typer ``main`` used by each platform curate script."""
     config_path = resolve_config_path(config, configs_dir)
     curate_with_spec(config_path, dataset_id, spec)
 
@@ -262,7 +265,7 @@ def make_curate_cli(
     *,
     configs_help: str,
 ) -> Callable[[], None]:
-    """Build a Typer CLI entrypoint for a platform curate script."""
+    """Return a Typer ``main`` function for a platform curate script."""
 
     def main(
         dataset_id: str = typer.Option(

--- a/data_platform/curate/runner.py
+++ b/data_platform/curate/runner.py
@@ -28,6 +28,9 @@ class CuratePlatformSpec:
     storage_cls: StorageManagerFactory
     columns: PlatformSpecificColumns
     record_noun: str
+    require_features_complete: bool = False
+    require_all_runs_complete: bool = False
+    skip_if_up_to_date: bool = False
 
 
 def build_curate_metadata(

--- a/data_platform/curate/runner.py
+++ b/data_platform/curate/runner.py
@@ -222,7 +222,7 @@ def curate_with_spec(config_path: Path, dataset_id: str, spec: CuratePlatformSpe
     """
     dataset_id = validate_dataset_id(dataset_id)
     rules_hash = hashlib.sha256(config_path.read_bytes()).hexdigest()
-    features_meta = _maybe_load_and_gate_features(spec, dataset_id)
+    features_meta = _load_and_gate_features(spec, dataset_id)
     if spec.require_all_runs_complete:
         require_all_runs_complete(spec.storage_cls("preprocessed", dataset_id), dataset_id)
     if spec.skip_if_up_to_date:
@@ -235,9 +235,15 @@ def curate_with_spec(config_path: Path, dataset_id: str, spec: CuratePlatformSpe
     return run_curation(config_path, dataset_id, spec, rules_hash=rules_hash)
 
 
-def _maybe_load_and_gate_features(
+def _load_and_gate_features(
     spec: CuratePlatformSpec, dataset_id: str
 ) -> FeatureRunMetadata | None:
+    """Load features metadata when completeness or skip flags require it.
+
+    Returns None when both ``require_features_complete`` and
+    ``skip_if_up_to_date`` are false, because those callers do not read
+    features metadata.
+    """
     if not spec.require_features_complete and not spec.skip_if_up_to_date:
         return None
     features_meta = load_features_run_metadata(spec.platform, dataset_id)

--- a/data_platform/curate/runner.py
+++ b/data_platform/curate/runner.py
@@ -24,6 +24,14 @@ StorageManagerFactory = Callable[..., StorageManager]
 
 @dataclass(frozen=True)
 class CuratePlatformSpec:
+    """Platform binding for the shared curate CLI.
+
+    Completeness gates and skip-if-up-to-date are Bluesky-only on purpose.
+    Reddit and Twitter leave these flags false so every call writes a new
+    curated run. The shared runner applies a true flag the same way on any
+    platform.
+    """
+
     platform: str
     storage_cls: StorageManagerFactory
     columns: PlatformSpecificColumns

--- a/data_platform/curate/runner.py
+++ b/data_platform/curate/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,8 +14,11 @@ import typer
 
 from data_platform.curate.apply_rules import ApplyRulesResult, apply_rules, load_rules_config
 from data_platform.curate.consolidate import ConsolidateConfig, build_wide_table
+from data_platform.generate_features.metadata import metadata_path
+from data_platform.generate_features.models import FeatureRunMetadata
 from data_platform.utils.config_paths import resolve_config_path
 from data_platform.utils.dataset import dataset_root, relative_run_path, validate_dataset_id
+from data_platform.utils.gate_checks import require_all_runs_complete, require_features_complete
 from data_platform.utils.platform_specific_columns import PlatformSpecificColumns
 from data_platform.utils.storage import StorageManager
 from lib.timestamp_utils import get_current_timestamp
@@ -127,10 +131,88 @@ def run_curation(
     return output_path
 
 
+def load_features_run_metadata(platform: str, dataset_id: str) -> FeatureRunMetadata:
+    """Load features/metadata.json for a dataset, or raise if it is missing."""
+    features_meta_path = metadata_path(dataset_root(platform, dataset_id) / "features")
+    if not features_meta_path.exists():
+        raise FileNotFoundError(f"No features metadata found for dataset {dataset_id}")
+    with features_meta_path.open(encoding="utf-8") as handle:
+        return FeatureRunMetadata.from_dict(json.load(handle))
+
+
+def _preprocessed_run_dirs(spec: CuratePlatformSpec, dataset_id: str) -> list[Path]:
+    preprocessed_storage = spec.storage_cls("preprocessed", dataset_id)
+    if not preprocessed_storage.root_dir.exists():
+        return []
+    return sorted(path for path in preprocessed_storage.root_dir.iterdir() if path.is_dir())
+
+
+def curated_export_if_up_to_date(
+    spec: CuratePlatformSpec,
+    dataset_id: str,
+    rules_hash: str,
+    features_meta: FeatureRunMetadata,
+) -> Path | None:
+    """Return the latest export path when curated inputs match, else None."""
+    root = dataset_root(spec.platform, dataset_id)
+    current_runs = [relative_run_path(root, path) for path in _preprocessed_run_dirs(spec, dataset_id)]
+    if features_meta.source_preprocessed_runs != current_runs:
+        return None
+    curated_storage = spec.storage_cls("curated", dataset_id)
+    if not curated_storage.root_dir.exists():
+        return None
+    run_dirs = sorted(path for path in curated_storage.root_dir.iterdir() if path.is_dir())
+    if not run_dirs:
+        return None
+    return _matching_curated_export(curated_storage, run_dirs[-1], current_runs, rules_hash)
+
+
+def _matching_curated_export(
+    curated_storage: StorageManager,
+    latest_run_dir: Path,
+    current_runs: list[str],
+    rules_hash: str,
+) -> Path | None:
+    latest_meta = curated_storage.load_run_metadata(latest_run_dir)
+    if latest_meta.get("source_preprocessed_runs") != current_runs:
+        return None
+    if latest_meta.get("rules_hash") != rules_hash:
+        return None
+    output_filename = latest_meta.get("files", {}).get("export")
+    if not output_filename:
+        return None
+    output_path = latest_run_dir / output_filename
+    if not output_path.exists():
+        return None
+    return output_path
+
+
 def curate_with_spec(config_path: Path, dataset_id: str, spec: CuratePlatformSpec) -> Path:
     """Run curation for a platform spec, hashing the rules config for metadata."""
+    dataset_id = validate_dataset_id(dataset_id)
     rules_hash = hashlib.sha256(config_path.read_bytes()).hexdigest()
+    features_meta = _maybe_load_and_gate_features(spec, dataset_id)
+    if spec.require_all_runs_complete:
+        require_all_runs_complete(spec.storage_cls("preprocessed", dataset_id), dataset_id)
+    if spec.skip_if_up_to_date:
+        if features_meta is None:
+            raise RuntimeError(f"Features metadata required to skip curation for {dataset_id}")
+        existing = curated_export_if_up_to_date(spec, dataset_id, rules_hash, features_meta)
+        if existing is not None:
+            print(f"curate_{spec.platform}: already up to date, skipping ({existing})")
+            return existing
     return run_curation(config_path, dataset_id, spec, rules_hash=rules_hash)
+
+
+def _maybe_load_and_gate_features(
+    spec: CuratePlatformSpec, dataset_id: str
+) -> FeatureRunMetadata | None:
+    if not spec.require_features_complete and not spec.skip_if_up_to_date:
+        return None
+    features_meta = load_features_run_metadata(spec.platform, dataset_id)
+    if spec.require_features_complete:
+        require_features_complete(features_meta, dataset_id)
+    return features_meta
 
 
 def run_curate_main(
@@ -141,7 +223,7 @@ def run_curate_main(
     dataset_id: str,
     config: Path,
 ) -> None:
-    """Shared Typer main for Reddit/Twitter curate CLIs."""
+    """Shared Typer main for platform curate CLIs."""
     config_path = resolve_config_path(config, configs_dir)
     curate_with_spec(config_path, dataset_id, spec)
 

--- a/data_platform/curate/runner.py
+++ b/data_platform/curate/runner.py
@@ -132,7 +132,13 @@ def run_curation(
 
 
 def load_features_run_metadata(platform: str, dataset_id: str) -> FeatureRunMetadata:
-    """Load features/metadata.json for a dataset, or raise if it is missing."""
+    """Load features/metadata.json for a dataset.
+
+    Raises
+    ------
+    FileNotFoundError
+        When the features metadata file does not exist.
+    """
     features_meta_path = metadata_path(dataset_root(platform, dataset_id) / "features")
     if not features_meta_path.exists():
         raise FileNotFoundError(f"No features metadata found for dataset {dataset_id}")
@@ -153,9 +159,15 @@ def curated_export_if_up_to_date(
     rules_hash: str,
     features_meta: FeatureRunMetadata,
 ) -> Path | None:
-    """Return the latest export path when curated inputs match, else None."""
+    """Return the latest export path when curated inputs have not changed.
+
+    Compares the current preprocessed run list and rules hash against the
+    latest curated run. Returns None when a new curated export is needed.
+    """
     root = dataset_root(spec.platform, dataset_id)
-    current_runs = [relative_run_path(root, path) for path in _preprocessed_run_dirs(spec, dataset_id)]
+    current_runs = [
+        relative_run_path(root, path) for path in _preprocessed_run_dirs(spec, dataset_id)
+    ]
     if features_meta.source_preprocessed_runs != current_runs:
         return None
     curated_storage = spec.storage_cls("curated", dataset_id)
@@ -188,7 +200,23 @@ def _matching_curated_export(
 
 
 def curate_with_spec(config_path: Path, dataset_id: str, spec: CuratePlatformSpec) -> Path:
-    """Run curation for a platform spec, hashing the rules config for metadata."""
+    """Run gated, optionally skipped curation for a platform spec.
+
+    Completeness and skip behavior come from flags on ``spec``. Reddit and
+    Twitter leave those flags false; Bluesky sets them true.
+
+    Returns
+    -------
+    Path
+        Path to the curated export CSV.
+
+    Raises
+    ------
+    FileNotFoundError
+        When required features metadata is missing.
+    RuntimeError
+        When a completeness gate fails.
+    """
     dataset_id = validate_dataset_id(dataset_id)
     rules_hash = hashlib.sha256(config_path.read_bytes()).hexdigest()
     features_meta = _maybe_load_and_gate_features(spec, dataset_id)

--- a/data_platform/generate_features/engines/thread_pool_engine.py
+++ b/data_platform/generate_features/engines/thread_pool_engine.py
@@ -8,12 +8,19 @@ from data_platform.generate_features.engines.base import (
     BaseBatchExecutionEngine,
     row_with_label_timestamp,
 )
-from data_platform.generate_features.models import LabelTask
+from data_platform.generate_features.models import FeatureRunConfig, FeatureSpec, LabelTask
 from lib.timestamp_utils import get_current_timestamp
 
 
 class ThreadPoolBatchEngine(BaseBatchExecutionEngine):
     """Label tasks by calling generate_fn concurrently in a thread pool."""
+
+    def __init__(self, spec: FeatureSpec, run_config: FeatureRunConfig) -> None:
+        super().__init__(spec, run_config)
+        generate_fn = spec.generate_fn
+        if generate_fn is None:
+            raise ValueError(f"Feature {spec.name} requires generate_fn")
+        self._generate_fn = generate_fn
 
     def batch_label_records(self, tasks: list[LabelTask]) -> list[dict]:
         """Score each task with generate_fn and return validated label dict rows."""
@@ -24,9 +31,7 @@ class ThreadPoolBatchEngine(BaseBatchExecutionEngine):
         rows: list[dict] = []
 
         def _label_one(task: LabelTask) -> dict:
-            if self.spec.generate_fn is None:
-                raise ValueError(f"Feature {self.spec.name} requires generate_fn")
-            result = self.spec.generate_fn(task.uri, task.text)
+            result = self._generate_fn(task.uri, task.text)
             return row_with_label_timestamp(
                 result.model_dump(),
                 label_timestamp=label_timestamp,

--- a/data_platform/generate_features/engines/thread_pool_engine.py
+++ b/data_platform/generate_features/engines/thread_pool_engine.py
@@ -24,6 +24,8 @@ class ThreadPoolBatchEngine(BaseBatchExecutionEngine):
         rows: list[dict] = []
 
         def _label_one(task: LabelTask) -> dict:
+            if self.spec.generate_fn is None:
+                raise ValueError(f"Feature {self.spec.name} requires generate_fn")
             result = self.spec.generate_fn(task.uri, task.text)
             return row_with_label_timestamp(
                 result.model_dump(),

--- a/data_platform/generate_features/generate_bluesky_features.py
+++ b/data_platform/generate_features/generate_bluesky_features.py
@@ -16,7 +16,6 @@ from data_platform.generate_features.platform_cli import (
     FeaturePlatformSpec,
     features_from_cli,
     generate_platform_features,
-    load_preprocessed_records,
 )
 from data_platform.models.sync import SyncBlueskyPostModel
 from data_platform.utils.platform_specific_columns import BLUESKY_COLUMNS
@@ -30,10 +29,6 @@ BLUESKY_SPEC = FeaturePlatformSpec(
     empty_message="generate_bluesky_features: no preprocessed posts found",
     require_all_runs_complete=True,
 )
-
-
-def load_all_posts(dataset_id: str):
-    return load_preprocessed_records(BLUESKY_SPEC, dataset_id)
 
 
 def generate_bluesky_features(

--- a/data_platform/generate_features/generate_bluesky_features.py
+++ b/data_platform/generate_features/generate_bluesky_features.py
@@ -12,20 +12,15 @@ from pathlib import Path
 
 import typer
 
-from data_platform.generate_features.models import FeatureRunConfig
 from data_platform.generate_features.platform_cli import (
     FeaturePlatformSpec,
-    build_feature_config,
     features_from_cli,
-    generate_feature_subset,
+    generate_platform_features,
     load_preprocessed_records,
-    run_feature_generation,
 )
 from data_platform.models.sync import SyncBlueskyPostModel
-from data_platform.utils.dataset import validate_dataset_id
-from data_platform.utils.gate_checks import require_all_runs_complete
 from data_platform.utils.platform_specific_columns import BLUESKY_COLUMNS
-from data_platform.utils.storage import BlueskyStorageManager, StorageStage
+from data_platform.utils.storage import BlueskyStorageManager
 
 BLUESKY_SPEC = FeaturePlatformSpec(
     platform="bluesky",
@@ -50,27 +45,14 @@ def generate_bluesky_features(
     feature_subset: list[str] | None = None,
 ) -> dict[str, Path]:
     """Load Bluesky posts and generate the requested feature labels."""
-    dataset_id = validate_dataset_id(dataset_id)
-
-    preprocessed_storage = BlueskyStorageManager(StorageStage.PREPROCESSED, dataset_id)
-    if preprocessed_storage.latest_run_dir() is None:
-        raise FileNotFoundError(f"No preprocessed runs found for dataset {dataset_id}")
-    require_all_runs_complete(preprocessed_storage, dataset_id)
-
-    features_subset = generate_feature_subset(feature_subset)
-    run_config = FeatureRunConfig(
+    return generate_platform_features(
+        BLUESKY_SPEC,
+        dataset_id,
         batch_size=batch_size,
         max_concurrency=max_concurrency,
         opik_enabled=opik_enabled,
+        feature_subset=feature_subset,
     )
-    posts = load_all_posts(dataset_id)
-    config = build_feature_config(
-        BLUESKY_SPEC,
-        dataset_id,
-        run_config=run_config,
-        features_subset=features_subset,
-    )
-    return run_feature_generation(posts, config, empty_message=BLUESKY_SPEC.empty_message)
 
 
 def main(

--- a/data_platform/generate_features/generate_reddit_features.py
+++ b/data_platform/generate_features/generate_reddit_features.py
@@ -31,10 +31,6 @@ REDDIT_SPEC = FeaturePlatformSpec(
     empty_message="generate_reddit_features: no preprocessed comments found",
 )
 
-ID_COLUMN = REDDIT_COLUMNS.records_id_column
-TEXT_COLUMN = REDDIT_COLUMNS.text_column
-FEATURE_FILE_ID_COLUMN = REDDIT_COLUMNS.feature_file_id_column
-
 
 def reddit_feature_config(*args, **kwargs):
     return build_feature_config(REDDIT_SPEC, *args, **kwargs)

--- a/data_platform/generate_features/generate_twitter_features.py
+++ b/data_platform/generate_features/generate_twitter_features.py
@@ -31,10 +31,6 @@ TWITTER_SPEC = FeaturePlatformSpec(
     empty_message="generate_twitter_features: no preprocessed posts found",
 )
 
-ID_COLUMN = TWITTER_COLUMNS.records_id_column
-TEXT_COLUMN = TWITTER_COLUMNS.text_column
-FEATURE_FILE_ID_COLUMN = TWITTER_COLUMNS.feature_file_id_column
-
 
 def twitter_feature_config(*args, **kwargs):
     return build_feature_config(TWITTER_SPEC, *args, **kwargs)

--- a/data_platform/generate_features/models.py
+++ b/data_platform/generate_features/models.py
@@ -114,6 +114,13 @@ FeatureFn = Callable[[str, str], BaseModel]
 
 @dataclass(frozen=True)
 class FeatureSpec:
+    """Registry entry for one feature labeler.
+
+    LangChain features are the batch-engine path: they supply
+    ``system_prompt`` and ``llm_output_schema`` and omit ``generate_fn``.
+    Thread-pool features require ``generate_fn``.
+    """
+
     name: str
     model: type[BaseModel]
     engine_type: EngineType

--- a/data_platform/generate_features/models.py
+++ b/data_platform/generate_features/models.py
@@ -114,11 +114,12 @@ FeatureFn = Callable[[str, str], BaseModel]
 
 @dataclass(frozen=True)
 class FeatureSpec:
-    """Registry entry for one feature labeler.
+    """One named feature in the feature registry.
 
-    LangChain features are the batch-engine path: they supply
-    ``system_prompt`` and ``llm_output_schema`` and omit ``generate_fn``.
-    Thread-pool features require ``generate_fn``.
+    A LangChain feature sets ``system_prompt`` and ``llm_output_schema``, and
+    it leaves ``generate_fn`` unset, because the LangChain engine labels a
+    batch of rows through that prompt and schema. A thread-pool feature must
+    set ``generate_fn``, because that engine calls the function on each row.
     """
 
     name: str

--- a/data_platform/generate_features/models.py
+++ b/data_platform/generate_features/models.py
@@ -117,7 +117,7 @@ class FeatureSpec:
     name: str
     model: type[BaseModel]
     engine_type: EngineType
-    generate_fn: FeatureFn
+    generate_fn: FeatureFn | None = None
     system_prompt: str | None = None
     llm_output_schema: type[BaseModel] | None = None
 

--- a/data_platform/generate_features/registry.py
+++ b/data_platform/generate_features/registry.py
@@ -7,18 +7,12 @@ from data_platform.generate_features.is_likely_spam.generate_feature import (
     IsLikelySpamModel,
     LlmIsLikelySpamModel,
 )
-from data_platform.generate_features.is_likely_spam.generate_feature import (
-    generate_feature as generate_is_likely_spam,
-)
 from data_platform.generate_features.is_news_or_opinion.generate_feature import (
     SYSTEM_PROMPT as IS_NEWS_OR_OPINION_SYSTEM_PROMPT,
 )
 from data_platform.generate_features.is_news_or_opinion.generate_feature import (
     IsNewsOrOpinionModel,
     LlmIsNewsOrOpinionModel,
-)
-from data_platform.generate_features.is_news_or_opinion.generate_feature import (
-    generate_feature as generate_is_news_or_opinion,
 )
 from data_platform.generate_features.is_political.generate_feature import (
     SYSTEM_PROMPT as IS_POLITICAL_SYSTEM_PROMPT,
@@ -27,9 +21,6 @@ from data_platform.generate_features.is_political.generate_feature import (
     IsPoliticalModel,
     LlmIsPoliticalModel,
 )
-from data_platform.generate_features.is_political.generate_feature import (
-    generate_feature as generate_is_political,
-)
 from data_platform.generate_features.is_self_contained.generate_feature import (
     SYSTEM_PROMPT as IS_SELF_CONTAINED_SYSTEM_PROMPT,
 )
@@ -37,18 +28,12 @@ from data_platform.generate_features.is_self_contained.generate_feature import (
     IsSelfContainedModel,
     LlmIsSelfContainedModel,
 )
-from data_platform.generate_features.is_self_contained.generate_feature import (
-    generate_feature as generate_is_self_contained,
-)
 from data_platform.generate_features.is_structurally_complete.generate_feature import (
     SYSTEM_PROMPT as IS_STRUCTURALLY_COMPLETE_SYSTEM_PROMPT,
 )
 from data_platform.generate_features.is_structurally_complete.generate_feature import (
     IsStructurallyCompleteModel,
     LlmIsStructurallyCompleteModel,
-)
-from data_platform.generate_features.is_structurally_complete.generate_feature import (
-    generate_feature as generate_is_structurally_complete,
 )
 from data_platform.generate_features.is_toxic_tiered.generate_feature import IsToxicTieredModel
 from data_platform.generate_features.is_toxic_tiered.generate_feature import (
@@ -62,16 +47,12 @@ from data_platform.generate_features.political_stance.generate_feature import (
     LlmPoliticalStanceModel,
     PoliticalStanceModel,
 )
-from data_platform.generate_features.political_stance.generate_feature import (
-    generate_feature as generate_political_stance,
-)
 
 FEATURE_REGISTRY: dict[str, FeatureSpec] = {
     "is_news_or_opinion": FeatureSpec(
         name="is_news_or_opinion",
         model=IsNewsOrOpinionModel,
         engine_type="langchain",
-        generate_fn=generate_is_news_or_opinion,
         system_prompt=IS_NEWS_OR_OPINION_SYSTEM_PROMPT,
         llm_output_schema=LlmIsNewsOrOpinionModel,
     ),
@@ -79,7 +60,6 @@ FEATURE_REGISTRY: dict[str, FeatureSpec] = {
         name="is_political",
         model=IsPoliticalModel,
         engine_type="langchain",
-        generate_fn=generate_is_political,
         system_prompt=IS_POLITICAL_SYSTEM_PROMPT,
         llm_output_schema=LlmIsPoliticalModel,
     ),
@@ -87,7 +67,6 @@ FEATURE_REGISTRY: dict[str, FeatureSpec] = {
         name="is_likely_spam",
         model=IsLikelySpamModel,
         engine_type="langchain",
-        generate_fn=generate_is_likely_spam,
         system_prompt=IS_LIKELY_SPAM_SYSTEM_PROMPT,
         llm_output_schema=LlmIsLikelySpamModel,
     ),
@@ -95,7 +74,6 @@ FEATURE_REGISTRY: dict[str, FeatureSpec] = {
         name="is_self_contained",
         model=IsSelfContainedModel,
         engine_type="langchain",
-        generate_fn=generate_is_self_contained,
         system_prompt=IS_SELF_CONTAINED_SYSTEM_PROMPT,
         llm_output_schema=LlmIsSelfContainedModel,
     ),
@@ -103,7 +81,6 @@ FEATURE_REGISTRY: dict[str, FeatureSpec] = {
         name="is_structurally_complete",
         model=IsStructurallyCompleteModel,
         engine_type="langchain",
-        generate_fn=generate_is_structurally_complete,
         system_prompt=IS_STRUCTURALLY_COMPLETE_SYSTEM_PROMPT,
         llm_output_schema=LlmIsStructurallyCompleteModel,
     ),
@@ -117,7 +94,6 @@ FEATURE_REGISTRY: dict[str, FeatureSpec] = {
         name="political_stance",
         model=PoliticalStanceModel,
         engine_type="langchain",
-        generate_fn=generate_political_stance,
         system_prompt=POLITICAL_STANCE_SYSTEM_PROMPT,
         llm_output_schema=LlmPoliticalStanceModel,
     ),

--- a/data_platform/preprocessing/preprocess_bluesky.py
+++ b/data_platform/preprocessing/preprocess_bluesky.py
@@ -29,7 +29,6 @@ from data_platform.preprocessing.validators.validators import (
     check_if_text_english,
     check_if_valid_post_length,
 )
-from data_platform.utils.dataset import validate_dataset_id
 from data_platform.utils.platform_specific_columns import BLUESKY_COLUMNS
 from data_platform.utils.storage import BlueskyStorageManager
 
@@ -64,7 +63,6 @@ def filter_posts(
 
 
 def preprocess_records(dataset_id: str) -> Path:
-    dataset_id = validate_dataset_id(dataset_id)
     return run_preprocess_records(dataset_id, BLUESKY_SPEC)
 
 

--- a/tests/data_platform/curate/test_curate_bluesky.py
+++ b/tests/data_platform/curate/test_curate_bluesky.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from data_platform.curate.curate_bluesky import curate
+from data_platform.curate.curate_bluesky import BLUESKY_CURATE_SPEC, curate
 from data_platform.generate_features.models import FeatureRunMetadata
 from tests.data_platform.constants import VALID_DATASET_ID
 
@@ -134,12 +134,12 @@ class TestCurateEarlyExit:
         )
 
         mock_run_curation = MagicMock()
-        monkeypatch.setattr("data_platform.curate.curate_bluesky.run_curation", mock_run_curation)
+        monkeypatch.setattr("data_platform.curate.runner.run_curation", mock_run_curation)
 
         result = curate(config_path, VALID_DATASET_ID)
 
         mock_run_curation.assert_not_called()
-        assert result == existing_run
+        assert result == existing_run / "test.csv"
 
     def test_reruns_if_new_preprocessed_run(
         self, data_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -162,7 +162,7 @@ class TestCurateEarlyExit:
 
         fake_output = _make_fake_new_run(data_root, VALID_DATASET_ID)
         mock_run_curation = MagicMock(return_value=fake_output)
-        monkeypatch.setattr("data_platform.curate.curate_bluesky.run_curation", mock_run_curation)
+        monkeypatch.setattr("data_platform.curate.runner.run_curation", mock_run_curation)
 
         curate(config_path, VALID_DATASET_ID)
 
@@ -188,7 +188,7 @@ class TestCurateEarlyExit:
 
         fake_output = _make_fake_new_run(data_root, VALID_DATASET_ID)
         mock_run_curation = MagicMock(return_value=fake_output)
-        monkeypatch.setattr("data_platform.curate.curate_bluesky.run_curation", mock_run_curation)
+        monkeypatch.setattr("data_platform.curate.runner.run_curation", mock_run_curation)
 
         curate(config_path, VALID_DATASET_ID)
 
@@ -217,7 +217,7 @@ class TestCurateEarlyExit:
 
         fake_output = _make_fake_new_run(data_root, VALID_DATASET_ID)
         mock_run_curation = MagicMock(return_value=fake_output)
-        monkeypatch.setattr("data_platform.curate.curate_bluesky.run_curation", mock_run_curation)
+        monkeypatch.setattr("data_platform.curate.runner.run_curation", mock_run_curation)
 
         curate(config_path, VALID_DATASET_ID)
 
@@ -244,8 +244,17 @@ class TestCurateEarlyExit:
 
         fake_output = _make_fake_new_run(data_root, VALID_DATASET_ID)
         mock_run_curation = MagicMock(return_value=fake_output)
-        monkeypatch.setattr("data_platform.curate.curate_bluesky.run_curation", mock_run_curation)
+        monkeypatch.setattr("data_platform.curate.runner.run_curation", mock_run_curation)
 
         curate(config_path, VALID_DATASET_ID)
 
         mock_run_curation.assert_called_once()
+
+
+class TestBlueskyCurateSpec:
+    """Tests for BLUESKY_CURATE_SPEC flags."""
+
+    def test_completeness_and_skip_flags_are_enabled(self) -> None:
+        assert BLUESKY_CURATE_SPEC.require_features_complete is True
+        assert BLUESKY_CURATE_SPEC.require_all_runs_complete is True
+        assert BLUESKY_CURATE_SPEC.skip_if_up_to_date is True

--- a/tests/data_platform/curate/test_curate_reddit.py
+++ b/tests/data_platform/curate/test_curate_reddit.py
@@ -5,11 +5,8 @@ from pathlib import Path
 import pandas as pd
 
 from data_platform.curate.consolidate import ConsolidateConfig, build_wide_table
-from data_platform.curate.curate_reddit import (
-    FEATURE_FILE_ID_COLUMN,
-    ID_COLUMN,
-    curate,
-)
+from data_platform.curate.curate_reddit import curate
+from data_platform.utils.platform_specific_columns import REDDIT_COLUMNS
 from data_platform.utils.storage import RedditStorageManager
 from tests.data_platform.constants import LABEL_TIMESTAMP, VALID_REDDIT_DATASET_ID
 from tests.data_platform.ingestion.reddit_conftest import mock_comment_row
@@ -36,12 +33,12 @@ def test_build_wide_table_joins_reddit_comments_on_comment_fullname(tmp_path: Pa
         "is_political",
         [
             {
-                FEATURE_FILE_ID_COLUMN: comment_a["comment_fullname"],
+                REDDIT_COLUMNS.feature_file_id_column: comment_a["comment_fullname"],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "is_political": True,
             },
             {
-                FEATURE_FILE_ID_COLUMN: comment_b["comment_fullname"],
+                REDDIT_COLUMNS.feature_file_id_column: comment_b["comment_fullname"],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "is_political": False,
             },
@@ -52,12 +49,12 @@ def test_build_wide_table_joins_reddit_comments_on_comment_fullname(tmp_path: Pa
         "is_news_or_opinion",
         [
             {
-                FEATURE_FILE_ID_COLUMN: comment_a["comment_fullname"],
+                REDDIT_COLUMNS.feature_file_id_column: comment_a["comment_fullname"],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "category": "opinion",
             },
             {
-                FEATURE_FILE_ID_COLUMN: comment_b["comment_fullname"],
+                REDDIT_COLUMNS.feature_file_id_column: comment_b["comment_fullname"],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "category": "news",
             },
@@ -68,12 +65,12 @@ def test_build_wide_table_joins_reddit_comments_on_comment_fullname(tmp_path: Pa
         "is_likely_spam",
         [
             {
-                FEATURE_FILE_ID_COLUMN: comment_a["comment_fullname"],
+                REDDIT_COLUMNS.feature_file_id_column: comment_a["comment_fullname"],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "is_likely_spam": False,
             },
             {
-                FEATURE_FILE_ID_COLUMN: comment_b["comment_fullname"],
+                REDDIT_COLUMNS.feature_file_id_column: comment_b["comment_fullname"],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "is_likely_spam": True,
             },
@@ -85,15 +82,15 @@ def test_build_wide_table_joins_reddit_comments_on_comment_fullname(tmp_path: Pa
             posts_file=comments_csv,
             features_root=features_root,
             feature_names=("is_political", "is_news_or_opinion"),
-            id_column=ID_COLUMN,
-            feature_file_id_column=FEATURE_FILE_ID_COLUMN,
+            id_column=REDDIT_COLUMNS.records_id_column,
+            feature_file_id_column=REDDIT_COLUMNS.feature_file_id_column,
         )
     )
 
     assert len(wide) == 2
     assert "body" in wide.columns
     assert "news_or_opinion_category" in wide.columns
-    assert wide.loc[wide[ID_COLUMN] == comment_a["comment_fullname"], "is_political"].iloc[0] in {
+    assert wide.loc[wide[REDDIT_COLUMNS.records_id_column] == comment_a["comment_fullname"], "is_political"].iloc[0] in {
         True,
         "True",
     }
@@ -123,7 +120,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "is_political",
                 {
-                    FEATURE_FILE_ID_COLUMN: comment["comment_fullname"],
+                    REDDIT_COLUMNS.feature_file_id_column: comment["comment_fullname"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "is_political": political,
                 },
@@ -131,7 +128,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "is_news_or_opinion",
                 {
-                    FEATURE_FILE_ID_COLUMN: comment["comment_fullname"],
+                    REDDIT_COLUMNS.feature_file_id_column: comment["comment_fullname"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "category": category,
                 },
@@ -139,7 +136,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "is_likely_spam",
                 {
-                    FEATURE_FILE_ID_COLUMN: comment["comment_fullname"],
+                    REDDIT_COLUMNS.feature_file_id_column: comment["comment_fullname"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "is_likely_spam": comment is comment_drop,
                 },
@@ -147,7 +144,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "is_self_contained",
                 {
-                    FEATURE_FILE_ID_COLUMN: comment["comment_fullname"],
+                    REDDIT_COLUMNS.feature_file_id_column: comment["comment_fullname"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "is_self_contained": self_contained,
                 },
@@ -155,7 +152,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "is_structurally_complete",
                 {
-                    FEATURE_FILE_ID_COLUMN: comment["comment_fullname"],
+                    REDDIT_COLUMNS.feature_file_id_column: comment["comment_fullname"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "is_structurally_complete": structurally_complete,
                 },
@@ -163,7 +160,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "is_toxic_tiered",
                 {
-                    FEATURE_FILE_ID_COLUMN: comment["comment_fullname"],
+                    REDDIT_COLUMNS.feature_file_id_column: comment["comment_fullname"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "toxicity_prob": 0.1,
                     "toxicity_tier": "low",
@@ -172,7 +169,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "political_stance",
                 {
-                    FEATURE_FILE_ID_COLUMN: comment["comment_fullname"],
+                    REDDIT_COLUMNS.feature_file_id_column: comment["comment_fullname"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "political_stance": stance,
                 },
@@ -198,7 +195,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
 
     assert output_path.name == "mirrorview.csv"
     assert len(curated) == 1
-    assert curated.iloc[0][ID_COLUMN] == comment_keep["comment_fullname"]
+    assert curated.iloc[0][REDDIT_COLUMNS.records_id_column] == comment_keep["comment_fullname"]
     assert "body" in curated.columns
     assert metadata["row_counts"]["after_filters"] == 1
     assert len(metadata["filter_results"]) == 6
@@ -206,3 +203,10 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
         metadata["filter_results"][0]["records_before"]
         >= metadata["filter_results"][-1]["records_passing"]
     )
+
+
+def test_reddit_curate_cli_does_not_reexport_column_aliases() -> None:
+    import data_platform.curate.curate_reddit as reddit_curate
+
+    assert not hasattr(reddit_curate, "ID_COLUMN")
+    assert not hasattr(reddit_curate, "FEATURE_FILE_ID_COLUMN")

--- a/tests/data_platform/curate/test_curate_twitter.py
+++ b/tests/data_platform/curate/test_curate_twitter.py
@@ -5,11 +5,8 @@ from pathlib import Path
 import pandas as pd
 
 from data_platform.curate.consolidate import ConsolidateConfig, build_wide_table
-from data_platform.curate.curate_twitter import (
-    FEATURE_FILE_ID_COLUMN,
-    ID_COLUMN,
-    curate,
-)
+from data_platform.curate.curate_twitter import curate
+from data_platform.utils.platform_specific_columns import TWITTER_COLUMNS
 from data_platform.utils.storage import TwitterStorageManager
 from tests.data_platform.constants import LABEL_TIMESTAMP, VALID_TWITTER_DATASET_ID
 from tests.data_platform.ingestion.twitter_conftest import mock_tweet_row
@@ -36,12 +33,12 @@ def test_build_wide_table_joins_twitter_posts_on_tweet_id(tmp_path: Path) -> Non
         "is_political",
         [
             {
-                FEATURE_FILE_ID_COLUMN: post_a["tweet_id"],
+                TWITTER_COLUMNS.feature_file_id_column: post_a["tweet_id"],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "is_political": True,
             },
             {
-                FEATURE_FILE_ID_COLUMN: post_b["tweet_id"],
+                TWITTER_COLUMNS.feature_file_id_column: post_b["tweet_id"],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "is_political": False,
             },
@@ -52,12 +49,12 @@ def test_build_wide_table_joins_twitter_posts_on_tweet_id(tmp_path: Path) -> Non
         "is_news_or_opinion",
         [
             {
-                FEATURE_FILE_ID_COLUMN: post_a["tweet_id"],
+                TWITTER_COLUMNS.feature_file_id_column: post_a["tweet_id"],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "category": "opinion",
             },
             {
-                FEATURE_FILE_ID_COLUMN: post_b["tweet_id"],
+                TWITTER_COLUMNS.feature_file_id_column: post_b["tweet_id"],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "category": "news",
             },
@@ -68,12 +65,12 @@ def test_build_wide_table_joins_twitter_posts_on_tweet_id(tmp_path: Path) -> Non
         "is_likely_spam",
         [
             {
-                FEATURE_FILE_ID_COLUMN: post_a["tweet_id"],
+                TWITTER_COLUMNS.feature_file_id_column: post_a["tweet_id"],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "is_likely_spam": False,
             },
             {
-                FEATURE_FILE_ID_COLUMN: post_b["tweet_id"],
+                TWITTER_COLUMNS.feature_file_id_column: post_b["tweet_id"],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "is_likely_spam": True,
             },
@@ -85,15 +82,15 @@ def test_build_wide_table_joins_twitter_posts_on_tweet_id(tmp_path: Path) -> Non
             posts_file=posts_file,
             features_root=features_root,
             feature_names=("is_political", "is_news_or_opinion"),
-            id_column=ID_COLUMN,
-            feature_file_id_column=FEATURE_FILE_ID_COLUMN,
+            id_column=TWITTER_COLUMNS.records_id_column,
+            feature_file_id_column=TWITTER_COLUMNS.feature_file_id_column,
         )
     )
 
     assert len(wide) == 2
     assert "text" in wide.columns
     assert "news_or_opinion_category" in wide.columns
-    assert wide.loc[wide[ID_COLUMN] == post_a["tweet_id"], "is_political"].iloc[0] in {
+    assert wide.loc[wide[TWITTER_COLUMNS.records_id_column] == post_a["tweet_id"], "is_political"].iloc[0] in {
         True,
         "True",
     }
@@ -123,7 +120,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "is_political",
                 {
-                    FEATURE_FILE_ID_COLUMN: post["tweet_id"],
+                    TWITTER_COLUMNS.feature_file_id_column: post["tweet_id"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "is_political": political,
                 },
@@ -131,7 +128,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "is_news_or_opinion",
                 {
-                    FEATURE_FILE_ID_COLUMN: post["tweet_id"],
+                    TWITTER_COLUMNS.feature_file_id_column: post["tweet_id"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "category": category,
                 },
@@ -139,7 +136,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "is_likely_spam",
                 {
-                    FEATURE_FILE_ID_COLUMN: post["tweet_id"],
+                    TWITTER_COLUMNS.feature_file_id_column: post["tweet_id"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "is_likely_spam": post is post_drop,
                 },
@@ -147,7 +144,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "is_self_contained",
                 {
-                    FEATURE_FILE_ID_COLUMN: post["tweet_id"],
+                    TWITTER_COLUMNS.feature_file_id_column: post["tweet_id"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "is_self_contained": self_contained,
                 },
@@ -155,7 +152,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "is_structurally_complete",
                 {
-                    FEATURE_FILE_ID_COLUMN: post["tweet_id"],
+                    TWITTER_COLUMNS.feature_file_id_column: post["tweet_id"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "is_structurally_complete": structurally_complete,
                 },
@@ -163,7 +160,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "is_toxic_tiered",
                 {
-                    FEATURE_FILE_ID_COLUMN: post["tweet_id"],
+                    TWITTER_COLUMNS.feature_file_id_column: post["tweet_id"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "toxicity_prob": 0.1,
                     "toxicity_tier": "low",
@@ -172,7 +169,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
             (
                 "political_stance",
                 {
-                    FEATURE_FILE_ID_COLUMN: post["tweet_id"],
+                    TWITTER_COLUMNS.feature_file_id_column: post["tweet_id"],
                     "label_timestamp": LABEL_TIMESTAMP,
                     "political_stance": stance,
                 },
@@ -198,7 +195,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
 
     assert output_path.name == "mirrorview.csv"
     assert len(curated) == 1
-    assert str(curated.iloc[0][ID_COLUMN]) == post_keep["tweet_id"]
+    assert str(curated.iloc[0][TWITTER_COLUMNS.records_id_column]) == post_keep["tweet_id"]
     assert "text" in curated.columns
     assert metadata["row_counts"]["after_filters"] == 1
     assert len(metadata["filter_results"]) == 6
@@ -211,3 +208,10 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
         metadata["filter_results"][0]["records_before"]
         >= metadata["filter_results"][-1]["records_passing"]
     )
+
+
+def test_twitter_curate_cli_does_not_reexport_column_aliases() -> None:
+    import data_platform.curate.curate_twitter as twitter_curate
+
+    assert not hasattr(twitter_curate, "ID_COLUMN")
+    assert not hasattr(twitter_curate, "FEATURE_FILE_ID_COLUMN")

--- a/tests/data_platform/generate_features/test_generate_bluesky_features.py
+++ b/tests/data_platform/generate_features/test_generate_bluesky_features.py
@@ -4,10 +4,12 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import pandas as pd
 import pytest
 
-from data_platform.generate_features.generate_bluesky_features import generate_bluesky_features
+from data_platform.generate_features.generate_bluesky_features import (
+    BLUESKY_SPEC,
+    generate_bluesky_features,
+)
 from tests.data_platform.constants import VALID_DATASET_ID
 
 
@@ -27,7 +29,9 @@ def _write_preprocessed_run(
     return run_dir
 
 
-class TestFeatureGenGates:
+class TestGenerateBlueskyFeatures:
+    """Tests for generate_bluesky_features()."""
+
     def test_gate_fails_if_no_preprocessed_runs(self, data_root: Path) -> None:
         with pytest.raises(FileNotFoundError):
             generate_bluesky_features(VALID_DATASET_ID)
@@ -39,24 +43,34 @@ class TestFeatureGenGates:
         with pytest.raises(RuntimeError):
             generate_bluesky_features(VALID_DATASET_ID)
 
-
-class TestFeatureGeneration:
-    def test_generate_with_complete_preprocessed_runs(
+    def test_delegates_to_generate_platform_features(
         self, data_root: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _write_preprocessed_run(
             data_root, VALID_DATASET_ID, "2026_01_01-00:00:00", sync_status="completed"
         )
+        mock_generate = MagicMock(return_value={})
         monkeypatch.setattr(
-            "data_platform.generate_features.generate_bluesky_features.load_all_posts",
-            lambda *_: pd.DataFrame(),
-        )
-        mock_run = MagicMock(return_value={})
-        monkeypatch.setattr(
-            "data_platform.generate_features.generate_bluesky_features.run_feature_generation",
-            mock_run,
+            "data_platform.generate_features.generate_bluesky_features.generate_platform_features",
+            mock_generate,
         )
 
-        generate_bluesky_features(VALID_DATASET_ID)
+        generate_bluesky_features(
+            VALID_DATASET_ID,
+            batch_size=8,
+            max_concurrency=4,
+            opik_enabled=False,
+            feature_subset=["is_political"],
+        )
 
-        mock_run.assert_called_once()
+        mock_generate.assert_called_once_with(
+            BLUESKY_SPEC,
+            VALID_DATASET_ID,
+            batch_size=8,
+            max_concurrency=4,
+            opik_enabled=False,
+            feature_subset=["is_political"],
+        )
+
+    def test_require_all_runs_complete_is_on_spec(self) -> None:
+        assert BLUESKY_SPEC.require_all_runs_complete is True

--- a/tests/data_platform/generate_features/test_generate_features.py
+++ b/tests/data_platform/generate_features/test_generate_features.py
@@ -165,12 +165,12 @@ def test_generate_bluesky_features_defaults_to_opik_disabled(
         return {}
 
     monkeypatch.setattr(
-        "data_platform.generate_features.generate_bluesky_features.run_feature_generation",
+        "data_platform.generate_features.platform_cli.run_feature_generation",
         fake_run_feature_generation,
     )
     monkeypatch.setattr(
-        "data_platform.generate_features.generate_bluesky_features.load_all_posts",
-        lambda dataset_id: pd.DataFrame([{"uri": "1", "text": "hello"}]),
+        "data_platform.generate_features.platform_cli.load_preprocessed_records",
+        lambda spec, dataset_id: pd.DataFrame([{"uri": "1", "text": "hello"}]),
     )
     write_preprocessed_posts(data_root, sample_preprocessed_records(1))
 

--- a/tests/data_platform/generate_features/test_generate_features.py
+++ b/tests/data_platform/generate_features/test_generate_features.py
@@ -170,7 +170,7 @@ def test_generate_bluesky_features_defaults_to_opik_disabled(
     )
     monkeypatch.setattr(
         "data_platform.generate_features.platform_cli.load_preprocessed_records",
-        lambda spec, dataset_id: pd.DataFrame([{"uri": "1", "text": "hello"}]),
+        lambda _spec, _dataset_id: pd.DataFrame([{"uri": "1", "text": "hello"}]),
     )
     write_preprocessed_posts(data_root, sample_preprocessed_records(1))
 

--- a/tests/data_platform/generate_features/test_generate_reddit_features.py
+++ b/tests/data_platform/generate_features/test_generate_reddit_features.py
@@ -145,7 +145,7 @@ def test_generate_reddit_features_defaults_to_opik_disabled(monkeypatch) -> None
     )
     monkeypatch.setattr(
         "data_platform.generate_features.platform_cli.load_preprocessed_records",
-        lambda spec, dataset_id: pd.DataFrame([{REDDIT_COLUMNS.records_id_column: "1", REDDIT_COLUMNS.text_column: "hello"}]),
+        lambda _spec, _dataset_id: pd.DataFrame([{REDDIT_COLUMNS.records_id_column: "1", REDDIT_COLUMNS.text_column: "hello"}]),
     )
 
     generate_reddit_features(VALID_REDDIT_DATASET_ID)

--- a/tests/data_platform/generate_features/test_generate_reddit_features.py
+++ b/tests/data_platform/generate_features/test_generate_reddit_features.py
@@ -7,13 +7,11 @@ import pandas as pd
 
 from data_platform.generate_features.generate_features import generate_features
 from data_platform.generate_features.generate_reddit_features import (
-    FEATURE_FILE_ID_COLUMN,
-    ID_COLUMN,
-    TEXT_COLUMN,
     generate_reddit_features,
     load_comments,
     reddit_feature_config,
 )
+from data_platform.utils.platform_specific_columns import REDDIT_COLUMNS
 from data_platform.generate_features.metadata import flush_metadata, load_or_init_metadata
 from data_platform.generate_features.models import (
     BatchRunStats,
@@ -68,10 +66,10 @@ def test_reddit_feature_config_columns(data_root) -> None:
         run_config=FeatureRunConfig(opik_enabled=False),
     )
     assert config.platform == "reddit"
-    assert config.id_column == ID_COLUMN
-    assert config.text_column == TEXT_COLUMN
-    assert config.feature_label_query.id_column == ID_COLUMN
-    assert config.feature_label_query.feature_file_id_column == FEATURE_FILE_ID_COLUMN
+    assert config.id_column == REDDIT_COLUMNS.records_id_column
+    assert config.text_column == REDDIT_COLUMNS.text_column
+    assert config.feature_label_query.id_column == REDDIT_COLUMNS.records_id_column
+    assert config.feature_label_query.feature_file_id_column == REDDIT_COLUMNS.feature_file_id_column
     assert config.input_storage.platform == "reddit"
 
 
@@ -81,8 +79,8 @@ def test_load_comments_reads_all_preprocessed_runs(data_root) -> None:
 
     comments = load_comments(VALID_REDDIT_DATASET_ID)
     assert len(comments) == 2
-    assert ID_COLUMN in comments.columns
-    assert TEXT_COLUMN in comments.columns
+    assert REDDIT_COLUMNS.records_id_column in comments.columns
+    assert REDDIT_COLUMNS.text_column in comments.columns
 
 
 def test_generate_reddit_features_skips_completed_feature(
@@ -105,7 +103,7 @@ def test_generate_reddit_features_skips_completed_feature(
     pd.DataFrame(
         [
             {
-                FEATURE_FILE_ID_COLUMN: records[0][ID_COLUMN],
+                REDDIT_COLUMNS.feature_file_id_column: records[0][REDDIT_COLUMNS.records_id_column],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "is_political": True,
             }
@@ -147,8 +145,16 @@ def test_generate_reddit_features_defaults_to_opik_disabled(monkeypatch) -> None
     )
     monkeypatch.setattr(
         "data_platform.generate_features.platform_cli.load_preprocessed_records",
-        lambda spec, dataset_id: pd.DataFrame([{ID_COLUMN: "1", TEXT_COLUMN: "hello"}]),
+        lambda spec, dataset_id: pd.DataFrame([{REDDIT_COLUMNS.records_id_column: "1", REDDIT_COLUMNS.text_column: "hello"}]),
     )
 
     generate_reddit_features(VALID_REDDIT_DATASET_ID)
     assert captured["opik_enabled"] is False
+
+
+def test_reddit_feature_cli_does_not_reexport_column_aliases() -> None:
+    import data_platform.generate_features.generate_reddit_features as reddit_features
+
+    assert not hasattr(reddit_features, "ID_COLUMN")
+    assert not hasattr(reddit_features, "TEXT_COLUMN")
+    assert not hasattr(reddit_features, "FEATURE_FILE_ID_COLUMN")

--- a/tests/data_platform/generate_features/test_generate_twitter_features.py
+++ b/tests/data_platform/generate_features/test_generate_twitter_features.py
@@ -177,7 +177,7 @@ def test_generate_twitter_features_defaults_to_opik_disabled(monkeypatch) -> Non
     )
     monkeypatch.setattr(
         "data_platform.generate_features.platform_cli.load_preprocessed_records",
-        lambda spec, dataset_id: pd.DataFrame([{TWITTER_COLUMNS.records_id_column: "1", TWITTER_COLUMNS.text_column: "hello"}]),
+        lambda _spec, _dataset_id: pd.DataFrame([{TWITTER_COLUMNS.records_id_column: "1", TWITTER_COLUMNS.text_column: "hello"}]),
     )
 
     generate_twitter_features(VALID_TWITTER_DATASET_ID)

--- a/tests/data_platform/generate_features/test_generate_twitter_features.py
+++ b/tests/data_platform/generate_features/test_generate_twitter_features.py
@@ -7,13 +7,11 @@ import pandas as pd
 
 from data_platform.generate_features.generate_features import generate_features
 from data_platform.generate_features.generate_twitter_features import (
-    FEATURE_FILE_ID_COLUMN,
-    ID_COLUMN,
-    TEXT_COLUMN,
     generate_twitter_features,
     load_posts,
     twitter_feature_config,
 )
+from data_platform.utils.platform_specific_columns import TWITTER_COLUMNS
 from data_platform.generate_features.metadata import flush_metadata, load_or_init_metadata
 from data_platform.generate_features.models import (
     BatchRunStats,
@@ -63,10 +61,10 @@ def test_twitter_feature_config_columns(data_root) -> None:
         run_config=FeatureRunConfig(opik_enabled=False),
     )
     assert config.platform == "twitter"
-    assert config.id_column == ID_COLUMN
-    assert config.text_column == TEXT_COLUMN
-    assert config.feature_label_query.id_column == ID_COLUMN
-    assert config.feature_label_query.feature_file_id_column == FEATURE_FILE_ID_COLUMN
+    assert config.id_column == TWITTER_COLUMNS.records_id_column
+    assert config.text_column == TWITTER_COLUMNS.text_column
+    assert config.feature_label_query.id_column == TWITTER_COLUMNS.records_id_column
+    assert config.feature_label_query.feature_file_id_column == TWITTER_COLUMNS.feature_file_id_column
     assert config.input_storage.platform == "twitter"
 
 
@@ -76,8 +74,8 @@ def test_load_posts_reads_all_preprocessed_runs(data_root) -> None:
 
     posts = load_posts(VALID_TWITTER_DATASET_ID)
     assert len(posts) == 2
-    assert ID_COLUMN in posts.columns
-    assert TEXT_COLUMN in posts.columns
+    assert TWITTER_COLUMNS.records_id_column in posts.columns
+    assert TWITTER_COLUMNS.text_column in posts.columns
 
 
 def test_filter_unlabeled_matches_tweet_id_to_feature_uri_column(data_root) -> None:
@@ -94,7 +92,7 @@ def test_filter_unlabeled_matches_tweet_id_to_feature_uri_column(data_root) -> N
     pd.DataFrame(
         [
             {
-                FEATURE_FILE_ID_COLUMN: tweet_labeled,
+                TWITTER_COLUMNS.feature_file_id_column: tweet_labeled,
                 "label_timestamp": LABEL_TIMESTAMP,
                 "is_political": True,
             }
@@ -103,18 +101,18 @@ def test_filter_unlabeled_matches_tweet_id_to_feature_uri_column(data_root) -> N
 
     records = pd.DataFrame(
         [
-            {ID_COLUMN: tweet_labeled, TEXT_COLUMN: mock_tweet_row(tweet_labeled)["text"]},
-            {ID_COLUMN: tweet_keep, TEXT_COLUMN: mock_tweet_row(tweet_keep)["text"]},
+            {TWITTER_COLUMNS.records_id_column: tweet_labeled, TWITTER_COLUMNS.text_column: mock_tweet_row(tweet_labeled)["text"]},
+            {TWITTER_COLUMNS.records_id_column: tweet_keep, TWITTER_COLUMNS.text_column: mock_tweet_row(tweet_keep)["text"]},
         ]
     )
     query = FeatureLabelQuery(
         feature_storage=feature_storage,
-        id_column=ID_COLUMN,
-        feature_file_id_column=FEATURE_FILE_ID_COLUMN,
+        id_column=TWITTER_COLUMNS.records_id_column,
+        feature_file_id_column=TWITTER_COLUMNS.feature_file_id_column,
     )
     pending = query.filter_unlabeled(records, "is_political")
     assert len(pending) == 1
-    assert pending.iloc[0][ID_COLUMN] == tweet_keep
+    assert pending.iloc[0][TWITTER_COLUMNS.records_id_column] == tweet_keep
 
 
 def test_generate_twitter_features_skips_completed_feature(
@@ -137,7 +135,7 @@ def test_generate_twitter_features_skips_completed_feature(
     pd.DataFrame(
         [
             {
-                FEATURE_FILE_ID_COLUMN: records[0][ID_COLUMN],
+                TWITTER_COLUMNS.feature_file_id_column: records[0][TWITTER_COLUMNS.records_id_column],
                 "label_timestamp": LABEL_TIMESTAMP,
                 "is_political": True,
             }
@@ -179,8 +177,16 @@ def test_generate_twitter_features_defaults_to_opik_disabled(monkeypatch) -> Non
     )
     monkeypatch.setattr(
         "data_platform.generate_features.platform_cli.load_preprocessed_records",
-        lambda spec, dataset_id: pd.DataFrame([{ID_COLUMN: "1", TEXT_COLUMN: "hello"}]),
+        lambda spec, dataset_id: pd.DataFrame([{TWITTER_COLUMNS.records_id_column: "1", TWITTER_COLUMNS.text_column: "hello"}]),
     )
 
     generate_twitter_features(VALID_TWITTER_DATASET_ID)
     assert captured["opik_enabled"] is False
+
+
+def test_twitter_feature_cli_does_not_reexport_column_aliases() -> None:
+    import data_platform.generate_features.generate_twitter_features as twitter_features
+
+    assert not hasattr(twitter_features, "ID_COLUMN")
+    assert not hasattr(twitter_features, "TEXT_COLUMN")
+    assert not hasattr(twitter_features, "FEATURE_FILE_ID_COLUMN")

--- a/tests/data_platform/generate_features/test_langchain_engine.py
+++ b/tests/data_platform/generate_features/test_langchain_engine.py
@@ -33,7 +33,6 @@ def test_langchain_batch_engine_writes_rows(monkeypatch: pytest.MonkeyPatch) -> 
         name="test_feature",
         model=_RowModel,
         engine_type="langchain",
-        generate_fn=lambda uri, text: _RowModel(uri=uri, label_timestamp="t", score=True),
         system_prompt="test",
         llm_output_schema=_LlmOut,
     )
@@ -46,3 +45,14 @@ def test_langchain_batch_engine_writes_rows(monkeypatch: pytest.MonkeyPatch) -> 
     assert len(labels) == 2
     assert labels[0]["uri"] == URI_POST_A
     assert "label_timestamp" in labels[0]
+
+
+def test_langchain_registry_specs_omit_generate_fn() -> None:
+    from data_platform.generate_features.registry import FEATURE_REGISTRY
+
+    for spec in FEATURE_REGISTRY.values():
+        if spec.engine_type == "langchain":
+            assert spec.generate_fn is None
+        else:
+            assert spec.generate_fn is not None
+

--- a/tests/data_platform/generate_features/test_thread_pool_engine.py
+++ b/tests/data_platform/generate_features/test_thread_pool_engine.py
@@ -41,7 +41,6 @@ def test_thread_pool_batch_engine_requires_generate_fn() -> None:
         model=_RowModel,
         engine_type="thread_pool",
     )
-    engine = ThreadPoolBatchEngine(spec, FeatureRunConfig(max_concurrency=1))
     with pytest.raises(ValueError, match="generate_fn"):
-        engine.batch_label_records([LabelTask(uri=URI_POST_A, text="hi")])
+        ThreadPoolBatchEngine(spec, FeatureRunConfig(max_concurrency=1))
 

--- a/tests/data_platform/generate_features/test_thread_pool_engine.py
+++ b/tests/data_platform/generate_features/test_thread_pool_engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from pydantic import BaseModel
 
 from data_platform.generate_features.engines.thread_pool_engine import ThreadPoolBatchEngine
@@ -32,3 +33,15 @@ def test_thread_pool_batch_engine_labels_tasks() -> None:
     assert len(labels) == 2
     assert labels[0]["value"] == 2
     assert labels[1]["value"] == 3
+
+
+def test_thread_pool_batch_engine_requires_generate_fn() -> None:
+    spec = FeatureSpec(
+        name="test_feature",
+        model=_RowModel,
+        engine_type="thread_pool",
+    )
+    engine = ThreadPoolBatchEngine(spec, FeatureRunConfig(max_concurrency=1))
+    with pytest.raises(ValueError, match="generate_fn"):
+        engine.batch_label_records([LabelTask(uri=URI_POST_A, text="hi")])
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #73

## Summary

Bluesky feature generation and curation now call the same platform command-line scripts that Reddit and Twitter already call. Bluesky still checks that feature labeling finished, that every preprocess run finished, and that it can skip work when nothing changed. Those checks live as flags on the Bluesky settings object.

## Purpose

The old Bluesky scripts copied helper functions that the Reddit and Twitter scripts already call. `generate_bluesky_features` reimplemented `generate_platform_features`, and `curate_bluesky` wrapped `run_curation` instead of `curate_with_spec`. Tests imported column-name constants that the platform scripts only re-exported for tests. LangChain feature settings also set `generate_fn`, even though `LangChainBatchEngine` never calls that function.

This change makes the Bluesky scripts call the shared command-line helpers and settings objects, and it deletes the copied functions. Ingest work for the other platforms is not part of this change.

## Architecture

Components:

- Each platform feature script calls `generate_platform_features`.
- Bluesky sets `require_all_runs_complete` on `FeaturePlatformSpec`.
- Each platform curate script calls `curate_with_spec` through `make_curate_cli`.
- Bluesky sets the completeness and skip flags on `CuratePlatformSpec`. Reddit and Twitter set those flags to false.
- LangChain feature settings omit `generate_fn`, because the LangChain batch engine does not use that function.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    B1[generate_bluesky_features] --> Dup[Copied generate_platform_features body]
    C1[curate_bluesky] --> Local[Local completeness and skip checks]
    C1 --> R1[run_curation]
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    B2[generate_bluesky_features] --> G[generate_platform_features]
    C2[curate_bluesky] --> S[curate_with_spec]
    S -->|flags| Gates[Completeness and skip]
    S --> R2[run_curation]
  end
```

## Interfaces

### Data / schema contracts

| Field | Type | Notes |
| ----- | ---- | ----- |
| `FeatureSpec.generate_fn` | `FeatureFn \| None` | The thread-pool engine needs this function. LangChain settings leave it unset. |
| `CuratePlatformSpec.require_features_complete` | `bool` | Bluesky sets this true so curation fails if feature labeling is incomplete. Reddit and Twitter set it false. |
| `CuratePlatformSpec.require_all_runs_complete` | `bool` | Bluesky sets this true so curation fails if a preprocess run is incomplete. Reddit and Twitter set it false. |
| `CuratePlatformSpec.skip_if_up_to_date` | `bool` | Bluesky sets this true so curation returns the existing export when inputs have not changed. Reddit and Twitter set it false. |
| `FeaturePlatformSpec.require_all_runs_complete` | `bool` | Bluesky sets this true so feature generation fails if a preprocess run is incomplete. |

`curate_with_spec` returns the path of the curated export CSV. If the skip flag is on and the inputs have not changed, it returns the path of the export that already exists.

Platform CLI modules no longer re-export `ID_COLUMN` / `TEXT_COLUMN` / `FEATURE_FILE_ID_COLUMN`. Callers and tests read `BLUESKY_COLUMNS` / `REDDIT_COLUMNS` / `TWITTER_COLUMNS`.

## How to run

```bash
PYTHONPATH=. uv run pytest tests/data_platform/generate_features tests/data_platform/curate tests/data_platform/preprocessing -q
```

Expected: all tests in those directories pass.

Bluesky CLI entrypoints are unchanged:

```bash
PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py --dataset-id bluesky_<uuid>
PYTHONPATH=. uv run python data_platform/curate/curate_bluesky.py --dataset-id bluesky_<uuid> --config mirrorview.yaml
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ceaca076-8513-4957-a8f9-24a143729a0c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceaca076-8513-4957-a8f9-24a143729a0c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared curation workflows with dataset completeness checks and reuse of current exports when source data and rules are unchanged.
  - Bluesky curation now verifies feature and run completeness and skips up-to-date datasets.
  - Feature generation supports both language-model-based and row-level generation methods.
  - Platform processing now uses consistent shared workflows across Bluesky, Reddit, and Twitter.

- **Bug Fixes**
  - Improved validation for feature-generation configurations and execution reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->