### PR TITLE
Remove the warmup API and rewrite the stimuli runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. Skip-set sessions can load this-run or all-runs ids, drop already-seen ingest rows, and extend the skip set after append, while the old warmup path still works for existing callers. [PR #79](https://github.com/METResearchGroup/mirrorView-task/pull/79)
 2. Bluesky, Twitter, and Reddit ingest pick one skip-set load from YAML policy, then drop known ids, persist remaining rows, and extend the skip set. Persist uses the explicit exclude and extend helpers, and ingest no longer passes the prior-runs flag. [PR #92](https://github.com/METResearchGroup/mirrorView-task/pull/92)
 3. Preprocess loads ids from every prior preprocessed run before creating the new run directory, drops known ids with pandas, then collapses remaining ids so the later row wins. The skip count names prior-run ids only. [PR #94](https://github.com/METResearchGroup/mirrorView-task/pull/94)
+4. Skip-set sessions no longer expose warmup, filter, or note helpers, and the session config no longer has a prior-runs flag. The stimuli runbook treats skip-set load as work before the new preprocess run directory, not as a preprocess stage.
 
 ## 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 1. Skip-set sessions can load this-run or all-runs ids, drop already-seen ingest rows, and extend the skip set after append, while the old warmup path still works for existing callers. [PR #79](https://github.com/METResearchGroup/mirrorView-task/pull/79)
 2. Bluesky, Twitter, and Reddit ingest pick one skip-set load from YAML policy, then drop known ids, persist remaining rows, and extend the skip set. Persist uses the explicit exclude and extend helpers, and ingest no longer passes the prior-runs flag. [PR #92](https://github.com/METResearchGroup/mirrorView-task/pull/92)
 3. Preprocess loads ids from every prior preprocessed run before creating the new run directory, drops known ids with pandas, then collapses remaining ids so the later row wins. The skip count names prior-run ids only. [PR #94](https://github.com/METResearchGroup/mirrorView-task/pull/94)
-4. Skip-set sessions no longer expose warmup, filter, or note helpers, and the session config no longer has a prior-runs flag. The stimuli runbook treats skip-set load as work before the new preprocess run directory, not as a preprocess stage.
+4. Skip-set sessions no longer expose warmup, filter, or note helpers, and the session config no longer has a prior-runs flag. The stimuli runbook treats skip-set load as work before the new preprocess run directory, not as a preprocess stage. [PR #96](https://github.com/METResearchGroup/mirrorView-task/pull/96)
 
 ## 2026-09-01
 

--- a/data_platform/utils/deduplication.py
+++ b/data_platform/utils/deduplication.py
@@ -26,7 +26,6 @@ def policy_includes_prior_runs(policy: Any) -> bool:
 class DedupeConfig:
     id_column: str
     filename: str | None = None
-    include_prior_runs: bool = False
 
 
 @dataclass
@@ -40,23 +39,6 @@ class DedupeSession:
 
     config: DedupeConfig
     seen_ids: set[str] = field(default_factory=set)
-
-    def warm(self, storage: StorageManager, output_dir: Path) -> None:  # noqa: F821
-        """Load this-run ids, then all-run ids when ``include_prior_runs`` is true.
-
-        Compatibility path for existing ingest and preprocess callers.
-        """
-        self.load_seen_ids(storage, output_dir)
-        if self.config.include_prior_runs:
-            self.load_seen_ids_from_all_runs(storage)
-
-    def filter_rows(self, rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
-        """Return unseen rows and a skipped count. Delegates to ``exclude_seen_ids``."""
-        return self.exclude_seen_ids(rows)
-
-    def note_appended(self, rows: list[dict[str, Any]]) -> None:
-        """Record persisted row ids. Delegates to ``add_seen_ids``."""
-        self.add_seen_ids(rows)
 
     def load_seen_ids(self, storage: StorageManager, run_dir: Path) -> None:  # noqa: F821
         """Add ids from one run directory to ``seen_ids`` without replacing existing ids.

--- a/docs/plans/2026-09-02_remove_warmup_api_and_rewrite_stimuli_runbook_c63a77/plan.md
+++ b/docs/plans/2026-09-02_remove_warmup_api_and_rewrite_stimuli_runbook_c63a77/plan.md
@@ -1,0 +1,50 @@
+# Delete leftover skip-set compatibility names and rewrite the stimuli runbook
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Ingest and preprocess already load known ids with explicit skip-set methods. The skip-set session still keeps a compatibility warmup path, a prior-runs config flag, and two alias methods that only delegate. Tests and the stimuli runbook still talk about warmup as if it were a preprocess stage. The work deletes those leftover names, keeps the real skip-set methods, and rewrites the stimuli runbook so skip-set load is work that happens before the new preprocess run directory, not a named stage.
+
+## Happy flow
+
+A caller builds a skip-set session with only an id column and an optional filename. It loads this-run ids or all-run ids, drops rows whose ids are already known, and records newly written ids. An operator reading the stimuli runbook sees load skip set, then drop known ids, then collapse remaining ids, then transform, filter, and save.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    Compat["Compatibility warmup path"]
+    Flag["Prior-runs flag on the session config"]
+    Stage["Runbook warmup stage"]
+    Compat --> Flag --> Stage
+  end
+  subgraph after [After]
+    Load["Load skip set"]
+    Drop["Drop known ids"]
+    Collapse["Collapse remaining ids"]
+    Rest["Transform, filter, save"]
+    Load --> Drop --> Collapse --> Rest
+  end
+```
+
+## Approach
+
+Delete the leftover compatibility path. Do not add a replacement helper. Do not migrate ingest, preprocess, or storage in this PR, because those callers already use the explicit methods. Keep the YAML policy helper that decides whether prior runs count. Land the stimuli runbook from the existing unmerged draft, and rewrite only the preprocess extra-details section so skip-set load is not a mermaid node or named stage.
+
+## Steps
+
+### Step 1: Delete leftover skip-set names, fix tests, and rewrite the stimuli runbook
+
+Remove the compatibility warmup method, the prior-runs config flag, and the two alias methods. Rename tests that still say warm, and add a test that constructing the config with the old flag raises TypeError. Put the stimuli runbook on this branch with the preprocess extra-details chain load skip set, drop known ids, collapse candidates, transform, filter, save.
+
+## What "done" looks like
+
+1. The skip-set session config has only an id column and an optional filename.
+2. The skip-set session public methods are this-run load, all-runs load, exclude, and extend. The YAML policy helper that names prior-run policies is still present.
+3. Tests no longer call warmup, filter, or note helpers, and coverage of load, exclude, and extend remains.
+4. The stimuli runbook describes load skip set, drop known ids, collapse candidates, transform, filter, and save. Skip-set load is not a preprocess stage.
+5. `PYTHONPATH=. uv run pytest tests/data_platform -q` exits 0.

--- a/docs/plans/2026-09-02_remove_warmup_api_and_rewrite_stimuli_runbook_c63a77/steps/step1.md
+++ b/docs/plans/2026-09-02_remove_warmup_api_and_rewrite_stimuli_runbook_c63a77/steps/step1.md
@@ -1,0 +1,156 @@
+# Step 1: Delete leftover skip-set names, fix tests, and rewrite the stimuli runbook
+
+## Goal
+
+Delete `warm`, `filter_rows`, `note_appended`, and `DedupeConfig.include_prior_runs`. Rename tests that still say warm. Land and rewrite `/workspace/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md` so skip-set load is not a mermaid node or named preprocess stage. Keep `policy_includes_prior_runs` and `PRIOR_RUN_POLICIES`.
+
+## Caller / unit of work
+
+**Main caller:** remaining references to `warm` / `include_prior_runs` / `filter_rows` / `note_appended` after GitHub issues #69 and #70. After this PR those names do not exist on `DedupeSession` or `DedupeConfig`.
+
+**Slice:** delete compatibility wrappers → fix tests → rewrite the stimuli runbook Stage 2 extra details.
+
+**Out of scope:** YAML `dedupe_policy` token rename; `FeatureLabelQuery`; renaming `DedupeSession` / `append_deduped_records`; ingest `sync_*.py`; `preprocessing/runner.py` and `preprocess_*.py`; `storage.py`; filling empty Stage 1 / Stage 3 / Stage 4 headings in the stimuli runbook; rewriting `DATA_INGESTION_PIPELINE_ARCHITECTURE.md` unless a leftover `warm` reference is found there (today it has none). Sibling GitHub issues #68, #69, and #70. Do not edit `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/**`, `/workspace/docs/plans/2026-09-02_explicit_skip_set_load_helpers_c4e91a/**`, `/workspace/docs/plans/2026-09-02_switch_ingest_to_explicit_skip_set_loads_a74c89/**`, or `/workspace/docs/plans/2026-09-02_switch_preprocess_to_skip_then_collapse_d2084b/**`.
+
+**Depends on:** GitHub issues #69 and #70 already on this stack branch. Production ingest, preprocess, and storage must not call `warm`. If any of those files still call `warm`, stop. Do not re-migrate callers in this PR.
+
+**Runbook source:** `/workspace/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md` is not on this branch. The draft lives on `origin/add-how-to-get-stimuli-runbook`. Copy that file onto this branch, then rewrite only the Stage 2 extra-details mermaid and the matching prose. When the draft names `PlatformIdBinding` / `binding`, write `PlatformSpecificColumns` / `columns` so the runbook matches this branch. Do not fill Stage 1, Stage 3, or Stage 4. Drop the trailing draft note about Reddit sources at the end of the file.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/plan.md` | Done-state and runbook target (do not edit) |
+| `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/steps/step4.md` | Source contracts for this slice (do not edit) |
+| `/workspace/data_platform/utils/deduplication.py` | Compatibility methods to delete |
+| `/workspace/data_platform/ingestion/sync_bluesky.py` | Confirm no `.warm(` caller. Stop if one remains. |
+| `/workspace/data_platform/ingestion/sync_twitter.py` | Confirm no `.warm(` caller. Stop if one remains. |
+| `/workspace/data_platform/ingestion/sync_reddit.py` | Confirm no `.warm(` caller. Stop if one remains. |
+| `/workspace/data_platform/preprocessing/runner.py` | Confirm no `.warm(` caller. Stop if one remains. |
+| `/workspace/data_platform/utils/storage.py` | Confirm no `.warm(` caller. Stop if one remains. |
+| `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md` | Mentions `append_deduped_records`. Do not invent a warm stage. |
+| `origin/add-how-to-get-stimuli-runbook:docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md` | Draft mermaid warm node and `_drop_already_preprocessed` prose |
+
+## Files allowed to change
+
+- `/workspace/data_platform/utils/deduplication.py`
+- `/workspace/tests/data_platform/utils/test_deduplication.py`
+- `/workspace/tests/data_platform/utils/test_storage.py` (only if a leftover `warm` remains)
+- `/workspace/tests/data_platform/ingestion/test_sync_checkpoint.py` (only if a leftover `warm` remains)
+- `/workspace/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md`
+
+Plan package files under `/workspace/docs/plans/2026-09-02_remove_warmup_api_and_rewrite_stimuli_runbook_c63a77/` may already be on the branch. Do not edit them during implementation.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/ingestion/sync_bluesky.py`
+- `/workspace/data_platform/ingestion/sync_twitter.py`
+- `/workspace/data_platform/ingestion/sync_reddit.py`
+- `/workspace/data_platform/preprocessing/runner.py`
+- `/workspace/data_platform/preprocessing/preprocess_bluesky.py`
+- `/workspace/data_platform/preprocessing/preprocess_twitter.py`
+- `/workspace/data_platform/preprocessing/preprocess_reddit.py`
+- `/workspace/data_platform/utils/storage.py`
+- `/workspace/backlog.md`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/docs/plans/2026-09-01_incremental_identity_skip_124df6/**`
+- `/workspace/docs/plans/2026-09-02_explicit_skip_set_load_helpers_c4e91a/**`
+- `/workspace/docs/plans/2026-09-02_switch_ingest_to_explicit_skip_set_loads_a74c89/**`
+- `/workspace/docs/plans/2026-09-02_switch_preprocess_to_skip_then_collapse_d2084b/**`
+
+Unrelated uses of the word "warm" (HF CLI, LR warmup, climate text) are out of scope. Do not grep-replace those.
+
+## Contracts to lock
+
+`DedupeConfig` after this PR:
+
+```text
+id_column: str
+filename: str | None = None
+# include_prior_runs is gone
+```
+
+Constructing `DedupeConfig(id_column="uri", include_prior_runs=True)` raises TypeError (unexpected keyword).
+
+`DedupeSession` public methods after this PR:
+
+```text
+load_seen_ids
+load_seen_ids_from_all_runs
+exclude_seen_ids
+add_seen_ids
+```
+
+Keep existing attributes `config` and `seen_ids`. `policy_includes_prior_runs` remains. `PRIOR_RUN_POLICIES` remains.
+
+Runbook mermaid (Stage 2 extra details) becomes:
+
+```text
+cli → validate → gate → load skip set → load raw → drop known IDs → collapse candidates → transform → filter → save
+```
+
+Prose must say:
+
+- Skip-set load is not a preprocess stage.
+- Load all prior preprocessed IDs before creating the new run directory.
+- Drop known IDs with pandas. Collapse remaining IDs last-wins.
+- Do not name `warm` or `_drop_already_preprocessed`.
+
+Keep `policy_includes_prior_runs` / YAML policy discussion out of this runbook unless it already exists there (it does not).
+
+## Test design
+
+Rename (do not drop coverage). `#68` already added explicit-method tests. After deleting wrappers:
+
+- `test_session_warm_loads_current_run_only_by_default` is covered by `test_load_seen_ids_unions_current_run_only`. Rename that existing test to `test_load_seen_ids_loads_current_run_only` if you keep one. Do not keep two copies.
+- `test_session_warm_unions_prior_runs_when_enabled` mixed two cases. Those cases already exist as `test_load_seen_ids_from_all_runs_does_not_call_disk` and `test_load_seen_ids_unions_into_existing_seen_ids`. Delete the warm test. Do not add a third copy.
+- `test_session_filter_rows_skips_seen` is covered by `test_exclude_seen_ids_skips_seen`. Delete the filter_rows test.
+- `test_note_appended_updates_seen_ids` is covered by `test_add_seen_ids_updates_seen_ids`. Delete the note_appended test.
+
+given no `include_prior_runs` on `DedupeConfig`
+when constructing `DedupeConfig(id_column="uri", include_prior_runs=True)`
+then TypeError (unexpected keyword)
+
+Name that test `test_dedupe_config_rejects_include_prior_runs`.
+
+Keep `test_policy_includes_prior_runs` green.
+
+Repo-wide grep after the change must not find production `warm` / `include_prior_runs` / `filter_rows` / `note_appended` except `policy_includes_prior_runs` and comments in `policy_includes_prior_runs` itself.
+
+## Implementation notes (implement-from-spec)
+
+Files already exist except the stimuli runbook. There are no new Python modules. Phase 2 scaffold and Phase 3 contracts do not add files or stub existing callers, because stubbing `DedupeSession` would break current tests before the deletion. If a phase does not change the repo, skip that commit. Full auto. Do not wait for Phase 3 approval.
+
+Flesh order (delete compatibility wrappers first, then fix tests, then runbook). One Git commit per phase that changes the repo, and one commit per Phase 5 unit:
+
+1. Phase 1 scope. Confirm caller, file tree, and out-of-scope. Grep ingest, preprocess, and storage for `.warm(`. If any production caller remains, stop. No product-code commit if nothing on disk changes.
+2. Phase 4 test design. Add `test_dedupe_config_rejects_include_prior_runs`. Do not delete wrappers in this commit. The TypeError test must fail because `include_prior_runs` is still accepted.
+3. Phase 5 units, in this order, one commit each:
+   1. Delete `warm`, `filter_rows`, `note_appended`, and `DedupeConfig.include_prior_runs` from `/workspace/data_platform/utils/deduplication.py`. Do not add replacement wrappers.
+   2. Remove tests that still call `warm`, `filter_rows`, or `note_appended`. Rename `test_load_seen_ids_unions_current_run_only` to `test_load_seen_ids_loads_current_run_only` if that name is not already present. Keep `test_policy_includes_prior_runs`. The TypeError test must now pass.
+   3. Copy the stimuli runbook from `origin/add-how-to-get-stimuli-runbook`, then rewrite Stage 2 extra details to the mermaid and prose contracts above. Use `PlatformSpecificColumns` / `columns` where the draft says `PlatformIdBinding` / `binding`. Do not name `warm` or `_drop_already_preprocessed`. Do not fill Stage 1, Stage 3, or Stage 4.
+4. Phase 6. Run the must-pass commands.
+
+## Must pass
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run pytest tests/data_platform -q
+```
+
+Expected: exit 0.
+
+```bash
+rg -n "include_prior_runs|\.warm\(|filter_rows|note_appended|_drop_already_preprocessed" data_platform tests docs/runbooks
+```
+
+Expected: matches only `policy_includes_prior_runs` (and its docstring/tests). No `DedupeSession.warm`. No mermaid node named warm. Unrelated uses of the word "warm" outside this grep are out of scope.
+
+## Must fail / not happen
+
+- Reintroducing `include_prior_runs` on `DedupeConfig`.
+- Changing YAML `dedupe_policy` token strings.
+- Touching `FeatureLabelQuery`.
+- Rewriting `DATA_INGESTION_PIPELINE_ARCHITECTURE.md` unless a leftover `warm` reference is found there.
+- Editing ingest, preprocess, or storage files in this layer.
+- Filling empty Stage 1 / Stage 3 / Stage 4 headings in the stimuli runbook.

--- a/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md
+++ b/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md
@@ -1,0 +1,202 @@
+# How do we get posts for the stimulus dataset?
+
+This runbook goes over how we get the posts that end up as part of our stimulus datasets.
+
+## Overview
+
+We have a 4-stage pipeline for getting records for the dataset.
+
+1. **Ingestion**: Ingest records from APIs and other sources.
+2. **Preprocessing**: Given the raw records, preprocess them (e.g., removing text that's too short, non-English text, etc.)
+3. **Feature generation**: Given the preprocessed posts, generate features.
+4. **Curation**: Given the preprocessed posts and the features, curate the subset that you want as part of your final stimulus dataset.
+
+We use 3 separate data sources:
+
+1. Bluesky
+2. Twitter
+3. Reddit (we use both `praw` as well as the Reddit PushShift dataset)
+
+## Where does data live?
+
+Data is stored in the following folder format:
+
+```markdown
+data_platform/data/{platform}/{dataset_id}/
+  dataset.json
+  raw/{timestamp}/          posts.csv or comments.csv + metadata.json
+  preprocessed/{timestamp}/ same + metadata.json
+  features/                 {feature}.csv + metadata.json [+ deadletter.jsonl]
+  curated/{timestamp}/      mirrorview.csv + metadata.json
+```
+
+Each platform is an independent dataset under `data_platform/data/{platform}/{dataset_id}/`. `dataset_id` is `{bluesky|reddit|twitter}_{uuid}`.
+
+## Stage 1: Ingestion
+
+## Stage 2: Preprocessing
+
+After ingestion finishes, you run preprocessing as a separate local CLI step. The code lives in `data_platform/preprocessing/`. Preprocessing does not call ingestion, and ingestion does not call preprocessing. You do not need environment variables or S3 for preprocessing. You read and write only on disk under `data_platform/data/{platform}/{dataset_id}/`.
+
+Reddit preprocessing works on comments only, not posts. You can preprocess Reddit comments from any ingestion source, as long as the file matches the expected schema.
+
+### Preprocessing inputs
+
+1. A valid `dataset_id` in the form `{bluesky|twitter|reddit}_{uuid}` (see `validate_dataset_id` in `data_platform/utils/dataset.py`).
+2. One or more completed raw run directories at `data_platform/data/{platform}/{dataset_id}/raw/{timestamp}/`.
+3. A records file in each raw run directory you want to load.
+   - Twitter uses `posts.csv` only. `TwitterStorageManager.load_records` always calls `pd.read_csv`.
+   - Bluesky uses `posts.csv` or `posts.parquet`.
+   - Reddit uses `comments.csv` or `comments.parquet`.
+   - Bluesky and Reddit pick `csv` or `parquet` from `dataset.json` via `StorageManager` in `data_platform/utils/storage.py`.
+4. `metadata.json` in every raw run directory. If `sync_status` is present, it must be `completed` (`require_all_runs_complete` in `data_platform/utils/gate_checks.py`).
+
+You invoke preprocessing from the repo root:
+
+```bash
+PYTHONPATH=. uv run python data_platform/preprocessing/preprocess_bluesky.py \
+  --dataset-id bluesky_<uuid>
+
+PYTHONPATH=. uv run python data_platform/preprocessing/preprocess_twitter.py \
+  --dataset-id twitter_<uuid>
+
+PYTHONPATH=. uv run python data_platform/preprocessing/preprocess_reddit.py \
+  --dataset-id reddit_<uuid>
+```
+
+In each `preprocess_*.py` file, you define a `PreprocessPlatformSpec` and call `preprocess_records` in `data_platform/preprocessing/runner.py`.
+
+| Platform | Entrypoint | Spec constant | Storage manager | Sync model |
+| --- | --- | --- | --- | --- |
+| Bluesky | `data_platform/preprocessing/preprocess_bluesky.py` | `BLUESKY_SPEC` | `BlueskyStorageManager` | `SyncBlueskyPostModel` |
+| Twitter | `data_platform/preprocessing/preprocess_twitter.py` | `TWITTER_SPEC` | `TwitterStorageManager` | `SyncTwitterPostModel` |
+| Reddit | `data_platform/preprocessing/preprocess_reddit.py` | `REDDIT_SPEC` | `RedditStorageManager` | `SyncRedditCommentModel` |
+
+Record schemas live in `data_platform/models/sync.py`.
+
+**Bluesky post fields** (`SyncBlueskyPostModel`)
+
+- `uri`, `url`, `author_handle`, `text`, `created_at`, `like_count`, `repost_count`, `reply_count`, `quote_count`
+
+**Twitter post fields** (`SyncTwitterPostModel`)
+
+- `tweet_id`, `text`, `author_id`, `username`, `created_at`, `like_count`, `retweet_count`, `reply_count`, `quote_count`, `url`, `keyword`, `sync_timestamp`
+
+**Reddit comment fields** (`SyncRedditCommentModel`)
+
+- `post_reddit_id`, `post_reddit_fullname`, `subreddit`, `comment_id`, `comment_fullname`, `parent_id`, `author`, `body`, `score`, `created_utc`, `permalink`, `depth`, `comment_rank`, `sync_timestamp`
+
+ID and text column bindings are in `PlatformSpecificColumns` (`data_platform/utils/platform_specific_columns.py`).
+
+| Platform | ID column | Text column | Records file key |
+| --- | --- | --- | --- |
+| Bluesky | `uri` | `text` | `posts` |
+| Twitter | `tweet_id` | `text` | `posts` |
+| Reddit | `comment_fullname` | `body` | `comments` |
+
+### Preprocessing outputs
+
+After each successful run, you get a new timestamped directory at `data_platform/data/{platform}/{dataset_id}/preprocessed/{timestamp}/`, even when zero rows pass the filters.
+
+1. A records file with the same basename and format as raw (`posts.csv` / `posts.parquet` or `comments.csv` / `comments.parquet`).
+2. `metadata.json` with at least these fields.
+   - `dataset_id`
+   - `source_raw_run` (last raw run path, relative to the dataset root)
+   - `source_raw_runs` (all raw run directories scanned, not only runs that contributed rows)
+   - `preprocess_timestamp` (the new run directory name)
+   - `row_counts.input` (rows after dedupe, before filters)
+   - `row_counts.output` (rows after filters)
+   - `files` (map from records file key to filename, e.g. `"posts": "posts.csv"`)
+
+You call `save_preprocessed` in `data_platform/preprocessing/runner.py` to write both files.
+
+### (Preprocessing) Extra details of note
+
+```mermaid
+flowchart TD
+  cli["cli"]
+  validate["validate"]
+  gate["gate"]
+  loadSkip["load skip set"]
+  loadRaw["load raw"]
+  drop["drop known IDs"]
+  collapse["collapse candidates"]
+  transform["transform"]
+  filter["filter"]
+  save["save"]
+
+  cli --> validate --> gate --> loadSkip --> loadRaw --> drop --> collapse --> transform --> filter --> save
+```
+
+**Shared pipeline** (`data_platform/preprocessing/runner.py`)
+
+`PreprocessPlatformSpec` fields:
+
+- `platform`
+- `storage_cls`
+- `model_cls`
+- `columns` (`PlatformSpecificColumns`)
+- `text_validators`
+- `row_validators` (optional; Reddit only)
+- `text_transform` (optional; Twitter only)
+
+Skip-set load is not a preprocess stage. You load all prior preprocessed IDs before creating the new run directory. You drop known IDs with pandas, and you collapse remaining IDs last-wins.
+
+You use `load_raw_records` to read every raw run directory. You validate each row with the sync model, and you concatenate the results.
+
+You call `apply_text_transform` before filtering when the spec defines a transform.
+
+You call `filter_records` to keep rows whose text passes all text validators. When the spec defines row validators (Reddit only), you also require the `author` column to pass them.
+
+You call `preprocess_records` to run:
+
+- `validate_dataset_id` (validate)
+- `require_all_runs_complete` (gate)
+- load skip set
+- `load_raw_records` (load raw)
+- drop known IDs
+- collapse candidates
+- `apply_text_transform` (transform, when defined)
+- `filter_records` (filter)
+- `save_preprocessed` (save)
+
+It prints how many rows were kept.
+
+**Platform filters**
+
+Each platform wires validators under `data_platform/preprocessing/validators/`. Bluesky and Twitter apply text validators only. Reddit applies text validators and row validators.
+
+Bluesky text validators (`preprocess_bluesky.py`)
+
+1. You reject rows that contain phone numbers (`check_if_not_phone`).
+2. You keep rows with length 100 to 300 characters (`check_if_valid_post_length`).
+3. You reject rows that contain URLs (`check_if_post_has_no_urls`).
+4. You keep rows with English text (`check_if_text_english`).
+
+Twitter text validators (`preprocess_twitter.py`)
+
+1. You strip `t.co` links before filter and save (`strip_tco_links` in `twitter_validators.py`, wired as `text_transform` on `TWITTER_SPEC`).
+2. You reject rows that contain phone numbers (`check_if_not_phone`).
+3. You keep rows with length 50 to 280 characters (`check_if_valid_twitter_post_length`).
+4. You reject rows with external URLs after `t.co` removal (`check_if_twitter_text_has_no_external_urls`).
+5. You keep rows with English text (`check_if_text_english`).
+
+Reddit comment text validators (`preprocess_reddit.py`)
+
+1. You reject rows with removed or deleted bodies (`check_if_body_not_removed`).
+2. You reject rows with `u/` and `r/` mentions (`check_if_no_reddit_mentions`).
+3. You reject rows with markdown links and images (`check_if_no_markdown_links`).
+4. You reject rows with direct URLs and bare domains (`check_if_no_direct_urls`).
+5. You reject rows with common media host names (`check_if_no_media_hosts`).
+6. You reject rows that contain phone numbers (`check_if_not_phone`).
+7. You keep rows with English text (`check_if_text_english`).
+
+Reddit row validators (`preprocess_reddit.py`)
+
+1. You reject rows whose author is AutoModerator (`check_if_not_automoderator`).
+
+You can re-run preprocessing on the same dataset safely. IDs from earlier preprocessed runs are skipped, and each run still creates a fresh timestamped output directory.
+
+## Stage 3: Feature generation
+
+## Stage 4: Curation

--- a/tests/data_platform/utils/test_deduplication.py
+++ b/tests/data_platform/utils/test_deduplication.py
@@ -12,45 +12,6 @@ from data_platform.utils.deduplication import (
 )
 
 
-def test_session_warm_loads_current_run_only_by_default() -> None:
-    storage = MagicMock()
-    storage.load_seen_ids_from_disk.return_value = {"uri-a"}
-    config = DedupeConfig(id_column="uri", filename="posts.csv")
-    session = DedupeSession(config)
-    session.warm(storage, Path("/tmp/run"))
-
-    assert session.seen_ids == {"uri-a"}
-    storage.load_seen_ids_from_disk.assert_called_once_with(
-        Path("/tmp/run"), "uri", filename="posts.csv"
-    )
-    storage.load_seen_ids_from_all_runs.assert_not_called()
-
-
-def test_session_warm_unions_prior_runs_when_enabled() -> None:
-    storage = MagicMock()
-    storage.load_seen_ids_from_disk.return_value = {"uri-a"}
-    storage.load_seen_ids_from_all_runs.return_value = {"uri-b"}
-    config = DedupeConfig(
-        id_column="uri", filename="posts.csv", include_prior_runs=True
-    )
-    session = DedupeSession(config)
-    session.warm(storage, Path("/tmp/run"))
-
-    assert session.seen_ids == {"uri-a", "uri-b"}
-    storage.load_seen_ids_from_all_runs.assert_called_once_with(
-        "uri", filename="posts.csv"
-    )
-    storage = MagicMock()
-    storage.load_seen_ids_from_disk.return_value = {"uri-b"}
-    config = DedupeConfig(id_column="uri", filename="posts.csv")
-    session = DedupeSession(config)
-    session.seen_ids = {"uri-a"}
-    session.warm(storage, Path("/tmp/run"))
-
-    assert session.seen_ids == {"uri-a", "uri-b"}
-    storage.load_seen_ids_from_all_runs.assert_not_called()
-
-
 def test_policy_includes_prior_runs() -> None:
     assert policy_includes_prior_runs(["current_run"]) is False
     assert policy_includes_prior_runs(["current_run", "prior_runs_same_dataset"]) is True
@@ -58,33 +19,7 @@ def test_policy_includes_prior_runs() -> None:
     assert policy_includes_prior_runs(None) is False
 
 
-def test_session_filter_rows_skips_seen() -> None:
-    config = DedupeConfig(id_column="uri")
-    session = DedupeSession(config)
-    session.seen_ids = {"uri-a"}
-
-    kept, skipped = session.filter_rows(
-        [
-            {"uri": "uri-a", "text": "dup"},
-            {"uri": "uri-b", "text": "new"},
-        ]
-    )
-
-    assert kept == [{"uri": "uri-b", "text": "new"}]
-    assert skipped == 1
-
-
-def test_note_appended_updates_seen_ids() -> None:
-    config = DedupeConfig(id_column="uri")
-    session = DedupeSession(config)
-    session.seen_ids = {"uri-a"}
-
-    session.note_appended([{"uri": "uri-b"}, {"uri": "uri-c"}])
-
-    assert session.seen_ids == {"uri-a", "uri-b", "uri-c"}
-
-
-def test_load_seen_ids_unions_current_run_only() -> None:
+def test_load_seen_ids_loads_current_run_only() -> None:
     storage = MagicMock()
     storage.load_seen_ids_from_disk.return_value = {"uri-a"}
     config = DedupeConfig(id_column="uri", filename="posts.csv")
@@ -148,9 +83,9 @@ def test_add_seen_ids_updates_seen_ids() -> None:
     session = DedupeSession(config)
     session.seen_ids = {"uri-a"}
 
-    session.add_seen_ids([{"uri": "uri-b"}])
+    session.add_seen_ids([{"uri": "uri-b"}, {"uri": "uri-c"}])
 
-    assert session.seen_ids == {"uri-a", "uri-b"}
+    assert session.seen_ids == {"uri-a", "uri-b", "uri-c"}
 
 
 def test_dedupe_config_rejects_include_prior_runs() -> None:

--- a/tests/data_platform/utils/test_deduplication.py
+++ b/tests/data_platform/utils/test_deduplication.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from data_platform.utils.deduplication import (
     DedupeConfig,
     DedupeSession,
@@ -149,3 +151,8 @@ def test_add_seen_ids_updates_seen_ids() -> None:
     session.add_seen_ids([{"uri": "uri-b"}])
 
     assert session.seen_ids == {"uri-a", "uri-b"}
+
+
+def test_dedupe_config_rejects_include_prior_runs() -> None:
+    with pytest.raises(TypeError):
+        DedupeConfig(id_column="uri", include_prior_runs=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Skip-set sessions still exposed leftover warmup, filter, and note helpers, and the session config still accepted a prior-runs flag. The stimuli runbook was missing from this stack, and the existing draft still named warmup as a preprocess stage.

## Solution

Delete `warm`, `filter_rows`, `note_appended`, and `DedupeConfig.include_prior_runs`. Keep `load_seen_ids`, `load_seen_ids_from_all_runs`, `exclude_seen_ids`, `add_seen_ids`, and `policy_includes_prior_runs`. Land `docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md` and rewrite Stage 2 extra details to load skip set, drop known IDs, collapse candidates, transform, filter, and save.

## Purpose

Finish the rename after ingest and preprocess already use the explicit skip-set methods. YAML `dedupe_policy` token strings, `FeatureLabelQuery`, and ingest/preprocess/storage callers stay out of this PR.

Plan: `docs/plans/2026-09-02_remove_warmup_api_and_rewrite_stimuli_runbook_c63a77/`

## How to run

```bash
PYTHONPATH=. uv run pytest tests/data_platform -q
rg -n "include_prior_runs|\\.warm\\(|filter_rows|note_appended|_drop_already_preprocessed" data_platform tests docs/runbooks
```

`pytest` exits 0. The grep has no `DedupeSession.warm` and no mermaid node named warm. The only remaining `include_prior_runs` hits are the TypeError test that constructs `DedupeConfig(..., include_prior_runs=True)`.

Fixes #71
Part of #67

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-360d748f-48bd-454a-8236-962ecfa7bde0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-360d748f-48bd-454a-8236-962ecfa7bde0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

