### PR TITLE
Slim preprocess metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. Data-platform code can resolve and validate file paths relative to the `data_platform/` package, using shared full names for posts, comments, and metadata files. [PR #95](https://github.com/METResearchGroup/mirrorView-task/pull/95)
 2. Storage load and write take an explicit package-relative file path, so csv versus parquet comes from the suffix, not from the dataset manifest. [PR #97](https://github.com/METResearchGroup/mirrorView-task/pull/97)
+3. New preprocess metadata is only dataset id, the raw runs considered, and row counts. [PR #98](https://github.com/METResearchGroup/mirrorView-task/pull/98)
 
 ## 2026-09-01
 

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -137,9 +137,7 @@ def save_preprocessed(
     *,
     source_raw_run_dirs: list[str],
 ) -> str:
-    """Write preprocessed records and provenance metadata to a new run directory.
-
-    Metadata contains only ``dataset_id``, ``source_raw_runs``, and ``row_counts``.
+    """Write preprocessed records and metadata to a new run directory.
 
     Parameters
     ----------

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -137,7 +137,20 @@ def save_preprocessed(
     *,
     source_raw_run_dirs: list[str],
 ) -> str:
-    """Persist preprocessed records to a new timestamped run directory."""
+    """Write preprocessed records and provenance metadata to a new run directory.
+
+    Metadata contains only ``dataset_id``, ``source_raw_runs``, and ``row_counts``.
+
+    Parameters
+    ----------
+    source_raw_run_dirs
+        Package-relative raw run directories that were considered.
+
+    Returns
+    -------
+    str
+        Package-relative preprocess run directory.
+    """
     preprocessed_storage = spec.storage_cls(StorageStage.PREPROCESSED, dataset_id)
     file_name = _records_file_name(spec)
 
@@ -146,19 +159,12 @@ def save_preprocessed(
         records.to_dict(orient="records"),
         f"{output_dir}/{file_name}",
     )
-    source_raw_runs = list(source_raw_run_dirs)
-    source_raw_run = source_raw_runs[-1] if source_raw_runs else None
     metadata: dict[str, Any] = {
         "dataset_id": dataset_id,
-        "source_raw_run": (source_raw_run),
-        "source_raw_runs": source_raw_runs,
-        "preprocess_timestamp": output_dir.rsplit("/", 1)[-1],
+        "source_raw_runs": list(source_raw_run_dirs),
         "row_counts": {
             "input": input_count,
             "output": len(records),
-        },
-        "files": {
-            spec.columns.records_file_key: file_name,
         },
     }
     preprocessed_storage.write_run_metadata(output_dir, metadata)

--- a/docs/plans/2026-09-02_slim_preprocess_metadata_61bee6/plan.md
+++ b/docs/plans/2026-09-02_slim_preprocess_metadata_61bee6/plan.md
@@ -1,0 +1,50 @@
+# Slim new preprocess metadata to provenance and row counts
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+New preprocess metadata still stores a files map, a singular source-raw-run field, and a timestamp that already exists as the run directory name. The writer will stop writing those extra keys. A new preprocess run records only the dataset id, the list of raw run directories considered, and input and output row counts. Historical JSON on disk is left alone. Raw and curated metadata are not changed.
+
+## Happy flow
+
+An operator runs a platform preprocess CLI. The writer saves records as before, and it writes metadata with only the three keys. Tests and the stimuli runbook preprocess outputs list name those same keys.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    WriterOld["Writer stores six keys"]
+    Extra["Files map, singular run, timestamp"]
+    WriterOld --> Extra
+  end
+  subgraph after [After]
+    WriterNew["Writer stores three keys"]
+    Keys["Dataset id, source raw runs, row counts"]
+    WriterNew --> Keys
+  end
+```
+
+## Approach
+
+Change only the preprocess metadata mapping that the shared writer saves. Keep the source-raw-runs list as the package-relative directories from the previous pull request. Keep row counts as the existing input and output mapping. Do not add a compatibility reader, and do not rewrite JSON already on disk. Do not drop the raw sync timestamp or the curated files map.
+
+The new key set is exactly dataset id, source raw runs, and row counts. There is no second writer path that still emits the dropped keys. The stimuli runbook preprocess outputs list is updated to those keys. The nested input and output counts stay under row counts, because the issue names that field as the row-count concern.
+
+## Steps
+
+### Step 1: Slim the preprocess writer, tests, and runbook list
+
+Stop writing the files map, the singular source-raw-run field, and the preprocess timestamp. Assert the remaining key set in preprocess tests. Update the preprocess outputs list in the stimuli runbook so it matches.
+
+## What "done" looks like
+
+1. New preprocess metadata keys are only `dataset_id`, `source_raw_runs`, and `row_counts`.
+2. `PYTHONPATH=. uv run pytest tests/data_platform/preprocessing tests/data_platform -q` exits 0.
+3. The stimuli runbook preprocess outputs list matches those keys.
+4. No dual-key writer remains.
+5. Historical JSON on disk is not rewritten.
+6. Sibling issues that drop raw `sync_timestamp` or the curated files map are not bundled.

--- a/docs/plans/2026-09-02_slim_preprocess_metadata_61bee6/steps/step1.md
+++ b/docs/plans/2026-09-02_slim_preprocess_metadata_61bee6/steps/step1.md
@@ -1,0 +1,139 @@
+# Step 1: Slim the preprocess writer, tests, and runbook list
+
+## Goal
+
+New preprocess `metadata.json` contains only `dataset_id`, `source_raw_runs`, and `row_counts`. Tests and the stimuli runbook preprocess outputs list match that key set. Historical JSON is not migrated.
+
+## Caller / unit of work
+
+**Main caller:** `save_preprocessed` in `/workspace/data_platform/preprocessing/runner.py`, invoked by `preprocess_records` in the same file, which the platform entrypoints call.
+
+**Slice:** write a preprocess run whose metadata dict has exactly those three keys; keep package-relative `source_raw_runs` and nested `row_counts` `input` / `output`; update tests and the runbook list.
+
+**Out of scope:** dropping raw `sync_timestamp` (issue #84); dropping curated `files` (issue #85); rewriting JSON already on disk; dual-key compatibility readers; changing how records files are named or loaded.
+
+## Decision (locked)
+
+Pick the option that most literally matches Done-when.
+
+1. The writer dict has exactly three top-level keys: `dataset_id`, `source_raw_runs`, `row_counts`. Do not keep `files`, `source_raw_run`, or `preprocess_timestamp` on any write path.
+2. `source_raw_runs` stays a list of package-relative raw run directories, same strings as today (for example `data/twitter/{dataset_id}/raw/2026_05_31-11:00:00`). An empty list is `[]`. Do not write a singular fallback field.
+3. `row_counts` stays `{"input": <int>, "output": <int>}`. Do not flatten those two numbers to top-level keys.
+4. Keep metadata as a `dict`. Do not add a TypedDict, Pydantic model, or helper class for this slim-down.
+5. Do not add a reader that accepts old keys. Downstream code does not read preprocess `files`, `source_raw_run`, or `preprocess_timestamp`.
+6. Stimuli runbook: `/workspace/docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md` is the operator runbook for the pipeline that produces stimuli. Add or update a preprocess outputs list so it names `dataset_id`, `source_raw_runs`, and `row_counts`. Also update the Preprocessed row in `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md` under `### metadata.json at each stage` so Main fields is those three keys. Do not rewrite other runbook sections. Do not edit JSON under `experiments/`.
+
+No new modules. Phases 2 and 3 have no new files. Do not stub `save_preprocessed`. Unattended: skip Phase 3 approval.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-02_slim_preprocess_metadata_61bee6/plan.md` | Parent plan |
+| `/workspace/data_platform/preprocessing/runner.py` | `save_preprocessed` is the only writer of preprocess metadata |
+| `/workspace/tests/data_platform/preprocessing/test_preprocess_twitter.py` | Asserts `files`, `source_raw_run`, `row_counts` |
+| `/workspace/tests/data_platform/preprocessing/test_preprocess_reddit.py` | Asserts `files` |
+| `/workspace/tests/data_platform/preprocessing/test_preprocess_bluesky.py` | Gates only; change only if a test would otherwise break |
+| `/workspace/docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md` | Stimuli pipeline runbook |
+| `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md` | Preprocessed metadata fields row |
+
+## Files allowed to change
+
+- `/workspace/data_platform/preprocessing/runner.py`
+- `/workspace/tests/data_platform/preprocessing/test_preprocess_twitter.py`
+- `/workspace/tests/data_platform/preprocessing/test_preprocess_reddit.py`
+- `/workspace/tests/data_platform/preprocessing/test_preprocess_bluesky.py` (only if a test would otherwise break)
+- `/workspace/docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md`
+- `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md`
+
+## Files forbidden to change
+
+- `/workspace/data_platform/utils/storage.py`
+- `/workspace/data_platform/ingestion/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/data_platform/generate_features/**`
+- Historical preprocess `metadata.json` under `experiments/` or `data_platform/data/`
+- Raw metadata writers (`sync_timestamp`)
+- Curated metadata `files` map
+- Plan files under `/workspace/docs/plans/2026-09-02_slim_preprocess_metadata_61bee6/` during implementation
+
+## Contracts to lock
+
+`save_preprocessed` in `/workspace/data_platform/preprocessing/runner.py` writes this metadata mapping and no other top-level keys:
+
+```text
+{
+  "dataset_id": dataset_id,
+  "source_raw_runs": list(source_raw_run_dirs),
+  "row_counts": {
+    "input": input_count,
+    "output": len(records),
+  },
+}
+```
+
+Delete the local `source_raw_run` variable. Delete the `files` map. Delete `preprocess_timestamp`.
+
+`source_raw_runs` values remain the package-relative directories already returned by `load_raw_records`.
+
+Function signatures of `save_preprocessed`, `load_raw_records`, and `preprocess_records` stay the same.
+
+## Test design
+
+given a completed Twitter raw run with two rows, one of which fails validators
+when preprocess_records
+then metadata keys are exactly dataset_id, source_raw_runs, row_counts
+and metadata["dataset_id"] equals the dataset id
+and metadata["row_counts"]["input"] == 2
+and metadata["row_counts"]["output"] == 1
+and "files" not in metadata
+and "source_raw_run" not in metadata
+and "preprocess_timestamp" not in metadata
+
+given two completed Twitter raw runs
+when preprocess_records
+then metadata["source_raw_runs"] has two package-relative directories under data/twitter/{id}/raw/
+and "source_raw_run" is not a metadata key
+
+given a completed Reddit raw run
+when preprocess_records
+then metadata keys are exactly dataset_id, source_raw_runs, row_counts
+and "files" is not a metadata key
+
+Update existing tests. Do not add a second writer test module.
+
+## Implementation notes
+
+Follow implement-from-spec. Unattended.
+
+Phase 1: scope above.
+
+Phase 2: no new files. Do not commit an empty scaffold.
+
+Phase 3: contract is the dict above. Do not stub the live writer. Skip approval.
+
+Phase 4: change the preprocess tests so they expect the three-key set. Commit. They must fail because the writer still emits the old keys.
+
+Phase 5 units of work:
+
+1. `save_preprocessed` writes only the three keys (designed tests go green)
+2. Runbook preprocess outputs lists match the three keys
+
+## Must pass
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run pytest tests/data_platform/preprocessing tests/data_platform -q
+```
+
+Expected: exit 0.
+
+A newly written preprocess metadata file has `set(metadata.keys()) == {"dataset_id", "source_raw_runs", "row_counts"}`.
+
+## Must fail / not happen
+
+- Writing `files`, `source_raw_run`, or `preprocess_timestamp` in new preprocess metadata.
+- A second write path that still emits the dropped keys.
+- Reading old keys as aliases.
+- Rewriting historical preprocess JSON under `experiments/` or `data_platform/data/`.
+- Dropping raw `sync_timestamp` or curated `files`.

--- a/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
+++ b/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
@@ -103,7 +103,7 @@ Feature generation uses a separate checkpoint model in `data_platform/generate_f
 | Stage | Path | Main fields |
 |-------|------|-------------|
 | Raw sync | `raw/<timestamp>/metadata.json` | `tasks`, `row_count`, `sync_status`, config snapshot |
-| Preprocessed | `preprocessed/<timestamp>/metadata.json` | source raw runs, row counts, validation stats |
+| Preprocessed | `preprocessed/<timestamp>/metadata.json` | `dataset_id`, `source_raw_runs`, `row_counts` |
 | Features | `features/metadata.json` | per-feature status, batch counts, source preprocessed runs |
 | Curated | `curated/<timestamp>/metadata.json` | filter results, `files.export`, `source_preprocessed_runs` |
 

--- a/docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md
+++ b/docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md
@@ -87,7 +87,10 @@ PYTHONPATH=. uv run python data_platform/curate/curate_reddit.py \
 
 Confirm outputs:
 
+Preprocess writes `preprocessed/<timestamp>/posts.csv` or `comments.csv`, plus `metadata.json` whose keys are only `dataset_id`, `source_raw_runs`, and `row_counts`.
+
 ```text
+data_platform/data/<platform>/<dataset_id>/preprocessed/<timestamp>/metadata.json
 data_platform/data/<platform>/<dataset_id>/curated/<timestamp>/mirrorview.csv
 data_platform/data/<platform>/<dataset_id>/curated/<timestamp>/metadata.json
 ```

--- a/tests/data_platform/preprocessing/test_preprocess_reddit.py
+++ b/tests/data_platform/preprocessing/test_preprocess_reddit.py
@@ -110,9 +110,10 @@ def test_preprocess_records_writes_output(data_root) -> None:
 
     assert len(output) == 1
     assert output.iloc[0]["comment_fullname"] == "t1_keep"
+    assert set(metadata.keys()) == {"dataset_id", "source_raw_runs", "row_counts"}
+    assert metadata["dataset_id"] == dataset_id
     assert metadata["row_counts"]["input"] == 2
     assert metadata["row_counts"]["output"] == 1
-    assert metadata["files"]["comments"] == "comments.csv"
 
 
 def test_individual_reddit_validator_functions() -> None:

--- a/tests/data_platform/preprocessing/test_preprocess_twitter.py
+++ b/tests/data_platform/preprocessing/test_preprocess_twitter.py
@@ -132,9 +132,10 @@ def test_preprocess_records_writes_output(data_root) -> None:
 
     assert len(output) == 1
     assert output.iloc[0]["tweet_id"] == "1000000000000000001"
+    assert set(metadata.keys()) == {"dataset_id", "source_raw_runs", "row_counts"}
+    assert metadata["dataset_id"] == dataset_id
     assert metadata["row_counts"]["input"] == 2
     assert metadata["row_counts"]["output"] == 1
-    assert metadata["files"]["posts"] == "posts.csv"
 
 
 def test_preprocess_records_strips_tco_from_saved_text(data_root) -> None:
@@ -209,9 +210,9 @@ def test_preprocess_records_merges_all_raw_runs_and_sets_source_raw_runs(data_ro
     # Newest wins: we keep the row from the newer run after deduping.
     assert output_df.iloc[0]["text"] == newer_text
 
-    assert "source_raw_runs" in metadata
+    assert set(metadata.keys()) == {"dataset_id", "source_raw_runs", "row_counts"}
+    assert metadata["dataset_id"] == dataset_id
     assert len(metadata["source_raw_runs"]) == 2
-    assert metadata["source_raw_runs"][-1] == metadata["source_raw_run"]
     assert metadata["source_raw_runs"][0] == (
         f"data/twitter/{dataset_id}/raw/2026_05_31-11:00:00"
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #83
Part of #80

## Problem

New preprocess metadata still stored a files map, a singular source-raw-run field, and a timestamp that already exists as the run directory name. Those fields duplicated information that lives in the records file name and the run directory.

## Solution

New preprocess metadata has only `dataset_id`, `source_raw_runs`, and `row_counts`. The files map, the singular source-raw-run field, and the preprocess timestamp are no longer written. Tests and the stimuli runbook preprocess outputs list match that key set.

## Purpose

Keep new preprocess metadata to provenance and row counts that cannot be reconstructed from the tree. Historical JSON on disk is left alone. There is no dual-key writer and no compatibility reader for old keys. Dropping raw `sync_timestamp` and the curated files map is out of scope.

## How to run

From the repo root:

```bash
PYTHONPATH=. uv run pytest tests/data_platform/preprocessing tests/data_platform -q
```

Expected: exit 0.

A newly written `preprocessed/<timestamp>/metadata.json` has exactly the keys `dataset_id`, `source_raw_runs`, and `row_counts`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8737d289-34a7-48b1-9f23-38ab2b359133?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8737d289-34a7-48b1-9f23-38ab2b359133&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

