### PR TITLE
Switch preprocess to skip then collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 1. Skip-set sessions can load this-run or all-runs ids, drop already-seen ingest rows, and extend the skip set after append, while the old warmup path still works for existing callers. [PR #79](https://github.com/METResearchGroup/mirrorView-task/pull/79)
 2. Bluesky, Twitter, and Reddit ingest pick one skip-set load from YAML policy, then drop known ids, persist remaining rows, and extend the skip set. Persist uses the explicit exclude and extend helpers, and ingest no longer passes the prior-runs flag. [PR #92](https://github.com/METResearchGroup/mirrorView-task/pull/92)
-3. Preprocess loads ids from every prior preprocessed run before creating the new run directory, drops known ids with pandas, then collapses remaining ids so the later row wins. The skip count names prior-run ids only.
+3. Preprocess loads ids from every prior preprocessed run before creating the new run directory, drops known ids with pandas, then collapses remaining ids so the later row wins. The skip count names prior-run ids only. [PR #94](https://github.com/METResearchGroup/mirrorView-task/pull/94)
 
 ## 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. Skip-set sessions can load this-run or all-runs ids, drop already-seen ingest rows, and extend the skip set after append, while the old warmup path still works for existing callers. [PR #79](https://github.com/METResearchGroup/mirrorView-task/pull/79)
 2. Bluesky, Twitter, and Reddit ingest pick one skip-set load from YAML policy, then drop known ids, persist remaining rows, and extend the skip set. Persist uses the explicit exclude and extend helpers, and ingest no longer passes the prior-runs flag. [PR #92](https://github.com/METResearchGroup/mirrorView-task/pull/92)
+3. Preprocess loads ids from every prior preprocessed run before creating the new run directory, drops known ids with pandas, then collapses remaining ids so the later row wins. The skip count names prior-run ids only.
 
 ## 2026-09-01
 

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -151,6 +151,33 @@ def save_preprocessed(
     return output_dir
 
 
+def collapse_candidates_by_id(
+    df: pd.DataFrame,
+    id_col: str,
+    keep: str = "last",
+) -> pd.DataFrame:
+    """Return one row per id, keeping the last duplicate when keep is "last".
+
+    Preprocess uses keep="last" so a later raw run wins when the same id appears
+    more than once in the current batch.
+
+    Parameters
+    ----------
+    df
+        Candidate records after prior-run ids have already been dropped.
+    id_col
+        Column that identifies a record.
+    keep
+        Which duplicate to keep. Preprocess callers pass ``"last"``.
+
+    Returns
+    -------
+    pd.DataFrame
+        A new frame with one row per id and a reset index.
+    """
+    raise NotImplementedError
+
+
 def _drop_already_preprocessed(
     records: pd.DataFrame, id_col: str, seen_ids: set[str]
 ) -> tuple[pd.DataFrame, int]:

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -175,7 +175,7 @@ def collapse_candidates_by_id(
     pd.DataFrame
         A new frame with one row per id and a reset index.
     """
-    raise NotImplementedError
+    return df.drop_duplicates(subset=[id_col], keep=keep).reset_index(drop=True)
 
 
 def _drop_already_preprocessed(

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -182,6 +182,29 @@ def preprocess_records(
     dataset_id: str,
     spec: PreprocessPlatformSpec,
 ) -> Path:
+    """Skip ids from prior preprocessed runs, collapse remaining ids, then filter and save.
+
+    The skip set is loaded from every existing preprocessed run before the new
+    run directory is created. The printed skip count is prior-run ids only, and
+    does not include rows removed when duplicate ids in the current batch collapse.
+
+    Parameters
+    ----------
+    dataset_id
+        Dataset whose raw runs are preprocessed.
+    spec
+        Platform storage, columns, validators, and optional text transform.
+
+    Returns
+    -------
+    Path
+        New preprocessed run directory.
+
+    Raises
+    ------
+    FileNotFoundError
+        When the dataset has no raw runs.
+    """
     dataset_id = validate_dataset_id(dataset_id)
     raw_storage = spec.storage_cls(StorageStage.RAW, dataset_id)
     if raw_storage.latest_run_dir() is None:

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -204,18 +204,15 @@ def preprocess_records(
         raise FileNotFoundError(f"No raw runs found for dataset {dataset_id}")
     require_all_runs_complete(raw_storage, dataset_id)
     preprocessed_storage = spec.storage_cls(StorageStage.PREPROCESSED, dataset_id)
-    dedupe_session = DedupeSession(
-        DedupeConfig(
-            id_column=spec.columns.records_id_column,
-            include_prior_runs=True,
-        )
-    )
-    dedupe_session.warm(preprocessed_storage, preprocessed_storage.root_dir)
+    session = DedupeSession(DedupeConfig(id_column=spec.columns.records_id_column))
+    session.load_seen_ids_from_all_runs(preprocessed_storage)
 
     records, source_raw_run_dirs = load_raw_records(spec, dataset_id)
-    records, skipped = _drop_already_preprocessed(
-        records, spec.columns.records_id_column, dedupe_session.seen_ids
-    )
+    id_col = spec.columns.records_id_column
+    is_new = ~records[id_col].isin(list(session.seen_ids))
+    skipped = len(records) - int(is_new.sum())
+    records = records.loc[is_new].reset_index(drop=True)
+    records = collapse_candidates_by_id(records, id_col, keep="last")
 
     preprocessed = apply_text_transform(records, spec)
     preprocessed = filter_records(preprocessed, spec)

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import pandas as pd
 from pydantic import BaseModel
@@ -176,22 +176,6 @@ def collapse_candidates_by_id(
         A new frame with one row per id and a reset index.
     """
     return df.drop_duplicates(subset=[id_col], keep=keep).reset_index(drop=True)
-
-
-def _drop_already_preprocessed(
-    records: pd.DataFrame, id_col: str, seen_ids: set[str]
-) -> tuple[pd.DataFrame, int]:
-    """Drop rows already preprocessed in a prior run, then dedupe by id within this batch.
-
-    Returns the surviving records and how many rows were dropped for being seen before.
-    """
-    id_series = cast(pd.Series, records[id_col])
-    is_new = ~id_series.isin(list(seen_ids))
-    skipped = len(records) - int(is_new.sum())
-    deduped = (
-        records.loc[is_new].drop_duplicates(subset=[id_col], keep="last").reset_index(drop=True)
-    )
-    return deduped, skipped
 
 
 def preprocess_records(

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -210,6 +210,6 @@ def preprocess_records(
     noun = spec.columns.records_file_key
     print(
         f"preprocess_records: kept {len(preprocessed)} of {len(records)} {noun}"
-        f" (skipped {skipped} already preprocessed) -> {output_dir}"
+        f" (skipped {skipped} already in a prior preprocessed run) -> {output_dir}"
     )
     return output_dir

--- a/docs/plans/2026-09-02_switch_preprocess_to_skip_then_collapse_d2084b/plan.md
+++ b/docs/plans/2026-09-02_switch_preprocess_to_skip_then_collapse_d2084b/plan.md
@@ -1,0 +1,50 @@
+# Switch preprocess to skip known ids then collapse remaining ids
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Preprocess already drops ids that exist in earlier preprocessed runs, and it also collapses duplicate ids in the current batch. Skip and collapse share one helper, and the skip set is loaded by passing the preprocessed stage root as if it were a run directory. The change loads every prior preprocessed run before the new run directory is created, drops known ids with pandas, then collapses remaining ids so that the later raw row wins. The skip count is prior-run ids only.
+
+## Happy flow
+
+An operator re-runs preprocess on a dataset. Ids from earlier preprocessed runs are loaded first. Incoming rows with those ids are dropped. Remaining duplicate ids in the current batch collapse to one row, and then the existing transform, filter, and save path runs.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    Warm["Load skip set with warmup"]
+    Combined["Skip and collapse in one helper"]
+    Warm --> Combined --> Save["Save"]
+  end
+  subgraph after [After]
+    Load["Load all prior preprocessed ids"]
+    Drop["Drop known ids with pandas"]
+    Collapse["Collapse remaining ids, later row wins"]
+    Save2["Save"]
+    Load --> Drop --> Collapse --> Save2
+  end
+```
+
+## Approach
+
+Keep skip-set load on the existing session type, and do not add collapse to that session. Put collapse on the preprocess runner. Load the skip set before save creates the new run directory, so the empty new directory is not part of the all-runs scan. Do not convert the records table to a list of dicts for skip, and do not extend the skip set from preprocess. Ingest, runbooks, and deleting warmup stay out of this PR.
+
+## Steps
+
+### Step 1: Switch preprocess to skip then collapse
+
+Add a named collapse helper on the preprocess runner. Load all prior preprocessed ids before save. Drop known ids with pandas. Call collapse so the later row wins. Delete the helper that combined skip and collapse. Change the skip-count print so it names prior preprocessed runs only.
+
+## What "done" looks like
+
+1. Preprocess never treats the preprocessed stage root as a run directory.
+2. The helper that combined skip and collapse is gone.
+3. The preprocessing package does not pass the prior-runs flag and does not call warmup.
+4. Skip-count print names only ids already in a prior preprocessed run, and that count does not include rows removed by collapse.
+5. Input row count still means length after skip and collapse, and before filters.
+6. `PYTHONPATH=. uv run pytest tests/data_platform/preprocessing tests/data_platform/utils/test_deduplication.py -q` exits 0.

--- a/docs/plans/2026-09-02_switch_preprocess_to_skip_then_collapse_d2084b/steps/step1.md
+++ b/docs/plans/2026-09-02_switch_preprocess_to_skip_then_collapse_d2084b/steps/step1.md
@@ -1,0 +1,160 @@
+# Step 1: Switch preprocess to skip then collapse
+
+## Goal
+
+Preprocess loads the all-runs skip set before creating the new run directory, drops known IDs with pandas, then collapses remaining IDs last-wins in a named helper. Delete `_drop_already_preprocessed`. Do not convert the DataFrame to `list[dict]` to call `exclude_seen_ids`. Do not call `add_seen_ids`.
+
+## Caller / unit of work
+
+**Main caller:** `preprocess_records` in `/workspace/data_platform/preprocessing/runner.py`.
+
+**Slice:** `load_seen_ids_from_all_runs` → pandas drop via `session.seen_ids` → `collapse_candidates_by_id(..., keep="last")` → existing transform/filter/save.
+
+**Out of scope:** ingest callers; deleting `warm` from `DedupeSession`; runbook mermaid (GitHub issue #71); YAML tokens; feature generation; sibling GitHub issue #71. Do not edit `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/**`, `/workspace/docs/plans/2026-09-02_explicit_skip_set_load_helpers_c4e91a/**`, or `/workspace/docs/plans/2026-09-02_switch_ingest_to_explicit_skip_set_loads_a74c89/**`.
+
+**Depends on:** GitHub issues #68 and #69 already on this stack branch (`load_seen_ids_from_all_runs` on `DedupeSession`).
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/step3.md` | Source contracts for this slice (do not edit) |
+| `/workspace/data_platform/preprocessing/runner.py` | `preprocess_records`, `_drop_already_preprocessed`, `save_preprocessed` |
+| `/workspace/data_platform/utils/storage.py` | `create_new_run_dir`, `load_seen_ids_from_all_runs` |
+| `/workspace/data_platform/utils/deduplication.py` | `load_seen_ids_from_all_runs` already exists. Do not edit. |
+| `/workspace/tests/data_platform/preprocessing/test_preprocess_twitter.py` | `test_second_preprocess_run_skips_already_preprocessed_ids` |
+
+## Files allowed to change
+
+- `/workspace/data_platform/preprocessing/runner.py`
+- `/workspace/tests/data_platform/preprocessing/test_preprocess_twitter.py` (add collapse / skip-count coverage; keep existing re-run test)
+- `/workspace/tests/data_platform/preprocessing/test_preprocess_bluesky.py` only if a test would otherwise break
+- `/workspace/tests/data_platform/preprocessing/test_preprocess_reddit.py` only if a test would otherwise break
+- `/workspace/tests/data_platform/preprocessing/test_runner.py` only if a test needs to import runner helpers without a platform CLI
+
+Plan package files under `/workspace/docs/plans/2026-09-02_switch_preprocess_to_skip_then_collapse_d2084b/` may already be on the branch. Do not edit them during implementation.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/ingestion/**`
+- `/workspace/data_platform/utils/deduplication.py`
+- `/workspace/data_platform/preprocessing/preprocess_bluesky.py` (still calls `preprocess_records`)
+- `/workspace/data_platform/preprocessing/preprocess_twitter.py`
+- `/workspace/data_platform/preprocessing/preprocess_reddit.py`
+- `/workspace/docs/runbooks/**`
+- `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/**`
+- `/workspace/docs/plans/2026-09-02_explicit_skip_set_load_helpers_c4e91a/**`
+- `/workspace/docs/plans/2026-09-02_switch_ingest_to_explicit_skip_set_loads_a74c89/**`
+
+## Contracts to lock
+
+`collapse_candidates_by_id` lives in `/workspace/data_platform/preprocessing/runner.py`, not on `DedupeSession`:
+
+```text
+collapse_candidates_by_id(df: pd.DataFrame, id_col: str, keep: str = "last") -> pd.DataFrame
+  drop_duplicates(subset=[id_col], keep=keep).reset_index(drop=True)
+  keep="last": later raw run wins
+```
+
+`preprocess_records` order after the raw-run gate:
+
+```text
+preprocessed_storage = spec.storage_cls(StorageStage.PREPROCESSED, dataset_id)
+session = DedupeSession(DedupeConfig(id_column=spec.columns.records_id_column))
+session.load_seen_ids_from_all_runs(preprocessed_storage)
+  # BEFORE save_preprocessed / create_new_run_dir
+  # never pass preprocessed_storage.root_dir as a fake run directory
+  # never pass include_prior_runs=True
+
+records, source_raw_run_dirs = load_raw_records(...)
+id_col = spec.columns.records_id_column
+is_new = ~records[id_col].isin(list(session.seen_ids))
+skipped = len(records) - int(is_new.sum())   # prior-run skips only
+records = records.loc[is_new].reset_index(drop=True)
+records = collapse_candidates_by_id(records, id_col, keep="last")
+
+then apply_text_transform / filter_records / save_preprocessed as today
+do not call add_seen_ids
+do not call exclude_seen_ids
+```
+
+Print: skipped count is prior-run IDs only, wording **"already in a prior preprocessed run"** (not rows removed by collapse). Example shape:
+
+```text
+preprocess_records: kept {n} of {m} {noun} (skipped {skipped} already in a prior preprocessed run) -> {output_dir}
+```
+
+`m` remains `len(records)` after skip+collapse and before filters (today's `input_count` meaning). Do not change `row_counts.input` semantics.
+
+Delete `_drop_already_preprocessed` entirely.
+
+Keep `create_new_run_dir` inside `save_preprocessed`. Load the skip set before that call so the new empty run dir is not part of the all-runs scan.
+
+## Test design
+
+Keep `test_second_preprocess_run_skips_already_preprocessed_ids` green (second run `row_counts.input == 0`). Put new tests in `/workspace/tests/data_platform/preprocessing/test_preprocess_twitter.py`. Do not add `test_runner.py` unless a twitter-module test cannot import the helper.
+
+given df with ids [a, a] and different text, keep="last"
+when collapse_candidates_by_id
+then one row, the last text
+
+given seen_ids {a} and df rows [a, b, b]
+when pandas drop then collapse
+then skipped == 1 (only a)
+and surviving ids == [b] (one row)
+
+given no prior preprocessed runs
+when load_seen_ids_from_all_runs then preprocess
+then skipped == 0 and create_new_run_dir still happens inside save (existing write-output tests)
+
+given a second preprocess run of the same already-preprocessed id
+when preprocess_records prints
+then the line includes "already in a prior preprocessed run"
+and the skipped count is 1, not a collapse count
+
+Do not convert records to `list[dict]` in `preprocess_records` for skip.
+
+## Implementation notes (implement-from-spec)
+
+Files already exist. There are no new modules. Phase 2 scaffold and Phase 3 contracts do not add files or stub existing callers, because stubbing `preprocess_records` would break current tests before the rewrite. If a phase does not change the repo, skip that commit. Full auto. Do not wait for Phase 3 approval.
+
+Phase 4 then Phase 5, one Git commit per phase that changes the repo, and one commit per Phase 5 unit:
+
+1. Phase 1 scope. Confirm caller, file tree, and out-of-scope. No product-code commit if nothing on disk changes.
+2. Phase 4 test design. Add the collapse, skip-count, and print-wording tests listed above. Keep `test_second_preprocess_run_skips_already_preprocessed_ids`. Do not implement product-code changes in this commit.
+3. Phase 5 units, in this order, one commit each:
+   1. `collapse_candidates_by_id` on `runner.py` (not on `DedupeSession`)
+   2. pandas drop in `preprocess_records` after `load_seen_ids_from_all_runs`, then call collapse with `keep="last"`. Stop calling `_drop_already_preprocessed`. Do not pass `include_prior_runs`. Do not call `warm`. Do not call `add_seen_ids` or `exclude_seen_ids`.
+   3. Delete `_drop_already_preprocessed` entirely. Remove unused imports that only it needed.
+   4. Print wording: `already in a prior preprocessed run`. Skip count stays prior-run only.
+4. Phase 6. Run the must-pass commands.
+
+## Must pass
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run pytest tests/data_platform/preprocessing tests/data_platform/utils/test_deduplication.py -q
+```
+
+Expected: exit 0.
+
+```bash
+rg -n "_drop_already_preprocessed" data_platform tests
+```
+
+Expected: no matches.
+
+```bash
+rg -n "include_prior_runs|\.warm\(" data_platform/preprocessing
+```
+
+Expected: no matches.
+
+## Must fail / not happen
+
+- Passing the stage root as `run_dir` to any load method.
+- Using `exclude_seen_ids` on preprocess rows.
+- Calling `add_seen_ids` from preprocess.
+- Putting `collapse_candidates_by_id` on `DedupeSession`.
+- Skip count including collapse duplicates.
+- Editing ingest files in this layer.

--- a/tests/data_platform/preprocessing/test_preprocess_twitter.py
+++ b/tests/data_platform/preprocessing/test_preprocess_twitter.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from data_platform.preprocessing import preprocess_twitter
+from data_platform.preprocessing.runner import collapse_candidates_by_id
 from data_platform.preprocessing.validators import twitter_validators
 from data_platform.utils.storage import StorageStage, TwitterStorageManager
 from tests.data_platform.constants import VALID_TWITTER_DATASET_ID
@@ -236,3 +237,96 @@ def test_second_preprocess_run_skips_already_preprocessed_ids(data_root) -> None
     assert second_metadata["row_counts"]["input"] == 0
     assert second_metadata["row_counts"]["output"] == 0
     assert len(preprocessed_storage.load_records(second_output)) == 0
+
+
+def test_collapse_candidates_by_id_keeps_last_text() -> None:
+    records = pd.DataFrame(
+        [
+            {"tweet_id": "a", "text": "first"},
+            {"tweet_id": "a", "text": "second"},
+        ]
+    )
+
+    result = collapse_candidates_by_id(records, "tweet_id", keep="last")
+
+    assert len(result) == 1
+    assert result.iloc[0]["tweet_id"] == "a"
+    assert result.iloc[0]["text"] == "second"
+
+
+def test_pandas_drop_then_collapse_skips_only_prior_run_ids() -> None:
+    seen_ids = {"a"}
+    records = pd.DataFrame(
+        [
+            {"tweet_id": "a", "text": "already seen"},
+            {"tweet_id": "b", "text": "first b"},
+            {"tweet_id": "b", "text": "second b"},
+        ]
+    )
+    id_col = "tweet_id"
+
+    is_new = ~records[id_col].isin(list(seen_ids))
+    skipped = len(records) - int(is_new.sum())
+    records = records.loc[is_new].reset_index(drop=True)
+    result = collapse_candidates_by_id(records, id_col, keep="last")
+
+    assert skipped == 1
+    assert list(result[id_col]) == ["b"]
+    assert result.iloc[0]["text"] == "second b"
+
+
+def test_first_preprocess_run_prints_zero_prior_run_skips(data_root, capsys) -> None:
+    dataset_id = VALID_TWITTER_DATASET_ID
+    raw_storage = TwitterStorageManager(StorageStage.RAW, dataset_id)
+    run_dir = raw_storage.create_new_run_dir("2026_05_31-14:00:00")
+    raw_storage.write_records(
+        [
+            _tweet_row(tweet_id="1000000000000000001"),
+            _tweet_row(
+                tweet_id="1000000000000000001",
+                text=_valid_text() + " later duplicate",
+            ),
+        ],
+        run_dir,
+    )
+    raw_storage.write_run_metadata(
+        run_dir,
+        {
+            "sync_status": "completed",
+            "row_count": 2,
+        },
+    )
+
+    output_dir = preprocess_twitter.preprocess_records(dataset_id)
+    preprocessed_storage = TwitterStorageManager(StorageStage.PREPROCESSED, dataset_id)
+    output = preprocessed_storage.load_records(output_dir)
+    metadata = preprocessed_storage.load_run_metadata(output_dir)
+    captured = capsys.readouterr()
+
+    assert len(output) == 1
+    assert output.iloc[0]["text"] == _valid_text() + " later duplicate"
+    assert metadata["row_counts"]["input"] == 1
+    assert "skipped 0 already in a prior preprocessed run" in captured.out
+
+
+def test_second_preprocess_run_print_names_prior_preprocessed_run(
+    data_root, capsys
+) -> None:
+    dataset_id = VALID_TWITTER_DATASET_ID
+    raw_storage = TwitterStorageManager(StorageStage.RAW, dataset_id)
+    run_dir = raw_storage.create_new_run_dir("2026_05_31-15:00:00")
+    raw_storage.write_records([_tweet_row(tweet_id="1000000000000000001")], run_dir)
+    raw_storage.write_run_metadata(
+        run_dir,
+        {
+            "sync_status": "completed",
+            "row_count": 1,
+        },
+    )
+
+    preprocess_twitter.preprocess_records(dataset_id)
+    capsys.readouterr()
+    preprocess_twitter.preprocess_records(dataset_id)
+    captured = capsys.readouterr()
+
+    assert "skipped 1 already in a prior preprocessed run" in captured.out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Switch preprocess to skip then collapse

## Summary

Preprocess loads ids from every prior preprocessed run before it creates the new run directory, drops those ids with pandas, then collapses remaining ids so the later raw row wins. The printed skip count is prior-run ids only. It does not include rows removed by collapse.

## Purpose

Skip and collapse used to share one helper, and the skip set was loaded by passing the preprocessed stage root as if it were a run directory. Callers now load all prior preprocessed ids first, drop known ids on the table, then collapse remaining ids in a named helper on the preprocess runner. Ingest, warmup deletion, and the stimuli runbook stay out of this PR.

Plan: `docs/plans/2026-09-02_switch_preprocess_to_skip_then_collapse_d2084b/`

## Architecture

Components:

- `preprocess_records` — loads the all-runs skip set, drops known ids, collapses remaining ids, then transform, filter, and save.
- `collapse_candidates_by_id` — one row per id on the preprocess runner, later row wins. Not a skip-set session method.
- `Skip-set session` — `load_seen_ids_from_all_runs` only. Preprocess does not call exclude or extend.
- `save_preprocessed` — still creates the new run directory. The skip set is loaded before that call.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    Warm["Load skip set with warmup"]
    Combined["Skip and collapse in one helper"]
    Save["Save"]
    Warm --> Combined --> Save
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    Load["Load all prior preprocessed ids"]
    Drop["Drop known ids with pandas"]
    Collapse["Collapse remaining ids, later row wins"]
    Save2["Save"]
    Load --> Drop --> Collapse --> Save2
  end
```

## Interfaces

### Skip then collapse

After the raw-run gate, preprocess constructs a skip-set session with the id column only, then calls all-runs load on preprocessed storage. It never passes the stage root as a run directory, and it never passes the prior-runs flag.

Known ids are dropped with pandas membership on the id column. Remaining ids collapse with `keep="last"`. `row_counts.input` is still the length after skip and collapse, and before filters.

Print shape:

```text
preprocess_records: kept {n} of {m} {noun} (skipped {skipped} already in a prior preprocessed run) -> {output_dir}
```

## How to run

```bash
PYTHONPATH=. uv run pytest tests/data_platform/preprocessing tests/data_platform/utils/test_deduplication.py -q
```

Expected: exit 0.

```bash
rg -n "_drop_already_preprocessed" data_platform tests
```

Expected: no matches.

```bash
rg -n "include_prior_runs|\\.warm\\(" data_platform/preprocessing
```

Expected: no matches.

Fixes #70
Part of #67

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-360d748f-48bd-454a-8236-962ecfa7bde0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-360d748f-48bd-454a-8236-962ecfa7bde0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

