### PR TITLE
Switch ingest to explicit skip-set loads from YAML policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2026-09-02
 
 1. Skip-set sessions can load this-run or all-runs ids, drop already-seen ingest rows, and extend the skip set after append, while the old warmup path still works for existing callers. [PR #79](https://github.com/METResearchGroup/mirrorView-task/pull/79)
-2. Bluesky, Twitter, and Reddit ingest pick one skip-set load from YAML policy, then drop known ids, persist remaining rows, and extend the skip set. Persist uses the explicit exclude and extend helpers, and ingest no longer passes the prior-runs flag.
+2. Bluesky, Twitter, and Reddit ingest pick one skip-set load from YAML policy, then drop known ids, persist remaining rows, and extend the skip set. Persist uses the explicit exclude and extend helpers, and ingest no longer passes the prior-runs flag. [PR #92](https://github.com/METResearchGroup/mirrorView-task/pull/92)
 
 ## 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-09-02
 
 1. Skip-set sessions can load this-run or all-runs ids, drop already-seen ingest rows, and extend the skip set after append, while the old warmup path still works for existing callers. [PR #79](https://github.com/METResearchGroup/mirrorView-task/pull/79)
+2. Bluesky, Twitter, and Reddit ingest pick one skip-set load from YAML policy, then drop known ids, persist remaining rows, and extend the skip set. Persist uses the explicit exclude and extend helpers, and ingest no longer passes the prior-runs flag.
 
 ## 2026-09-01
 

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -237,12 +237,12 @@ def run_sync_tasks(
         DedupeConfig(
             id_column="uri",
             filename=filename,
-            include_prior_runs=policy_includes_prior_runs(
-                ingestion_params.get("dedupe_policy")
-            ),
         )
     )
-    dedupe_session.warm(storage, output_dir)
+    if policy_includes_prior_runs(ingestion_params.get("dedupe_policy")):
+        dedupe_session.load_seen_ids_from_all_runs(storage)
+    else:
+        dedupe_session.load_seen_ids(storage, output_dir)
 
     def process_task(task: BlueskyTask, entry: dict[str, Any]) -> None:
         """Fetch one keyword, persist deduped rows, and update the task ledger entry."""

--- a/data_platform/ingestion/sync_reddit.py
+++ b/data_platform/ingestion/sync_reddit.py
@@ -386,23 +386,23 @@ def _open_reddit_dedupe_sessions(
             DedupeConfig(
                 id_column="comment_fullname",
                 filename=comments_csv,
-                include_prior_runs=policy_includes_prior_runs(
-                    ingestion_params.get("comments_dedupe_policy")
-                ),
             )
         )
-        comment_dedupe_session.warm(comment_storage, output_dir)
+        if policy_includes_prior_runs(ingestion_params.get("comments_dedupe_policy")):
+            comment_dedupe_session.load_seen_ids_from_all_runs(comment_storage)
+        else:
+            comment_dedupe_session.load_seen_ids(comment_storage, output_dir)
     if include_posts:
         post_dedupe_session = DedupeSession(
             DedupeConfig(
                 id_column="reddit_fullname",
                 filename=posts_csv,
-                include_prior_runs=policy_includes_prior_runs(
-                    ingestion_params.get("posts_dedupe_policy")
-                ),
             )
         )
-        post_dedupe_session.warm(post_storage, output_dir)
+        if policy_includes_prior_runs(ingestion_params.get("posts_dedupe_policy")):
+            post_dedupe_session.load_seen_ids_from_all_runs(post_storage)
+        else:
+            post_dedupe_session.load_seen_ids(post_storage, output_dir)
     return comment_dedupe_session, post_dedupe_session
 
 

--- a/data_platform/ingestion/sync_twitter.py
+++ b/data_platform/ingestion/sync_twitter.py
@@ -120,12 +120,12 @@ def run_sync_tasks(
         DedupeConfig(
             id_column="tweet_id",
             filename=csv_filename,
-            include_prior_runs=policy_includes_prior_runs(
-                ingestion_params.get("dedupe_policy")
-            ),
         )
     )
-    dedupe_session.warm(storage, output_dir)
+    if policy_includes_prior_runs(ingestion_params.get("dedupe_policy")):
+        dedupe_session.load_seen_ids_from_all_runs(storage)
+    else:
+        dedupe_session.load_seen_ids(storage, output_dir)
 
     def process_task(task: TwitterTask, entry: dict[str, Any]) -> None:
         mark_task_in_progress(entry, storage, output_dir, metadata)

--- a/data_platform/utils/storage.py
+++ b/data_platform/utils/storage.py
@@ -228,11 +228,11 @@ class StorageManager:
         dedupe_session: DedupeSession,
         filename: str | None = None,
     ) -> AppendResult:
-        kept_rows, skipped = dedupe_session.filter_rows(rows)
+        kept_rows, skipped = dedupe_session.exclude_seen_ids(rows)
         resolved_filename = filename or dedupe_session.config.filename
         if kept_rows:
             self.append_records(kept_rows, run_dir, filename=resolved_filename)
-            dedupe_session.note_appended(kept_rows)
+            dedupe_session.add_seen_ids(kept_rows)
         return AppendResult(kept=len(kept_rows), skipped=skipped)
 
     def load_seen_uris(

--- a/data_platform/utils/storage.py
+++ b/data_platform/utils/storage.py
@@ -228,6 +228,17 @@ class StorageManager:
         dedupe_session: DedupeSession,
         filename: str | None = None,
     ) -> AppendResult:
+        """Drop rows whose ids are already in the skip set, then append the rest.
+
+        The caller must already have loaded ``dedupe_session.seen_ids``. Ids from
+        kept rows are added to the skip set only after those rows are written.
+        When every incoming row is already seen, the CSV is left unchanged.
+
+        Returns
+        -------
+        AppendResult
+            Counts of rows written and rows skipped.
+        """
         kept_rows, skipped = dedupe_session.exclude_seen_ids(rows)
         resolved_filename = filename or dedupe_session.config.filename
         if kept_rows:

--- a/docs/plans/2026-09-02_switch_ingest_to_explicit_skip_set_loads_a74c89/plan.md
+++ b/docs/plans/2026-09-02_switch_ingest_to_explicit_skip_set_loads_a74c89/plan.md
@@ -1,0 +1,50 @@
+# Switch ingest to one skip-set load from YAML policy
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Bluesky, Twitter, and Reddit ingest already skip ids that were written before. Today each ingest session still passes a prior-runs flag and then runs one warmup call that can hide two disk scans. The change makes ingest pick exactly one skip-set load from the existing YAML policy, then exclude known ids, persist new rows, and extend the skip set. A skip set is the in-memory set of already-written record ids. Preprocess keeps using warmup.
+
+## Happy flow
+
+An operator resumes ingest for a dataset. The YAML policy chooses either this-run ids or all-run ids. Incoming rows whose ids are already in the skip set are dropped. Remaining rows are written to disk, and those ids are added to the skip set for later batches in the same session.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    Flag["Prior-runs flag on the session"]
+    Warm["One warmup call"]
+    Flag --> Warm --> Persist["Persist"]
+  end
+  subgraph after [After]
+    Policy["YAML policy picks one load"]
+    Load["This-run or all-runs load"]
+    Exclude["Drop known ids"]
+    Write["Write remaining rows"]
+    Extend["Extend skip set"]
+    Policy --> Load --> Exclude --> Write --> Extend
+  end
+```
+
+## Approach
+
+Keep the existing skip-set session type. Do not add a helper that wraps the load choice. Repeat the same one-load branch at each ingest session setup. Change persist so it uses exclude then extend. Leave preprocess, YAML token strings, and the warmup method in place.
+
+## Steps
+
+### Step 1: Switch ingest persist and session setup to the explicit skip-set loads
+
+Rewrite persist tests to load the skip set with the new methods. Change persist to exclude, write, then extend. Then switch Bluesky, Twitter, and Reddit ingest session setup so each session calls exactly one load from YAML policy and does not pass the prior-runs flag.
+
+## What "done" looks like
+
+1. Each Bluesky, Twitter, and Reddit ingest session is constructed without the prior-runs flag, and it calls exactly one of this-run load or all-runs load from YAML policy.
+2. Persist drops known ids, writes remaining rows, and extends the skip set only when remaining rows are non-empty.
+3. Persist tests load the skip set with the new methods. Warmup tests in the skip-set unit file stay and stay green.
+4. `PYTHONPATH=. uv run pytest tests/data_platform/utils/test_storage.py tests/data_platform/utils/test_deduplication.py tests/data_platform/ingestion -q` exits 0.
+5. `rg -n "include_prior_runs|\.warm\(" data_platform/ingestion` finds no matches. Preprocess still calls warmup.

--- a/docs/plans/2026-09-02_switch_ingest_to_explicit_skip_set_loads_a74c89/steps/step1.md
+++ b/docs/plans/2026-09-02_switch_ingest_to_explicit_skip_set_loads_a74c89/steps/step1.md
@@ -1,0 +1,152 @@
+# Step 1: Switch ingest persist and session setup to the explicit skip-set loads
+
+## Goal
+
+Bluesky, Twitter, and Reddit ingest pick one skip-set load from YAML policy, then exclude, persist, and extend. `StorageManager.append_deduped_records` calls `exclude_seen_ids` and `add_seen_ids`. Ingest stops passing `include_prior_runs` on `DedupeConfig`. Preprocess still calls `warm`.
+
+## Caller / unit of work
+
+**Main caller:** `run_sync_tasks` in `/workspace/data_platform/ingestion/sync_bluesky.py`. The same session-setup shape is used in `/workspace/data_platform/ingestion/sync_twitter.py` `run_sync_tasks` and `/workspace/data_platform/ingestion/sync_reddit.py` `_open_reddit_dedupe_sessions`.
+
+**Slice:** construct `DedupeSession` without `include_prior_runs`, call exactly one load, then `append_deduped_records` uses exclude then add.
+
+**Out of scope:** preprocess runner; deleting `warm` / `include_prior_runs` / `filter_rows` / `note_appended`; runbook; YAML token meanings; feature generation; sibling GitHub issues #70 and #71. Do not edit `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/**` or `/workspace/docs/plans/2026-09-02_explicit_skip_set_load_helpers_c4e91a/**`.
+
+**Depends on:** GitHub issue #68 helpers already on the stack base (`load_seen_ids`, `load_seen_ids_from_all_runs`, `exclude_seen_ids`, `add_seen_ids`, `policy_includes_prior_runs`).
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/step2.md` | Source contracts for this slice (do not edit) |
+| `/workspace/data_platform/utils/deduplication.py` | `policy_includes_prior_runs` and the new load/exclude/add methods |
+| `/workspace/data_platform/ingestion/sync_bluesky.py` | `run_sync_tasks` session setup |
+| `/workspace/data_platform/ingestion/sync_twitter.py` | `run_sync_tasks` session setup |
+| `/workspace/data_platform/ingestion/sync_reddit.py` | `_open_reddit_dedupe_sessions` comments vs posts policies |
+| `/workspace/data_platform/utils/storage.py` | `append_deduped_records` currently calls `filter_rows` / `note_appended` |
+| `/workspace/tests/data_platform/utils/test_storage.py` | persist tests that currently call `warm` |
+| `/workspace/tests/data_platform/ingestion/test_sync_checkpoint.py` | `test_append_deduped_records_skips_seen_ids` |
+| `/workspace/data_platform/preprocessing/runner.py` | Confirm `warm` stays. Do not edit. |
+
+## Files allowed to change
+
+- `/workspace/data_platform/ingestion/sync_bluesky.py`
+- `/workspace/data_platform/ingestion/sync_twitter.py`
+- `/workspace/data_platform/ingestion/sync_reddit.py`
+- `/workspace/data_platform/utils/storage.py` (`append_deduped_records` only)
+- `/workspace/tests/data_platform/utils/test_storage.py`
+- `/workspace/tests/data_platform/ingestion/test_sync_checkpoint.py`
+
+Plan package files under `/workspace/docs/plans/2026-09-02_switch_ingest_to_explicit_skip_set_loads_a74c89/` may already be on the branch. Do not edit them during implementation.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/preprocessing/**`
+- `/workspace/data_platform/utils/deduplication.py` (do not delete compatibility methods)
+- `/workspace/docs/runbooks/**`
+- `/workspace/data_platform/generate_features/**`
+- YAML config files / `dedupe_policy` token strings
+- `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/plan.md`
+- `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/*.md`
+- `/workspace/docs/plans/2026-09-02_explicit_skip_set_load_helpers_c4e91a/**`
+
+## Contracts to lock
+
+Ingest session setup (Bluesky and Twitter once; Reddit repeats per comments session and per posts session):
+
+```text
+session = DedupeSession(DedupeConfig(id_column=..., filename=...))
+  # do not pass include_prior_runs
+
+if policy_includes_prior_runs(policy):
+    session.load_seen_ids_from_all_runs(storage)
+else:
+    session.load_seen_ids(storage, output_dir)
+
+# then existing append_deduped_records(...)
+```
+
+Do not extract a shared load helper. Repeat this branch at each ingest session setup. Do not call both load methods on one ingest session.
+
+Policy sources (unchanged keys):
+
+- Bluesky/Twitter: `ingestion_params.get("dedupe_policy")`
+- Reddit comments: `ingestion_params.get("comments_dedupe_policy")`
+- Reddit posts: `ingestion_params.get("posts_dedupe_policy")`
+
+`append_deduped_records`:
+
+```text
+kept_rows, skipped = dedupe_session.exclude_seen_ids(rows)
+if kept_rows:
+    append_records(...)
+    dedupe_session.add_seen_ids(kept_rows)
+return AppendResult(kept=len(kept_rows), skipped=skipped)
+```
+
+Do not call `add_seen_ids` when `kept_rows` is empty. Do not rename `append_deduped_records`. Do not migrate YAML tokens. `policy_includes_prior_runs` stays the branch.
+
+## Test design
+
+given a current-run CSV already containing id "1"
+when the test session calls load_seen_ids (not warm) then append_deduped_records with ["1", "2"]
+then kept == 1, skipped == 1, disk ids == {"1", "2"}
+
+given a prior run dir with uri X and include-prior policy
+when the test session calls load_seen_ids_from_all_runs then append_deduped_records with [X, new]
+then skipped == 1, kept == 1
+
+given two dataset ids
+when session B loads only B's run
+then id present only in A is not skipped
+
+Rewrite persist tests in `/workspace/tests/data_platform/utils/test_storage.py` and `test_append_deduped_records_skips_seen_ids` in `/workspace/tests/data_platform/ingestion/test_sync_checkpoint.py` so they call `load_seen_ids` or `load_seen_ids_from_all_runs` instead of `warm` plus `include_prior_runs=True`. Do not delete those tests.
+
+`/workspace/tests/data_platform/utils/test_deduplication.py` warm tests stay. They still prove compatibility for preprocess.
+
+The persist tests will stay green after the load-method swap, because the load methods already exist. The rewritten tests still lock the public setup the persist path will use. Do not add spies on `filter_rows` or `note_appended`.
+
+## Implementation notes (implement-from-spec)
+
+Files already exist. There are no new modules. Phase 2 scaffold and Phase 3 contracts do not add files or stub existing callers, because stubbing persist or ingest would break current tests before the rewrite. If a phase does not change the repo, skip that commit. Full auto. Do not wait for Phase 3 approval.
+
+Phase 4 then Phase 5, one Git commit per phase that changes the repo, and one commit per Phase 5 unit:
+
+1. Phase 1 scope. Confirm caller, file tree, and out-of-scope. No product-code commit if nothing on disk changes.
+2. Phase 4 test design. Rewrite the persist tests listed above so they call `load_seen_ids` or `load_seen_ids_from_all_runs`. Do not implement product-code changes in this commit.
+3. Phase 5 units, in this order, one commit each:
+   1. `append_deduped_records` uses `exclude_seen_ids` then persist then `add_seen_ids` only when `kept_rows` is non-empty
+   2. Bluesky `run_sync_tasks` session setup
+   3. Twitter `run_sync_tasks` session setup
+   4. Reddit `_open_reddit_dedupe_sessions` for comments and for posts
+4. Phase 6. Run the must-pass commands. Confirm preprocess still calls `warm`. Confirm ingest has no `include_prior_runs=` and no `.warm(`.
+
+## Must pass
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run pytest tests/data_platform/utils/test_storage.py tests/data_platform/utils/test_deduplication.py tests/data_platform/ingestion -q
+```
+
+Expected: exit 0.
+
+```bash
+rg -n "include_prior_runs|\.warm\(" data_platform/ingestion
+```
+
+Expected: no matches.
+
+```bash
+rg -n "\.warm\(" data_platform/preprocessing
+```
+
+Expected: at least one match. Preprocess still using `warm` is required.
+
+## Must fail / not happen
+
+- Preprocess migrated off `warm`.
+- `warm` removed from `DedupeSession`.
+- Both load methods called on one ingest session.
+- `dedupe_policy` YAML token strings changed.
+- A shared helper extracted for the ingest load branch.
+- `add_seen_ids` called when `kept_rows` is empty.

--- a/tests/data_platform/ingestion/test_sync_checkpoint.py
+++ b/tests/data_platform/ingestion/test_sync_checkpoint.py
@@ -187,7 +187,7 @@ def test_append_deduped_records_skips_seen_ids(data_root) -> None:
     storage.append_records(existing, run_dir)
     config = DedupeConfig(id_column="tweet_id")
     dedupe_session = DedupeSession(config)
-    dedupe_session.warm(storage, run_dir)
+    dedupe_session.load_seen_ids(storage, run_dir)
     incoming = [mock_tweet_row("1"), mock_tweet_row("2")]
     result = storage.append_deduped_records(incoming, run_dir, dedupe_session=dedupe_session)
     assert result.skipped == 1

--- a/tests/data_platform/utils/test_storage.py
+++ b/tests/data_platform/utils/test_storage.py
@@ -52,7 +52,7 @@ def test_append_deduped_records_skips_current_run_duplicates(bluesky_storage) ->
     bluesky_storage.append_records(existing, run_dir)
     config = DedupeConfig(id_column="uri")
     dedupe_session = DedupeSession(config)
-    dedupe_session.warm(bluesky_storage, run_dir)
+    dedupe_session.load_seen_ids(bluesky_storage, run_dir)
 
     result = bluesky_storage.append_deduped_records(
         [
@@ -81,7 +81,7 @@ def test_append_deduped_records_skips_prior_run_duplicates(data_root) -> None:
     )
     config = DedupeConfig(id_column="comment_fullname", filename="comments.csv")
     dedupe_session = DedupeSession(config)
-    dedupe_session.warm(comment_storage, current_run)
+    dedupe_session.load_seen_ids(comment_storage, current_run)
 
     result = comment_storage.append_deduped_records(
         [
@@ -105,9 +105,9 @@ def test_append_deduped_records_skips_ids_from_prior_run_dirs(bluesky_storage) -
     current_run = bluesky_storage.create_new_run_dir("2026_05_30-10:00:00")
     prior_uri = "at://did:plc:ex/app.bsky.feed.post/prior"
     bluesky_storage.append_records([make_ingestion_row(uri=prior_uri)], prior_run)
-    config = DedupeConfig(id_column="uri", include_prior_runs=True)
+    config = DedupeConfig(id_column="uri")
     dedupe_session = DedupeSession(config)
-    dedupe_session.warm(bluesky_storage, current_run)
+    dedupe_session.load_seen_ids_from_all_runs(bluesky_storage)
 
     result = bluesky_storage.append_deduped_records(
         [
@@ -140,7 +140,7 @@ def test_append_deduped_records_does_not_dedupe_across_datasets(data_root) -> No
     )
     config = DedupeConfig(id_column="comment_fullname", filename="comments.csv")
     dedupe_session = DedupeSession(config)
-    dedupe_session.warm(storage_b, current_run_b)
+    dedupe_session.load_seen_ids(storage_b, current_run_b)
 
     result = storage_b.append_deduped_records(
         [
@@ -162,7 +162,7 @@ def test_append_deduped_records_returns_empty_when_all_duplicates(bluesky_storag
     bluesky_storage.append_records(existing, run_dir)
     config = DedupeConfig(id_column="uri")
     dedupe_session = DedupeSession(config)
-    dedupe_session.warm(bluesky_storage, run_dir)
+    dedupe_session.load_seen_ids(bluesky_storage, run_dir)
 
     result = bluesky_storage.append_deduped_records(
         [make_ingestion_row(uri="at://did:plc:ex/app.bsky.feed.post/a1")],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Switch ingest to explicit skip-set loads from YAML policy

## Summary

Bluesky, Twitter, and Reddit ingest skip already-written record ids by loading exactly one skip set from YAML policy, then dropping known ids, writing remaining rows, and adding those ids to the skip set. A skip set is the in-memory set of already-written record ids. Ingest no longer passes a prior-runs flag or uses the warmup call.

## Purpose

Ingest session setup used one warmup call plus a prior-runs flag, so one config value could hide two disk scans. Callers now pick this-run load or all-runs load from the existing YAML policy keys, and persist uses exclude then extend. Preprocess still uses warmup. YAML token strings are unchanged.

Plan: `docs/plans/2026-09-02_switch_ingest_to_explicit_skip_set_loads_a74c89/`

## Architecture

Components:

- `Ingest session setup` — constructs a skip-set session without the prior-runs flag, then calls one load from YAML policy.
- `Skip-set session` — holds already-written ids and exposes this-run load, all-runs load, exclude, and extend.
- `Persist` — drops known ids, writes remaining rows, and extends the skip set only when remaining rows are non-empty.
- `Local run directories` — source of this-run or all-runs ids.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    Flag["Prior-runs flag on the session"]
    Warm["One warmup call"]
    Persist["Persist via filter and note"]
    Flag --> Warm --> Persist
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    Policy["YAML policy picks one load"]
    Load["This-run or all-runs load"]
    Exclude["Drop known ids"]
    Write["Write remaining rows"]
    Extend["Extend skip set"]
    Policy --> Load --> Exclude --> Write --> Extend
  end
```

## Interfaces

### Ingest session setup

Each Bluesky, Twitter, and Reddit ingest session is constructed with id column and filename only. Exactly one load runs:

- all-runs load when `policy_includes_prior_runs(policy)` is true
- this-run load otherwise

Policy keys are unchanged:

- Bluesky and Twitter: `ingestion_params["dedupe_policy"]`
- Reddit comments: `ingestion_params["comments_dedupe_policy"]`
- Reddit posts: `ingestion_params["posts_dedupe_policy"]`

### Persist

`append_deduped_records` excludes seen ids, appends remaining rows, and extends the skip set only when remaining rows are non-empty. The caller must already have loaded the skip set.

## How to run

```bash
PYTHONPATH=. uv run pytest tests/data_platform/utils/test_storage.py tests/data_platform/utils/test_deduplication.py tests/data_platform/ingestion -q
```

Expected: exit 0.

```bash
rg -n "include_prior_runs|\\.warm\\(" data_platform/ingestion
```

Expected: no matches.

```bash
rg -n "\\.warm\\(" data_platform/preprocessing
```

Expected: preprocess still calls warmup.

Fixes #69
Part of #67

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-360d748f-48bd-454a-8236-962ecfa7bde0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-360d748f-48bd-454a-8236-962ecfa7bde0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

