### PR TITLE
Add a shared text column during preprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2026-09-02
+
+1. Preprocess writes a canonical `text` column on kept Bluesky, Twitter, and Reddit-comment rows, and Reddit features now read that column while native `body` stays on the record for audit. [PR #91](https://github.com/METResearchGroup/mirrorView-task/pull/91)
+
 ## 2026-09-01
 
 1. Shared preprocessing, feature, and curation runners now take `PlatformSpecificColumns` on `spec.columns` instead of the overloaded `PlatformIdBinding` name, so per-platform CSV column maps read as what they are. [PR #65](https://github.com/METResearchGroup/mirrorView-task/pull/65)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-02
 
-1. Preprocess writes a canonical `text` column on kept Bluesky, Twitter, and Reddit-comment rows, and Reddit features now read that column while native `body` stays on the record for audit. [PR #91](https://github.com/METResearchGroup/mirrorView-task/pull/91)
+1. The preprocess step adds a shared `text` column on Bluesky, Twitter, and Reddit comment rows that pass the filters. Reddit feature code now reads that column, and the original `body` field is still on the record so you can check it. [PR #91](https://github.com/METResearchGroup/mirrorView-task/pull/91)
 
 ## 2026-09-01
 

--- a/data_platform/generate_features/generate_reddit_features.py
+++ b/data_platform/generate_features/generate_reddit_features.py
@@ -19,14 +19,14 @@ from data_platform.generate_features.platform_cli import (
     generate_platform_features,
     load_preprocessed_records,
 )
-from data_platform.models.sync import SyncRedditCommentModel
+from data_platform.models.sync import PreprocessedRedditCommentModel
 from data_platform.utils.platform_specific_columns import REDDIT_COLUMNS
 from data_platform.utils.storage import RedditStorageManager
 
 REDDIT_SPEC = FeaturePlatformSpec(
     platform="reddit",
     storage_cls=RedditStorageManager,
-    model_cls=SyncRedditCommentModel,
+    model_cls=PreprocessedRedditCommentModel,
     columns=REDDIT_COLUMNS,
     empty_message="generate_reddit_features: no preprocessed comments found",
 )

--- a/data_platform/models/sync.py
+++ b/data_platform/models/sync.py
@@ -73,6 +73,10 @@ class SyncRedditCommentModel(BaseModel):
 
 
 class PreprocessedRedditCommentModel(SyncRedditCommentModel):
-    """Reddit comment after preprocess: native ``body`` plus canonical ``text``."""
+    """Preprocessed Reddit comment with native ``body`` and canonical ``text``.
+
+    Raw ingest still uses ``SyncRedditCommentModel``. This model is the
+    preprocessed CSV contract so feature generation can read ``text``.
+    """
 
     text: str

--- a/data_platform/models/sync.py
+++ b/data_platform/models/sync.py
@@ -70,3 +70,9 @@ class SyncRedditCommentModel(BaseModel):
     depth: int
     comment_rank: int
     sync_timestamp: str
+
+
+class PreprocessedRedditCommentModel(SyncRedditCommentModel):
+    """Reddit comment after preprocess: native ``body`` plus canonical ``text``."""
+
+    text: str

--- a/data_platform/models/sync.py
+++ b/data_platform/models/sync.py
@@ -73,10 +73,10 @@ class SyncRedditCommentModel(BaseModel):
 
 
 class PreprocessedRedditCommentModel(SyncRedditCommentModel):
-    """Preprocessed Reddit comment with native ``body`` and canonical ``text``.
+    """A Reddit comment after preprocess, with original body and shared text.
 
-    Raw ingest still uses ``SyncRedditCommentModel``. This model is the
-    preprocessed CSV contract so feature generation can read ``text``.
+    Raw ingest still uses ``SyncRedditCommentModel``. Feature generation reads
+    ``text`` from the preprocessed CSV described by this model.
     """
 
     text: str

--- a/data_platform/preprocessing/preprocess_reddit.py
+++ b/data_platform/preprocessing/preprocess_reddit.py
@@ -42,7 +42,10 @@ from data_platform.preprocessing.validators.validators import (
     check_if_not_phone,
     check_if_text_english,
 )
-from data_platform.utils.platform_specific_columns import REDDIT_COLUMNS
+from data_platform.utils.platform_specific_columns import (
+    REDDIT_COLUMNS,
+    REDDIT_NATIVE_TEXT_COLUMN,
+)
 from data_platform.utils.storage import RedditStorageManager
 
 COMMENT_TEXT_VALIDATORS: tuple[TextValidator, ...] = (
@@ -64,6 +67,7 @@ REDDIT_SPEC = PreprocessPlatformSpec(
     columns=REDDIT_COLUMNS,
     text_validators=COMMENT_TEXT_VALIDATORS,
     row_validators=COMMENT_ROW_VALIDATORS,
+    native_text_column=REDDIT_NATIVE_TEXT_COLUMN,
 )
 
 
@@ -93,6 +97,7 @@ def filter_comments(
         columns=REDDIT_SPEC.columns,
         text_validators=tuple(text_validators),
         row_validators=tuple(row_validators),
+        native_text_column=REDDIT_SPEC.native_text_column,
     )
     return filter_records(comments, spec)
 

--- a/data_platform/preprocessing/preprocess_reddit.py
+++ b/data_platform/preprocessing/preprocess_reddit.py
@@ -44,7 +44,7 @@ from data_platform.preprocessing.validators.validators import (
 )
 from data_platform.utils.platform_specific_columns import (
     REDDIT_COLUMNS,
-    REDDIT_NATIVE_TEXT_COLUMN,
+    REDDIT_ORIGINAL_PLATFORM_TEXT_COLUMN,
 )
 from data_platform.utils.storage import RedditStorageManager
 
@@ -67,7 +67,7 @@ REDDIT_SPEC = PreprocessPlatformSpec(
     columns=REDDIT_COLUMNS,
     text_validators=COMMENT_TEXT_VALIDATORS,
     row_validators=COMMENT_ROW_VALIDATORS,
-    native_text_column=REDDIT_NATIVE_TEXT_COLUMN,
+    original_platform_text_column=REDDIT_ORIGINAL_PLATFORM_TEXT_COLUMN,
 )
 
 
@@ -97,7 +97,7 @@ def filter_comments(
         columns=REDDIT_SPEC.columns,
         text_validators=tuple(text_validators),
         row_validators=tuple(row_validators),
-        native_text_column=REDDIT_SPEC.native_text_column,
+        original_platform_text_column=REDDIT_SPEC.original_platform_text_column,
     )
     return filter_records(comments, spec)
 

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -86,17 +86,18 @@ def filter_records(df: pd.DataFrame, spec: PreprocessPlatformSpec) -> pd.DataFra
     if df.empty:
         return df.copy()
 
+    prepared = add_canonical_text_column(df, spec)
     text_col = spec.columns.text_column
-    text_mask = df[text_col].map(
+    text_mask = prepared[text_col].map(
         lambda value: passes_all_validators(str(value), spec.text_validators)
     )
     if not spec.row_validators:
-        return df.loc[text_mask].reset_index(drop=True)
+        return prepared.loc[text_mask].reset_index(drop=True)
 
-    author_mask = df[AUTHOR_COLUMN].map(
+    author_mask = prepared[AUTHOR_COLUMN].map(
         lambda value: passes_row_validators(str(value), spec.row_validators)
     )
-    return df.loc[text_mask & author_mask].reset_index(drop=True)
+    return prepared.loc[text_mask & author_mask].reset_index(drop=True)
 
 
 def _rows_to_validated_dicts(

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -43,16 +43,16 @@ def add_canonical_text_column(
     df: pd.DataFrame,
     spec: PreprocessPlatformSpec,
 ) -> pd.DataFrame:
-    """Copy native post or comment text onto the shared ``text`` column.
+    """Copy the platform's original post or comment text onto the shared ``text`` column.
 
-    Native fields such as Reddit ``body`` stay on the frame for audit.
-    The input frame is not modified.
+    You still have original fields such as Reddit ``body`` on the returned frame.
+    The function does not modify the input frame.
 
     Parameters
     ----------
     spec
         ``native_text_column`` is the copy source. The destination is always
-        canonical ``text``.
+        shared ``text``.
 
     Returns
     -------
@@ -102,7 +102,9 @@ def filter_records(df: pd.DataFrame, spec: PreprocessPlatformSpec) -> pd.DataFra
     if df.empty:
         return df.copy()
 
-    prepared = add_canonical_text_column(df, spec)
+    prepared = df
+    if spec.columns.text_column not in df.columns:
+        prepared = add_canonical_text_column(df, spec)
     text_col = spec.columns.text_column
     text_mask = prepared[text_col].map(
         lambda value: passes_all_validators(str(value), spec.text_validators)

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -209,6 +209,7 @@ def preprocess_records(
         records, spec.columns.records_id_column, dedupe_session.seen_ids
     )
 
+    records = add_canonical_text_column(records, spec)
     preprocessed = apply_text_transform(records, spec)
     preprocessed = filter_records(preprocessed, spec)
     output_dir = save_preprocessed(

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -46,8 +46,12 @@ def add_canonical_text_column(
     """Copy native post or comment text onto the shared ``text`` column.
 
     Native fields stay on the frame. Downstream stages read ``spec.columns.text_column``.
+    The input frame is not modified.
     """
-    raise NotImplementedError
+    out = df.copy()
+    native_text = out[spec.native_text_column]
+    out[CANONICAL_TEXT_COLUMN] = native_text.map(lambda value: str(value))
+    return out
 
 
 def apply_text_transform(

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -13,7 +13,10 @@ from pydantic import BaseModel
 from data_platform.utils.dataset import dataset_root, relative_run_path, validate_dataset_id
 from data_platform.utils.deduplication import DedupeConfig, DedupeSession
 from data_platform.utils.gate_checks import require_all_runs_complete
-from data_platform.utils.platform_specific_columns import PlatformSpecificColumns
+from data_platform.utils.platform_specific_columns import (
+    CANONICAL_TEXT_COLUMN,
+    PlatformSpecificColumns,
+)
 from data_platform.utils.storage import StorageManager, StorageStage
 
 TextValidator = Callable[[str], bool]
@@ -33,6 +36,7 @@ class PreprocessPlatformSpec:
     text_validators: tuple[TextValidator, ...]
     row_validators: tuple[RowValidator, ...] = ()
     text_transform: Callable[[str], str] | None = None
+    native_text_column: str = CANONICAL_TEXT_COLUMN
 
 
 def add_canonical_text_column(

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -35,7 +35,7 @@ class PreprocessPlatformSpec:
     text_validators: tuple[TextValidator, ...]
     row_validators: tuple[RowValidator, ...] = ()
     text_transform: Callable[[str], str] | None = None
-    native_text_column: str = CANONICAL_TEXT_COLUMN
+    original_platform_text_column: str = CANONICAL_TEXT_COLUMN
 
 
 def add_canonical_text_column(
@@ -50,8 +50,8 @@ def add_canonical_text_column(
     Parameters
     ----------
     spec
-        ``native_text_column`` is the copy source. The destination is always
-        shared ``text``.
+        ``original_platform_text_column`` is the copy source. The destination is
+        always shared ``text``.
 
     Returns
     -------
@@ -61,11 +61,11 @@ def add_canonical_text_column(
     Raises
     ------
     KeyError
-        When ``spec.native_text_column`` is missing from the frame.
+        When ``spec.original_platform_text_column`` is missing from the frame.
     """
     out = df.copy()
-    native_text = out[spec.native_text_column]
-    out[CANONICAL_TEXT_COLUMN] = native_text.map(lambda value: str(value))
+    original_platform_text = out[spec.original_platform_text_column]
+    out[CANONICAL_TEXT_COLUMN] = original_platform_text.map(lambda value: str(value))
     return out
 
 

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -35,6 +35,17 @@ class PreprocessPlatformSpec:
     text_transform: Callable[[str], str] | None = None
 
 
+def add_canonical_text_column(
+    df: pd.DataFrame,
+    spec: PreprocessPlatformSpec,
+) -> pd.DataFrame:
+    """Copy native post or comment text onto the shared ``text`` column.
+
+    Native fields stay on the frame. Downstream stages read ``spec.columns.text_column``.
+    """
+    raise NotImplementedError
+
+
 def apply_text_transform(
     df: pd.DataFrame,
     spec: PreprocessPlatformSpec,

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -45,8 +45,24 @@ def add_canonical_text_column(
 ) -> pd.DataFrame:
     """Copy native post or comment text onto the shared ``text`` column.
 
-    Native fields stay on the frame. Downstream stages read ``spec.columns.text_column``.
+    Native fields such as Reddit ``body`` stay on the frame for audit.
     The input frame is not modified.
+
+    Parameters
+    ----------
+    spec
+        ``native_text_column`` is the copy source. The destination is always
+        canonical ``text``.
+
+    Returns
+    -------
+    pd.DataFrame
+        A new frame that includes ``text``.
+
+    Raises
+    ------
+    KeyError
+        When ``spec.native_text_column`` is missing from the frame.
     """
     out = df.copy()
     native_text = out[spec.native_text_column]

--- a/data_platform/utils/platform_specific_columns.py
+++ b/data_platform/utils/platform_specific_columns.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 CANONICAL_TEXT_COLUMN = "text"
-REDDIT_NATIVE_TEXT_COLUMN = "body"
+REDDIT_ORIGINAL_PLATFORM_TEXT_COLUMN = "body"
 
 
 @dataclass(frozen=True)
@@ -17,7 +17,7 @@ class PlatformSpecificColumns:
     (``BLUESKY_COLUMNS``, ``REDDIT_COLUMNS``, ``TWITTER_COLUMNS``) so those
     runners can resolve:
 
-    - ``records_id_column``: native unique id on the record CSV (dedupe / joins)
+    - ``records_id_column``: original platform unique id on the record CSV (dedupe / joins)
     - ``text_column``: shared body text (``text``) to validate, transform, and embed
     - ``feature_file_id_column``: id column written in feature files (often ``uri``)
     - ``records_file_key``: metadata / log noun for the file (``posts`` vs ``comments``)

--- a/data_platform/utils/platform_specific_columns.py
+++ b/data_platform/utils/platform_specific_columns.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+CANONICAL_TEXT_COLUMN = "text"
+REDDIT_NATIVE_TEXT_COLUMN = "body"
+
 
 @dataclass(frozen=True)
 class PlatformSpecificColumns:
@@ -28,7 +31,7 @@ class PlatformSpecificColumns:
 
 BLUESKY_COLUMNS = PlatformSpecificColumns(
     records_id_column="uri",
-    text_column="text",
+    text_column=CANONICAL_TEXT_COLUMN,
     feature_file_id_column="uri",
     records_file_key="posts",
 )
@@ -42,7 +45,7 @@ REDDIT_COLUMNS = PlatformSpecificColumns(
 
 TWITTER_COLUMNS = PlatformSpecificColumns(
     records_id_column="tweet_id",
-    text_column="text",
+    text_column=CANONICAL_TEXT_COLUMN,
     feature_file_id_column="uri",
     records_file_key="posts",
 )

--- a/data_platform/utils/platform_specific_columns.py
+++ b/data_platform/utils/platform_specific_columns.py
@@ -18,7 +18,7 @@ class PlatformSpecificColumns:
     runners can resolve:
 
     - ``records_id_column``: native unique id on the record CSV (dedupe / joins)
-    - ``text_column``: body text to validate, transform, and embed
+    - ``text_column``: canonical body text (``text``) to validate, transform, and embed
     - ``feature_file_id_column``: id column written in feature files (often ``uri``)
     - ``records_file_key``: metadata / log noun for the file (``posts`` vs ``comments``)
     """
@@ -38,7 +38,7 @@ BLUESKY_COLUMNS = PlatformSpecificColumns(
 
 REDDIT_COLUMNS = PlatformSpecificColumns(
     records_id_column="comment_fullname",
-    text_column="body",
+    text_column=CANONICAL_TEXT_COLUMN,
     feature_file_id_column="uri",
     records_file_key="comments",
 )

--- a/data_platform/utils/platform_specific_columns.py
+++ b/data_platform/utils/platform_specific_columns.py
@@ -18,7 +18,7 @@ class PlatformSpecificColumns:
     runners can resolve:
 
     - ``records_id_column``: native unique id on the record CSV (dedupe / joins)
-    - ``text_column``: canonical body text (``text``) to validate, transform, and embed
+    - ``text_column``: shared body text (``text``) to validate, transform, and embed
     - ``feature_file_id_column``: id column written in feature files (often ``uri``)
     - ``records_file_key``: metadata / log noun for the file (``posts`` vs ``comments``)
     """

--- a/data_platform/utils/storage.py
+++ b/data_platform/utils/storage.py
@@ -11,6 +11,7 @@ import pandas as pd
 from pydantic import BaseModel
 
 from data_platform.models.sync import (
+    PreprocessedRedditCommentModel,
     SyncBlueskyPostModel,
     SyncRedditCommentModel,
     SyncRedditPostModel,
@@ -330,10 +331,14 @@ class RedditStorageManager(StorageManager):
         records_filename: str = "comments.csv",
         model: type[BaseModel] | None = None,
     ) -> None:
+        if model is None and stage == StorageStage.PREPROCESSED:
+            resolved_model: type[BaseModel] = PreprocessedRedditCommentModel
+        else:
+            resolved_model = model or SyncRedditCommentModel
         super().__init__(
             "reddit",
             stage,
-            model or SyncRedditCommentModel,
+            resolved_model,
             dataset_id,
             records_filename=records_filename,
         )

--- a/tests/data_platform/generate_features/test_generate_reddit_features.py
+++ b/tests/data_platform/generate_features/test_generate_reddit_features.py
@@ -21,6 +21,7 @@ from data_platform.generate_features.models import (
     FeatureSpec,
     FeatureStatus,
 )
+from data_platform.utils.platform_specific_columns import CANONICAL_TEXT_COLUMN
 from tests.data_platform.constants import LABEL_TIMESTAMP, VALID_REDDIT_DATASET_ID
 from tests.data_platform.generate_features.conftest import DummyModel
 from tests.data_platform.ingestion.reddit_conftest import mock_comment_row
@@ -70,6 +71,7 @@ def test_reddit_feature_config_columns(data_root) -> None:
     assert config.platform == "reddit"
     assert config.id_column == ID_COLUMN
     assert config.text_column == TEXT_COLUMN
+    assert TEXT_COLUMN == CANONICAL_TEXT_COLUMN
     assert config.feature_label_query.id_column == ID_COLUMN
     assert config.feature_label_query.feature_file_id_column == FEATURE_FILE_ID_COLUMN
     assert config.input_storage.platform == "reddit"

--- a/tests/data_platform/generate_features/test_generate_reddit_features.py
+++ b/tests/data_platform/generate_features/test_generate_reddit_features.py
@@ -28,13 +28,16 @@ from tests.data_platform.ingestion.reddit_conftest import mock_comment_row
 
 
 def _sample_preprocessed_comments(count: int = 1) -> list[dict[str, Any]]:
-    return [
+    rows = [
         mock_comment_row(
             f"t1_comment_{index}",
             subreddit="politics",
         )
         for index in range(count)
     ]
+    for row in rows:
+        row["text"] = row["body"]
+    return rows
 
 
 def write_preprocessed_comments(

--- a/tests/data_platform/preprocessing/test_add_canonical_text_column.py
+++ b/tests/data_platform/preprocessing/test_add_canonical_text_column.py
@@ -15,7 +15,7 @@ class TestAddCanonicalTextColumn:
     """Tests for add_canonical_text_column()."""
 
     def test_copies_reddit_body_onto_text_and_keeps_body(self) -> None:
-        """Reddit comments get canonical text equal to native body."""
+        """Reddit comments get shared text equal to original body."""
         body = "This is a clear English comment about policy and governance."
         source = pd.DataFrame([mock_comment_row("t1_keep", subreddit="politics")])
         source.loc[0, "body"] = body
@@ -36,8 +36,8 @@ class TestAddCanonicalTextColumn:
 
         assert result.iloc[0][CANONICAL_TEXT_COLUMN] == text
 
-    def test_raises_when_native_text_column_is_missing(self) -> None:
-        """Missing native text is a caller error, not a silent empty column."""
+    def test_raises_when_original_platform_text_column_is_missing(self) -> None:
+        """Missing original platform text is a caller error, not a silent empty column."""
         source = pd.DataFrame([{"comment_fullname": "t1_missing"}])
 
         with pytest.raises(KeyError):

--- a/tests/data_platform/preprocessing/test_add_canonical_text_column.py
+++ b/tests/data_platform/preprocessing/test_add_canonical_text_column.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from data_platform.preprocessing.preprocess_reddit import REDDIT_SPEC
+from data_platform.preprocessing.preprocess_twitter import TWITTER_SPEC
+from data_platform.preprocessing.runner import add_canonical_text_column
+from data_platform.utils.platform_specific_columns import CANONICAL_TEXT_COLUMN
+from tests.data_platform.ingestion.reddit_conftest import mock_comment_row
+from tests.data_platform.ingestion.twitter_conftest import mock_tweet_row
+
+
+class TestAddCanonicalTextColumn:
+    """Tests for add_canonical_text_column()."""
+
+    def test_copies_reddit_body_onto_text_and_keeps_body(self) -> None:
+        """Reddit comments get canonical text equal to native body."""
+        body = "This is a clear English comment about policy and governance."
+        source = pd.DataFrame([mock_comment_row("t1_keep", subreddit="politics")])
+        source.loc[0, "body"] = body
+
+        result = add_canonical_text_column(source, REDDIT_SPEC)
+
+        assert result.iloc[0][CANONICAL_TEXT_COLUMN] == body
+        assert result.iloc[0]["body"] == body
+        assert CANONICAL_TEXT_COLUMN not in source.columns
+
+    def test_keeps_existing_twitter_text(self) -> None:
+        """Twitter rows already store text; the helper leaves that value in place."""
+        text = "This is a valid English tweet for preprocessing tests without external URLs."
+        source = pd.DataFrame([mock_tweet_row("1000000000000000001")])
+        source.loc[0, "text"] = text
+
+        result = add_canonical_text_column(source, TWITTER_SPEC)
+
+        assert result.iloc[0][CANONICAL_TEXT_COLUMN] == text
+
+    def test_raises_when_native_text_column_is_missing(self) -> None:
+        """Missing native text is a caller error, not a silent empty column."""
+        source = pd.DataFrame([{"comment_fullname": "t1_missing"}])
+
+        with pytest.raises(KeyError):
+            add_canonical_text_column(source, REDDIT_SPEC)

--- a/tests/data_platform/preprocessing/test_preprocess_bluesky.py
+++ b/tests/data_platform/preprocessing/test_preprocess_bluesky.py
@@ -70,7 +70,7 @@ class TestPreprocessRecordsCanonicalText:
     """Tests that Bluesky preprocess output includes canonical text."""
 
     def test_preprocessed_rows_include_text(self, data_root: Path) -> None:
-        """Kept Bluesky posts still have their native text column."""
+        """Kept Bluesky posts still have their original platform text column."""
         dataset_id = VALID_DATASET_ID
         raw_storage = BlueskyStorageManager(StorageStage.RAW, dataset_id)
         run_dir = raw_storage.create_new_run_dir("2026_05_31-10:00:00")

--- a/tests/data_platform/preprocessing/test_preprocess_bluesky.py
+++ b/tests/data_platform/preprocessing/test_preprocess_bluesky.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from data_platform.preprocessing.preprocess_bluesky import preprocess_records
+from data_platform.utils.storage import BlueskyStorageManager, StorageStage
+from tests.data_platform.conftest import make_post_row
 from tests.data_platform.constants import VALID_DATASET_ID
 
 
@@ -56,3 +58,35 @@ class TestPreprocessRun:
 
         mock_run.assert_called_once()
         assert result == expected
+
+
+VALID_BLUESKY_POST_TEXT = (
+    "This is a valid English bluesky post for preprocessing tests without any "
+    "links and with enough words that length and language checks both pass here."
+)
+
+
+class TestPreprocessRecordsCanonicalText:
+    """Tests that Bluesky preprocess output includes canonical text."""
+
+    def test_preprocessed_rows_include_text(self, data_root: Path) -> None:
+        """Kept Bluesky posts still have their native text column."""
+        dataset_id = VALID_DATASET_ID
+        raw_storage = BlueskyStorageManager(StorageStage.RAW, dataset_id)
+        run_dir = raw_storage.create_new_run_dir("2026_05_31-10:00:00")
+        raw_storage.write_records(
+            [make_post_row(text=VALID_BLUESKY_POST_TEXT)],
+            run_dir,
+        )
+        raw_storage.write_run_metadata(
+            run_dir,
+            {"sync_status": "completed", "row_count": 1},
+        )
+
+        output_dir = preprocess_records(dataset_id)
+        output = BlueskyStorageManager(StorageStage.PREPROCESSED, dataset_id).load_records(
+            output_dir
+        )
+
+        assert len(output) == 1
+        assert output.iloc[0]["text"] == VALID_BLUESKY_POST_TEXT

--- a/tests/data_platform/preprocessing/test_preprocess_reddit.py
+++ b/tests/data_platform/preprocessing/test_preprocess_reddit.py
@@ -109,6 +109,8 @@ def test_preprocess_records_writes_output(data_root) -> None:
 
     assert len(output) == 1
     assert output.iloc[0]["comment_fullname"] == "t1_keep"
+    assert output.iloc[0]["text"] == output.iloc[0]["body"]
+    assert output.iloc[0]["body"] == _valid_body()
     assert metadata["row_counts"]["input"] == 2
     assert metadata["row_counts"]["output"] == 1
     assert metadata["files"]["comments"] == "comments.csv"

--- a/tests/data_platform/preprocessing/test_preprocess_reddit.py
+++ b/tests/data_platform/preprocessing/test_preprocess_reddit.py
@@ -79,6 +79,17 @@ def test_filter_comments_drops_invalid_rows() -> None:
     assert filtered.iloc[0]["comment_fullname"] == "t1_keep"
 
 
+def test_filter_comments_does_not_replace_existing_text_from_body() -> None:
+    """Existing canonical text is what validators see, even if body would fail."""
+    comments = pd.DataFrame([_comment_row(comment_fullname="t1_keep")])
+    comments["text"] = _valid_body()
+    comments["body"] = "[removed]"
+    filtered = preprocess_reddit.filter_comments(comments)
+    assert len(filtered) == 1
+    assert filtered.iloc[0]["text"] == _valid_body()
+    assert filtered.iloc[0]["body"] == "[removed]"
+
+
 def test_preprocess_records_writes_output(data_root) -> None:
     dataset_id = VALID_REDDIT_DATASET_ID
     raw_storage = RedditStorageManager(StorageStage.RAW, dataset_id)

--- a/tests/data_platform/utils/test_platform_specific_columns.py
+++ b/tests/data_platform/utils/test_platform_specific_columns.py
@@ -1,7 +1,7 @@
 from data_platform.utils.platform_specific_columns import (
     CANONICAL_TEXT_COLUMN,
     REDDIT_COLUMNS,
-    REDDIT_NATIVE_TEXT_COLUMN,
+    REDDIT_ORIGINAL_PLATFORM_TEXT_COLUMN,
 )
 
 
@@ -12,6 +12,6 @@ class TestRedditColumns:
         """Feature generation and curate read Reddit comment text from ``text``."""
         assert REDDIT_COLUMNS.text_column == CANONICAL_TEXT_COLUMN
 
-    def test_native_comment_text_stays_on_body(self) -> None:
-        """Raw and preprocessed Reddit comments keep native ``body`` for audit."""
-        assert REDDIT_NATIVE_TEXT_COLUMN == "body"
+    def test_original_platform_comment_text_stays_on_body(self) -> None:
+        """Raw and preprocessed Reddit comments keep original ``body``."""
+        assert REDDIT_ORIGINAL_PLATFORM_TEXT_COLUMN == "body"

--- a/tests/data_platform/utils/test_platform_specific_columns.py
+++ b/tests/data_platform/utils/test_platform_specific_columns.py
@@ -1,0 +1,17 @@
+from data_platform.utils.platform_specific_columns import (
+    CANONICAL_TEXT_COLUMN,
+    REDDIT_COLUMNS,
+    REDDIT_NATIVE_TEXT_COLUMN,
+)
+
+
+class TestRedditColumns:
+    """Tests for REDDIT_COLUMNS text mapping."""
+
+    def test_text_column_is_canonical_text(self) -> None:
+        """Feature generation and curate read Reddit comment text from ``text``."""
+        assert REDDIT_COLUMNS.text_column == CANONICAL_TEXT_COLUMN
+
+    def test_native_comment_text_stays_on_body(self) -> None:
+        """Raw and preprocessed Reddit comments keep native ``body`` for audit."""
+        assert REDDIT_NATIVE_TEXT_COLUMN == "body"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Add a shared text column during preprocess

Closes #75.

## Summary

After preprocess, Bluesky posts, Twitter posts, and Reddit comments that pass the filters have a shared `text` column. Reddit comments still have `body` as well, so you can check the original comment text.

Feature generation and the curate stage read `REDDIT_COLUMNS.text_column`. For Bluesky, Twitter, and Reddit comments, `text_column` is `text`.

On Twitter, `text` is still the value after `strip_tco_links` runs, and that is the value used for validation. On Bluesky, `text` is the same as it was before. There is no preprocessor for Reddit posts.

## Purpose

Feature code used to read `text` for Bluesky and Twitter, and `body` for Reddit comments. Preprocess only filtered rows, except on Twitter, where it also ran `strip_tco_links`. After preprocess, every platform uses the same column name, `text`.

Reddit posts still use `title` and `selftext`, and this PR does not change that. Study stimuli are still Reddit comments, not Reddit posts.

## Architecture

Components:

- The preprocess runner copies the platform's original text field onto `text`, then transforms the text and filters the rows. It writes the result to disk.
- For Bluesky, Twitter, and Reddit comments, `text_column` in the platform column map is `text`.
- The Reddit preprocessed model stores both `body` and `text`. Raw ingest still uses the old schema with `body` only.

Existing flow

```mermaid
flowchart LR
  subgraph before [Before]
    Raw[Raw records] --> Filter[Transform and filter]
    Filter --> Out[Preprocessed CSV]
    Out --> Feat[Features and curate]
    Feat --> Branch[text vs body]
  end
```

New flow

```mermaid
flowchart LR
  subgraph after [After]
    Raw2[Raw records] --> Copy[Copy original platform text onto text]
    Copy --> Filter2[Transform and filter]
    Filter2 --> Out2[Preprocessed CSV with text]
    Out2 --> Feat2[Features and curate]
    Feat2 --> Col[text_column is text]
  end
```

## Interfaces

### Data / schema contracts

| Field | Type | Notes |
| ----- | ---- | ----- |
| `text` | string | Shared post or comment text. Reddit comments copy `body` into `text`. Twitter keeps the value after `strip_tco_links`, and Bluesky keeps the original post text. |
| `body` | string | Original Reddit comment text. The preprocessed CSV still includes this column. |
| `REDDIT_COLUMNS.text_column` | `"text"` | Feature generation and the curate stage read this field. |

Raw Reddit comments still validate as `SyncRedditCommentModel` (`body` only). Preprocessed comments validate as `PreprocessedRedditCommentModel` (`body` and `text`).

## How to run

```bash
PYTHONPATH=. uv run python data_platform/preprocessing/preprocess_reddit.py --dataset-id reddit_<uuid>
```

You should see `text` equal to `body` in preprocessed `comments.csv`, and `body` should still be there.

```bash
PYTHONPATH=. uv run pytest tests/data_platform/preprocessing tests/data_platform/generate_features tests/data_platform/curate -q
```

The tests should exit 0.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-500b5f59-0b0d-4cb0-887c-540789b0035a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-500b5f59-0b0d-4cb0-887c-540789b0035a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Standardized processed comment records around a shared `text` field across supported platforms.
  - Reddit preprocessing now preserves native `body` content while also providing canonical `text` content.
  - Added configurable handling for platform-specific text sources.

- **Bug Fixes**
  - Prevented existing canonical text from being overwritten during Reddit filtering.
  - Ensured preprocessed Reddit records use the appropriate processed data format.

- **Tests**
  - Added coverage for canonical text preservation and Reddit, Bluesky, and platform-specific column mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->