### PR TITLE
Add package-relative path helpers and file-name constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2026-09-02
+
+1. Data-platform code can resolve and validate file paths relative to the `data_platform/` package, using shared full names for posts, comments, and metadata files. [PR #95](https://github.com/METResearchGroup/mirrorView-task/pull/95)
+
 ## 2026-09-01
 
 1. Shared preprocessing, feature, and curation runners now take `PlatformSpecificColumns` on `spec.columns` instead of the overloaded `PlatformIdBinding` name, so per-platform CSV column maps read as what they are. [PR #65](https://github.com/METResearchGroup/mirrorView-task/pull/65)

--- a/data_platform/constants.py
+++ b/data_platform/constants.py
@@ -1,0 +1,15 @@
+"""Package-level path root and record file-name constants.
+
+Run from the repo root:
+
+    PYTHONPATH=. uv run pytest tests/data_platform/utils/test_paths.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PACKAGE_ROOT = Path()
+POSTS_FILENAME = ""
+COMMENTS_FILENAME = ""
+METADATA_FILENAME = ""

--- a/data_platform/constants.py
+++ b/data_platform/constants.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-PACKAGE_ROOT = Path()
-POSTS_FILENAME = ""
-COMMENTS_FILENAME = ""
-METADATA_FILENAME = ""
+PACKAGE_ROOT: Path = Path()
+POSTS_FILENAME: str = ""
+COMMENTS_FILENAME: str = ""
+METADATA_FILENAME: str = ""

--- a/data_platform/constants.py
+++ b/data_platform/constants.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-PACKAGE_ROOT: Path = Path()
-POSTS_FILENAME: str = ""
-COMMENTS_FILENAME: str = ""
-METADATA_FILENAME: str = ""
+PACKAGE_ROOT: Path = Path(__file__).resolve().parent
+POSTS_FILENAME: str = "posts.csv"
+COMMENTS_FILENAME: str = "comments.csv"
+METADATA_FILENAME: str = "metadata.json"

--- a/data_platform/utils/paths.py
+++ b/data_platform/utils/paths.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from data_platform.constants import PACKAGE_ROOT
+
 
 def resolve_package_path(relative_path: str | Path) -> Path:
     """Return the resolved path of a location under the data-platform package.
@@ -32,7 +34,22 @@ def resolve_package_path(relative_path: str | Path) -> Path:
         If ``relative_path`` is empty, absolute, contains ``..``, or would
         resolve outside ``PACKAGE_ROOT``.
     """
-    raise NotImplementedError
+    if relative_path == "":
+        raise ValueError("Package-relative path must not be empty.")
+    candidate = Path(relative_path)
+    if candidate.is_absolute():
+        raise ValueError(f"Package-relative path must not be absolute: {relative_path}")
+    if ".." in candidate.parts:
+        raise ValueError(
+            f"Package-relative path must not contain parent segments: {relative_path}"
+        )
+    package_root = PACKAGE_ROOT.resolve()
+    resolved = (package_root / candidate).resolve()
+    if not resolved.is_relative_to(package_root):
+        raise ValueError(
+            f"Resolved path is outside the data-platform package: {relative_path}"
+        )
+    return resolved
 
 
 def to_package_relative(path: str | Path) -> str:

--- a/data_platform/utils/paths.py
+++ b/data_platform/utils/paths.py
@@ -11,8 +11,47 @@ from pathlib import Path
 
 
 def resolve_package_path(relative_path: str | Path) -> Path:
+    """Return the resolved path of a location under the data-platform package.
+
+    The target file does not need to exist.
+
+    Parameters
+    ----------
+    relative_path
+        Path relative to ``PACKAGE_ROOT``. Must not be absolute and must not
+        contain ``..`` parts.
+
+    Returns
+    -------
+    Path
+        The resolved location under ``PACKAGE_ROOT``.
+
+    Raises
+    ------
+    ValueError
+        If ``relative_path`` is empty, absolute, contains ``..``, or would
+        resolve outside ``PACKAGE_ROOT``.
+    """
     raise NotImplementedError
 
 
 def to_package_relative(path: str | Path) -> str:
+    """Return the POSIX path of an absolute location relative to the package.
+
+    Parameters
+    ----------
+    path
+        Absolute path that must resolve inside ``PACKAGE_ROOT``.
+
+    Returns
+    -------
+    str
+        Forward-slash relative path with no leading slash. The package root
+        itself is ``"."``.
+
+    Raises
+    ------
+    ValueError
+        If ``path`` is not absolute or does not resolve inside ``PACKAGE_ROOT``.
+    """
     raise NotImplementedError

--- a/data_platform/utils/paths.py
+++ b/data_platform/utils/paths.py
@@ -71,4 +71,14 @@ def to_package_relative(path: str | Path) -> str:
     ValueError
         If ``path`` is not absolute or does not resolve inside ``PACKAGE_ROOT``.
     """
-    raise NotImplementedError
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        raise ValueError(f"Path must be absolute: {path}")
+    package_root = PACKAGE_ROOT.resolve()
+    resolved = candidate.resolve()
+    if not resolved.is_relative_to(package_root):
+        raise ValueError(f"Path is outside the data-platform package: {path}")
+    relative = resolved.relative_to(package_root).as_posix()
+    if relative == "":
+        return "."
+    return relative

--- a/data_platform/utils/paths.py
+++ b/data_platform/utils/paths.py
@@ -11,6 +11,30 @@ from pathlib import Path
 
 from data_platform.constants import PACKAGE_ROOT
 
+_PARENT_DIR = ".."
+
+
+def _validated_relative_path(relative_path: str | Path) -> Path:
+    if relative_path == "":
+        raise ValueError("Package-relative path must not be empty.")
+    candidate = Path(relative_path)
+    if candidate.is_absolute():
+        raise ValueError(f"Package-relative path must not be absolute: {relative_path}")
+    if _PARENT_DIR in candidate.parts:
+        raise ValueError(
+            f"Package-relative path must not contain parent segments: {relative_path}"
+        )
+    return candidate
+
+
+def _require_resolved_inside_package(resolved: Path, source: str | Path) -> Path:
+    package_root = PACKAGE_ROOT.resolve()
+    if not resolved.is_relative_to(package_root):
+        raise ValueError(
+            f"Path is outside the data-platform package: {source}"
+        )
+    return package_root
+
 
 def resolve_package_path(relative_path: str | Path) -> Path:
     """Return the resolved path of a location under the data-platform package.
@@ -34,21 +58,10 @@ def resolve_package_path(relative_path: str | Path) -> Path:
         If ``relative_path`` is empty, absolute, contains ``..``, or would
         resolve outside ``PACKAGE_ROOT``.
     """
-    if relative_path == "":
-        raise ValueError("Package-relative path must not be empty.")
-    candidate = Path(relative_path)
-    if candidate.is_absolute():
-        raise ValueError(f"Package-relative path must not be absolute: {relative_path}")
-    if ".." in candidate.parts:
-        raise ValueError(
-            f"Package-relative path must not contain parent segments: {relative_path}"
-        )
+    candidate = _validated_relative_path(relative_path)
     package_root = PACKAGE_ROOT.resolve()
     resolved = (package_root / candidate).resolve()
-    if not resolved.is_relative_to(package_root):
-        raise ValueError(
-            f"Resolved path is outside the data-platform package: {relative_path}"
-        )
+    _require_resolved_inside_package(resolved, relative_path)
     return resolved
 
 
@@ -74,11 +87,6 @@ def to_package_relative(path: str | Path) -> str:
     candidate = Path(path)
     if not candidate.is_absolute():
         raise ValueError(f"Path must be absolute: {path}")
-    package_root = PACKAGE_ROOT.resolve()
     resolved = candidate.resolve()
-    if not resolved.is_relative_to(package_root):
-        raise ValueError(f"Path is outside the data-platform package: {path}")
-    relative = resolved.relative_to(package_root).as_posix()
-    if relative == "":
-        return "."
-    return relative
+    package_root = _require_resolved_inside_package(resolved, path)
+    return resolved.relative_to(package_root).as_posix()

--- a/data_platform/utils/paths.py
+++ b/data_platform/utils/paths.py
@@ -1,0 +1,18 @@
+"""Resolve and round-trip paths relative to the data-platform package.
+
+Run from the repo root:
+
+    PYTHONPATH=. uv run pytest tests/data_platform/utils/test_paths.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_package_path(relative_path: str | Path) -> Path:
+    raise NotImplementedError
+
+
+def to_package_relative(path: str | Path) -> str:
+    raise NotImplementedError

--- a/docs/plans/2026-09-02_package_relative_path_helpers_4d3233/plan.md
+++ b/docs/plans/2026-09-02_package_relative_path_helpers_4d3233/plan.md
@@ -1,0 +1,53 @@
+# Add package-relative path helpers for the data platform
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Pipeline stages still build record paths from platform defaults, suffix rewrites, and metadata. Later work in the parent epic will pass explicit paths relative to the data-platform package. The plan adds only the shared names and the path helper that later stages will call. Storage and stage CLIs stay on the old API.
+
+## Happy flow
+
+A later caller hands the helper a path relative to the data-platform package. The helper either returns a resolved path under that package, or it raises when the input is absolute or uses parent-directory parts to leave the package. A second helper turns an absolute path under the package back into a POSIX string relative to the package.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    Lit["Hardcoded file names"]
+    Join["Join against data root in storage"]
+    Lit --> Join
+  end
+  subgraph after [After]
+    Names["Shared full file names"]
+    Rel["Relative path in"]
+    Check["Reject absolute and parent walk"]
+    Abs["Resolved path under package"]
+    Back["Absolute path back to POSIX relative"]
+    Names --> Rel
+    Rel --> Check --> Abs --> Back
+  end
+```
+
+No production caller uses the helper yet. Tests are the only caller.
+
+## Approach
+
+Add the smallest set of names and functions that later explicit-path work can import without rewriting storage now. Keep checks inside the helper functions. Do not add a new path type, a custom error class, or a third function that only validates.
+
+## Steps
+
+### Step 1: Land constants, path helpers, and their tests
+
+Add the package constants and the two helpers. Cover resolve, rejection, and reverse conversion with unit tests. Leave storage, ingest, preprocess, curate, and feature generation unchanged.
+
+## What "done" looks like
+
+1. Full file names for posts, comments, and metadata live in a production constants module next to the package root constant.
+2. Helpers resolve package-relative paths, reject absolute paths and parent-directory traversal, and convert absolute paths back to package-relative POSIX strings.
+3. `PYTHONPATH=. uv run pytest tests/data_platform/utils/test_paths.py -q` exits 0.
+4. `PYTHONPATH=. uv run pytest tests/data_platform -q` has no new failures.
+5. Storage and stage CLIs still use their current path API. Sibling issues are not bundled.

--- a/docs/plans/2026-09-02_package_relative_path_helpers_4d3233/steps/step1.md
+++ b/docs/plans/2026-09-02_package_relative_path_helpers_4d3233/steps/step1.md
@@ -1,0 +1,206 @@
+# Step 1: Land constants, path helpers, and their tests
+
+## Goal
+
+Add `data_platform/constants.py` and `data_platform/utils/paths.py` so later explicit-path work can resolve and round-trip paths relative to the data-platform package. Production storage and stage CLIs stay on the old API. Tests in `tests/data_platform/utils/test_paths.py` are the only caller.
+
+## Caller / unit of work
+
+**Main caller:** unit tests in `/workspace/tests/data_platform/utils/test_paths.py` importing constants and calling `resolve_package_path` then `to_package_relative`.
+
+**Slice:** constants exist; a relative path resolves under the package; invalid relative inputs raise; an absolute path under the package converts back to a POSIX relative string.
+
+**Out of scope:** `data_platform/utils/storage.py` API; ingest, preprocess, curate, and feature-generation CLIs; slimming metadata; sibling issues #82 to #85; editing `tests/data_platform/constants.py` (that file is a test fixture module, not production constants).
+
+## Decision (locked)
+
+Put the helper at `/workspace/data_platform/utils/paths.py` because the issue's required test path is `/workspace/tests/data_platform/utils/test_paths.py`, which matches the existing `data_platform/utils/` plus `tests/data_platform/utils/` pairing (see `/workspace/data_platform/utils/config_paths.py` and `/workspace/tests/data_platform/utils/test_config_paths.py`).
+
+Keep two functions. Do not add a separate validate-only helper, a custom exception type, or a Path subclass. Raise `ValueError` to match existing package validation in `/workspace/data_platform/utils/dataset.py`.
+
+Do not require the target file to exist. Later writers will resolve paths before creating files.
+
+`PACKAGE_ROOT` is the directory that contains `/workspace/data_platform/constants.py` (`Path(__file__).resolve().parent`), not the repo root and not `data_platform/data/`. Current `DATA_ROOT` in `/workspace/data_platform/utils/storage.py` stays as it is.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-02_package_relative_path_helpers_4d3233/plan.md` | Parent plan |
+| `/workspace/data_platform/utils/storage.py` | Current `DATA_ROOT`, `METADATA_FILENAME`, and `posts.csv` / `comments.csv` literals. Do not change this file. |
+| `/workspace/data_platform/utils/dataset.py` | Current `_DATA_ROOT` and `ValueError` validation style. Do not change this file. |
+| `/workspace/data_platform/utils/config_paths.py` | Nearby path helper style. It allows absolute YAML paths relative to repo root, so it is not the model for this helper. |
+| `/workspace/lib/constants.py` | Existing `Path(__file__).parent` root constant style. |
+| `/workspace/tests/data_platform/utils/test_config_paths.py` | Test layout next to utils helpers. |
+| `/workspace/tests/data_platform/constants.py` | Fixture module. Do not confuse with production constants. Do not edit. |
+
+## Files allowed to change
+
+- Create `/workspace/data_platform/constants.py`
+- Create `/workspace/data_platform/utils/paths.py`
+- Create `/workspace/tests/data_platform/utils/test_paths.py`
+- `/workspace/CHANGELOG.md` (after the PR exists, via write-changelog)
+
+Plan files under `/workspace/docs/plans/2026-09-02_package_relative_path_helpers_4d3233/` are already committed on this branch. Do not rewrite them during implementation.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/utils/storage.py`
+- `/workspace/data_platform/utils/dataset.py`
+- `/workspace/data_platform/utils/config_paths.py`
+- `/workspace/data_platform/ingestion/**`
+- `/workspace/data_platform/preprocessing/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/tests/data_platform/constants.py`
+- `/workspace/docs/runbooks/**`
+
+## Contracts to lock
+
+`/workspace/data_platform/constants.py`:
+
+```text
+PACKAGE_ROOT: Path
+  Path(__file__).resolve().parent
+  the data_platform package directory
+
+POSTS_FILENAME: str = "posts.csv"
+COMMENTS_FILENAME: str = "comments.csv"
+METADATA_FILENAME: str = "metadata.json"
+```
+
+Use these exact names. Values are the full file names, including the suffix. Do not add stem-only constants (`posts`, `comments`) and do not add parquet aliases.
+
+`/workspace/data_platform/utils/paths.py`:
+
+```text
+resolve_package_path(relative_path: str | Path) -> Path
+  Join relative_path onto PACKAGE_ROOT and return a resolved Path.
+  The target file does not need to exist.
+  Raise ValueError if relative_path is absolute.
+  Raise ValueError if any path part is "..".
+  Raise ValueError if the resolved path is not inside PACKAGE_ROOT.
+
+to_package_relative(path: str | Path) -> str
+  Convert an absolute path under PACKAGE_ROOT into a POSIX string relative to PACKAGE_ROOT
+  (forward slashes, no leading slash).
+  Raise ValueError if path is not absolute.
+  Raise ValueError if the resolved path is not inside PACKAGE_ROOT.
+```
+
+Round-trip invariant for a valid relative input that stays under the package:
+
+```text
+to_package_relative(resolve_package_path(relative_path)) == Path(relative_path).as_posix()
+```
+
+Empty string is invalid for `resolve_package_path` (raise `ValueError`). A lone `.` is valid and resolves to `PACKAGE_ROOT`. `to_package_relative(PACKAGE_ROOT)` returns `"."`.
+
+Do not change `StorageManager`, `DATA_ROOT`, or the `METADATA_FILENAME` copy inside `/workspace/data_platform/utils/storage.py`.
+
+## Test design
+
+Pseudocode then real tests. One test class per public function, named `TestResolvePackagePath` and `TestToPackageRelative`, plus `TestPackageConstants` for the constants. Follow `/workspace/.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md`. Prefer `pytest.raises(ValueError)`.
+
+given relative_path "data/bluesky/example/posts.csv"
+when resolve_package_path(relative_path)
+then result == PACKAGE_ROOT / "data" / "bluesky" / "example" / "posts.csv"
+and result == result.resolve()
+
+given relative_path Path("data/x/posts.csv")
+when resolve_package_path(relative_path)
+then result is PACKAGE_ROOT joined with those parts (Path input is accepted)
+
+given relative_path "."
+when resolve_package_path(".")
+then result == PACKAGE_ROOT
+
+given relative_path ""
+when resolve_package_path("")
+then raise ValueError
+
+given an absolute path such as Path("/tmp/posts.csv")
+when resolve_package_path(absolute)
+then raise ValueError
+
+given relative_path "data/../secrets.txt"
+when resolve_package_path(relative_path)
+then raise ValueError
+and do not return a path even though it would stay under PACKAGE_ROOT after normalize
+
+given relative_path "../README.md"
+when resolve_package_path(relative_path)
+then raise ValueError
+
+given absolute_path PACKAGE_ROOT / "data" / "posts.csv"
+when to_package_relative(absolute_path)
+then result == "data/posts.csv"
+
+given absolute_path PACKAGE_ROOT
+when to_package_relative(PACKAGE_ROOT)
+then result == "."
+
+given relative string "data/posts.csv"
+when to_package_relative("data/posts.csv")
+then raise ValueError
+
+given absolute_path /tmp/outside.csv (or another path outside PACKAGE_ROOT)
+when to_package_relative(absolute_path)
+then raise ValueError
+
+given relative_path "data/run/posts.csv"
+when to_package_relative(resolve_package_path(relative_path))
+then result == "data/run/posts.csv"
+
+given the constants module
+then POSTS_FILENAME == "posts.csv"
+and COMMENTS_FILENAME == "comments.csv"
+and METADATA_FILENAME == "metadata.json"
+and PACKAGE_ROOT == Path of data_platform/constants.py .parent
+and PACKAGE_ROOT.name == "data_platform"
+
+## Implementation notes
+
+Follow implement-from-spec phases in this packet. One Git commit per phase and per unit of work.
+
+Phase 2 scaffold: create the two production modules and the test module with imports and stub bodies (`raise NotImplementedError`). No validation logic yet.
+
+Phase 3 contracts: signatures and constants only. Bodies stay stubs.
+
+Phase 4: write the failing tests from the scenarios above.
+
+Phase 5 units of work, in this order:
+
+1. Constants in `/workspace/data_platform/constants.py`
+2. `resolve_package_path`
+3. `to_package_relative`
+
+Do not import the new helpers from storage or CLIs.
+
+Numpy-style docstrings on the public functions and a module docstring on each new production file. The module docstring may include `PYTHONPATH=. uv run pytest tests/data_platform/utils/test_paths.py -q` as the relevant run command.
+
+## Must pass
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run pytest tests/data_platform/utils/test_paths.py -q
+```
+
+Expected: exit 0.
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run pytest tests/data_platform -q
+```
+
+Expected: exit 0, or only failures that already existed on `main` before this branch. No new failures from this step.
+
+## Must fail / not happen
+
+- Any edit to `/workspace/data_platform/utils/storage.py` or stage CLIs.
+- Helpers accepting absolute paths in `resolve_package_path`.
+- Helpers accepting a `..` part in `resolve_package_path`.
+- `to_package_relative` returning backslashes or a string that starts with `/`.
+- `PACKAGE_ROOT` pointing at the repo root or at `data_platform/data`.
+- Adding stem-only file-name constants or parquet filename constants.
+- Editing `/workspace/tests/data_platform/constants.py`.

--- a/tests/data_platform/utils/test_paths.py
+++ b/tests/data_platform/utils/test_paths.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
+import data_platform.constants as constants_mod
 from data_platform.constants import (
     COMMENTS_FILENAME,
     METADATA_FILENAME,
@@ -7,3 +12,131 @@ from data_platform.constants import (
     POSTS_FILENAME,
 )
 from data_platform.utils.paths import resolve_package_path, to_package_relative
+
+
+class TestPackageConstants:
+    """Tests for production file-name constants and PACKAGE_ROOT."""
+
+    def test_posts_filename_is_full_csv_name(self) -> None:
+        """Verifies POSTS_FILENAME is the full posts.csv name."""
+        expected = "posts.csv"
+        result = POSTS_FILENAME
+        assert result == expected
+
+    def test_comments_filename_is_full_csv_name(self) -> None:
+        """Verifies COMMENTS_FILENAME is the full comments.csv name."""
+        expected = "comments.csv"
+        result = COMMENTS_FILENAME
+        assert result == expected
+
+    def test_metadata_filename_is_full_json_name(self) -> None:
+        """Verifies METADATA_FILENAME is the full metadata.json name."""
+        expected = "metadata.json"
+        result = METADATA_FILENAME
+        assert result == expected
+
+    def test_package_root_is_data_platform_directory(self) -> None:
+        """Verifies PACKAGE_ROOT is the directory that contains constants.py."""
+        expected = Path(constants_mod.__file__).resolve().parent
+        result = PACKAGE_ROOT
+        assert result == expected
+        assert result.name == "data_platform"
+        assert (result / "constants.py").is_file()
+
+
+class TestResolvePackagePath:
+    """Tests for resolve_package_path()."""
+
+    def test_joins_relative_string_under_package_root(self) -> None:
+        """Verifies a nested relative string resolves under PACKAGE_ROOT."""
+        relative_path = "data/bluesky/example/posts.csv"
+        expected = (PACKAGE_ROOT / "data" / "bluesky" / "example" / "posts.csv").resolve()
+
+        result = resolve_package_path(relative_path)
+
+        assert result == expected
+        assert result == result.resolve()
+
+    def test_accepts_path_input(self) -> None:
+        """Verifies a pathlib Path relative input is accepted."""
+        relative_path = Path("data/x/posts.csv")
+        expected = (PACKAGE_ROOT / "data" / "x" / "posts.csv").resolve()
+
+        result = resolve_package_path(relative_path)
+
+        assert result == expected
+
+    def test_dot_resolves_to_package_root(self) -> None:
+        """Verifies a lone dot resolves to PACKAGE_ROOT."""
+        expected = PACKAGE_ROOT.resolve()
+
+        result = resolve_package_path(".")
+
+        assert result == expected
+
+    def test_empty_string_raises_value_error(self) -> None:
+        """Verifies an empty relative path is rejected."""
+        with pytest.raises(ValueError):
+            resolve_package_path("")
+
+    def test_absolute_path_raises_value_error(self) -> None:
+        """Verifies an absolute path is rejected."""
+        absolute = Path("/tmp/posts.csv")
+
+        with pytest.raises(ValueError):
+            resolve_package_path(absolute)
+
+    def test_parent_segment_inside_package_raises_value_error(self) -> None:
+        """Verifies .. is rejected even when the result would stay in the package."""
+        with pytest.raises(ValueError):
+            resolve_package_path("data/../secrets.txt")
+
+    def test_parent_segment_leaving_package_raises_value_error(self) -> None:
+        """Verifies a relative path that walks out of the package is rejected."""
+        with pytest.raises(ValueError):
+            resolve_package_path("../README.md")
+
+
+class TestToPackageRelative:
+    """Tests for to_package_relative()."""
+
+    def test_absolute_path_under_package_returns_posix_relative(self) -> None:
+        """Verifies an absolute path under PACKAGE_ROOT becomes a POSIX relative string."""
+        absolute_path = PACKAGE_ROOT / "data" / "posts.csv"
+        expected = "data/posts.csv"
+
+        result = to_package_relative(absolute_path)
+
+        assert result == expected
+        assert "\\" not in result
+        assert not result.startswith("/")
+
+    def test_package_root_returns_dot(self) -> None:
+        """Verifies the package root itself converts to a lone dot."""
+        expected = "."
+
+        result = to_package_relative(PACKAGE_ROOT)
+
+        assert result == expected
+
+    def test_relative_input_raises_value_error(self) -> None:
+        """Verifies a non-absolute input is rejected."""
+        with pytest.raises(ValueError):
+            to_package_relative("data/posts.csv")
+
+    def test_path_outside_package_raises_value_error(self, tmp_path: Path) -> None:
+        """Verifies an absolute path outside PACKAGE_ROOT is rejected."""
+        outside = tmp_path / "outside.csv"
+        outside.write_text("x", encoding="utf-8")
+
+        with pytest.raises(ValueError):
+            to_package_relative(outside)
+
+    def test_round_trip_relative_path(self) -> None:
+        """Verifies resolve then convert-back returns the original POSIX relative path."""
+        relative_path = "data/run/posts.csv"
+        expected = "data/run/posts.csv"
+
+        result = to_package_relative(resolve_package_path(relative_path))
+
+        assert result == expected

--- a/tests/data_platform/utils/test_paths.py
+++ b/tests/data_platform/utils/test_paths.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from data_platform.constants import (
+    COMMENTS_FILENAME,
+    METADATA_FILENAME,
+    PACKAGE_ROOT,
+    POSTS_FILENAME,
+)
+from data_platform.utils.paths import resolve_package_path, to_package_relative


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #81
Part of #80

## Summary

Adds shared full file names for posts, comments, and metadata, plus helpers that resolve paths relative to the data-platform package.

Callers pass a package-relative path and get a resolved location under that package, or a `ValueError` when the input is absolute or contains parent-directory parts. An absolute path under the package converts back to a POSIX string relative to the package. Tests are the only caller in this PR.

## Purpose

Later stages in the parent epic will pass explicit file paths relative to the data-platform package instead of inferring names from platform defaults and metadata. Those callers need a tested helper first.

Storage, ingest, preprocess, curate, and feature-generation CLIs stay on the current path API. Slimming metadata and switching production callers belong to sibling issues.

## Architecture

Components:

- Constants module holds `PACKAGE_ROOT` and the full file names `posts.csv`, `comments.csv`, and `metadata.json`.
- Path helpers resolve a package-relative path, reject absolute and parent-walk inputs, and convert an absolute path back to a POSIX relative string.
- Unit tests are the only caller of the new helpers.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    C1[Stage CLI] --> S1[Storage]
    S1 --> F1[Join file name onto run dir]
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    T2[Unit tests] --> H2[Path helpers]
    H2 --> R2[Resolved path under package]
    C2[Stage CLI] --> S2[Storage]
    S2 --> F2[Unchanged run-dir join]
  end
```

Plan: `docs/plans/2026-09-02_package_relative_path_helpers_4d3233/`

## Interfaces

### Constants

| Name | Type | Value |
| ---- | ---- | ----- |
| `PACKAGE_ROOT` | `Path` | Directory that contains `data_platform/constants.py` |
| `POSTS_FILENAME` | `str` | `posts.csv` |
| `COMMENTS_FILENAME` | `str` | `comments.csv` |
| `METADATA_FILENAME` | `str` | `metadata.json` |

### Path helpers

`resolve_package_path(relative_path: str | Path) -> Path`

Joins the relative path onto `PACKAGE_ROOT` and returns a resolved path. The target file does not need to exist. Raises `ValueError` when the input is empty, absolute, contains `..`, or would resolve outside the package.

`to_package_relative(path: str | Path) -> str`

Converts an absolute path under `PACKAGE_ROOT` to a forward-slash relative string with no leading slash. The package root itself is `"."`. Raises `ValueError` when the input is not absolute or is outside the package.

Round-trip for a valid relative input:

`to_package_relative(resolve_package_path(relative_path))` equals the POSIX form of that relative path.

## How to run

```bash
PYTHONPATH=. uv run pytest tests/data_platform/utils/test_paths.py -q
```

Expected: exit 0.

```bash
PYTHONPATH=. uv run pytest tests/data_platform -q
```

Expected: exit 0 with no new failures.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8737d289-34a7-48b1-9f23-38ab2b359133?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8737d289-34a7-48b1-9f23-38ab2b359133&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent package path handling for resolving valid relative paths and converting package paths to portable relative formats.
  * Added standardized names for posts, comments, and metadata files.

* **Tests**
  * Added coverage for path validation, package-root discovery, POSIX conversion, round trips, and invalid path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->