### PR TITLE
Stamp raw ingest rows from the run folder name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. Data-platform code can resolve and validate file paths relative to the `data_platform/` package, using shared full names for posts, comments, and metadata files. [PR #95](https://github.com/METResearchGroup/mirrorView-task/pull/95)
 2. Storage load and write take an explicit package-relative file path, so csv versus parquet comes from the suffix, not from the dataset manifest. [PR #97](https://github.com/METResearchGroup/mirrorView-task/pull/97)
 3. New preprocess metadata is only dataset id, the raw runs considered, and row counts. [PR #98](https://github.com/METResearchGroup/mirrorView-task/pull/98)
+4. New raw metadata omits the sync timestamp field, and resume stamps Twitter and Reddit rows from the run folder name. [PR #99](https://github.com/METResearchGroup/mirrorView-task/pull/99)
 
 ## 2026-09-01
 

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -205,14 +205,12 @@ def _initial_task_progress(task: BlueskyTask) -> dict[str, Any]:
 def init_sync_metadata(
     config: dict[str, Any],
     config_path: Path,
-    sync_timestamp: str,
     sync_tasks: list[BlueskyTask],
 ) -> dict[str, Any]:
     """Build the initial metadata.json payload for a new raw run directory."""
     return build_base_sync_metadata(
         config,
         config_path,
-        sync_timestamp,
         sync_tasks,
         task_progress_builder=_initial_task_progress,
     )
@@ -339,7 +337,7 @@ def sync_records(
         storage,
         sync_tasks,
         run_dir_name=run_dir_name,
-        init_metadata_fn=lambda ts: init_sync_metadata(config, config_path, ts, sync_tasks),
+        init_metadata_fn=lambda: init_sync_metadata(config, config_path, sync_tasks),
         entity_label="keywords",
     )
 

--- a/data_platform/ingestion/sync_checkpoint.py
+++ b/data_platform/ingestion/sync_checkpoint.py
@@ -172,7 +172,6 @@ def parse_max_rows(ingestion_params: dict[str, Any]) -> int | None:
 def build_base_sync_metadata(
     config: dict[str, Any],
     config_path: Path,
-    sync_timestamp: str,
     sync_tasks: Sequence[TTask],
     *,
     task_progress_builder: Callable[[TTask], dict[str, Any]],
@@ -184,7 +183,6 @@ def build_base_sync_metadata(
         "name": config["name"],
         "description": config["description"],
         "date": config["date"],
-        "sync_timestamp": sync_timestamp,
         "ingestion_config": config_path.name,
         "record_types": config["record_types"],
         "ingestion_params": config["ingestion_params"],
@@ -290,7 +288,7 @@ def prepare_sync_run(
     sync_tasks: Sequence[HasTaskId],
     *,
     run_dir_name: str | None,
-    init_metadata_fn: Callable[[str], dict[str, Any]],
+    init_metadata_fn: Callable[[], dict[str, Any]],
     entity_label: str,
 ) -> tuple[str, dict[str, Any]]:
     resume_dir = find_resume_run_dir(storage, run_dir_name=run_dir_name)
@@ -305,7 +303,7 @@ def prepare_sync_run(
 
     sync_timestamp = get_current_timestamp()
     output_dir = storage.create_new_run_dir(sync_timestamp)
-    metadata = init_metadata_fn(sync_timestamp)
+    metadata = init_metadata_fn()
     flush_run_metadata(storage, output_dir, metadata)
     print(f"sync_records: started new run {output_dir}")
     return output_dir, metadata

--- a/data_platform/ingestion/sync_reddit.py
+++ b/data_platform/ingestion/sync_reddit.py
@@ -470,7 +470,7 @@ def run_sync_tasks(
     include_posts: bool,
 ) -> None:
     max_rows_int = parse_max_rows(ingestion_params)
-    sync_timestamp = str(metadata["sync_timestamp"])
+    sync_timestamp = Path(relative_run_dir).name
     comments_csv = COMMENTS_FILENAME
     posts_csv = POSTS_FILENAME
 

--- a/data_platform/ingestion/sync_reddit.py
+++ b/data_platform/ingestion/sync_reddit.py
@@ -356,13 +356,11 @@ def _initial_task_progress(task: RedditTask) -> dict[str, Any]:
 def init_sync_metadata(
     config: dict[str, Any],
     config_path: Path,
-    sync_timestamp: str,
     sync_tasks: list[RedditTask],
 ) -> dict[str, Any]:
     return build_base_sync_metadata(
         config,
         config_path,
-        sync_timestamp,
         sync_tasks,
         task_progress_builder=_initial_task_progress,
         extra_fields={"post_row_count": 0},
@@ -589,7 +587,7 @@ def sync_records(
         comment_storage,
         sync_tasks,
         run_dir_name=run_dir_name,
-        init_metadata_fn=lambda ts: init_sync_metadata(config, config_path, ts, sync_tasks),
+        init_metadata_fn=lambda: init_sync_metadata(config, config_path, sync_tasks),
         entity_label="subreddits",
     )
 

--- a/data_platform/ingestion/sync_twitter.py
+++ b/data_platform/ingestion/sync_twitter.py
@@ -107,13 +107,13 @@ def run_sync_tasks(
     metadata: dict[str, Any],
     sync_tasks: list[TwitterTask],
     *,
-    sync_timestamp: str,
     csv_filename: str,
 ) -> None:
     max_rows_int = parse_max_rows(ingestion_params)
     lang = str(ingestion_params.get("lang", "en"))
     exclude = list(ingestion_params.get("exclude", ["reply", "retweet", "quote"]))
     relative_file_path = f"{relative_run_dir}/{csv_filename}"
+    sync_timestamp = Path(relative_run_dir).name
     dedupe_session = DedupeSession(
         DedupeConfig(
             id_column="tweet_id",
@@ -213,7 +213,6 @@ def sync_records(
         init_metadata_fn=lambda: init_sync_metadata(config, config_path, sync_tasks),
         entity_label="keywords",
     )
-    sync_timestamp = str(metadata["sync_timestamp"])
 
     run_sync_tasks(
         client,
@@ -222,7 +221,6 @@ def sync_records(
         storage,
         metadata,
         sync_tasks,
-        sync_timestamp=sync_timestamp,
         csv_filename=POSTS_FILENAME,
     )
     finalize_local_disk_sync(storage, output_dir, metadata)

--- a/data_platform/ingestion/sync_twitter.py
+++ b/data_platform/ingestion/sync_twitter.py
@@ -76,13 +76,11 @@ def _initial_task_progress(task: TwitterTask) -> dict[str, Any]:
 def init_sync_metadata(
     config: dict[str, Any],
     config_path: Path,
-    sync_timestamp: str,
     sync_tasks: list[TwitterTask],
 ) -> dict[str, Any]:
     return build_base_sync_metadata(
         config,
         config_path,
-        sync_timestamp,
         sync_tasks,
         task_progress_builder=_initial_task_progress,
     )
@@ -212,7 +210,7 @@ def sync_records(
         storage,
         sync_tasks,
         run_dir_name=run_dir_name,
-        init_metadata_fn=lambda ts: init_sync_metadata(config, config_path, ts, sync_tasks),
+        init_metadata_fn=lambda: init_sync_metadata(config, config_path, sync_tasks),
         entity_label="keywords",
     )
     sync_timestamp = str(metadata["sync_timestamp"])

--- a/docs/plans/2026-09-02_resume_raw_ingest_from_run_dir_9f2b18/plan.md
+++ b/docs/plans/2026-09-02_resume_raw_ingest_from_run_dir_9f2b18/plan.md
@@ -1,0 +1,51 @@
+# Stamp raw ingest rows from the run folder name
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+New raw metadata still has a sync timestamp field whose value is already the run folder name. The resume path reads that field when it stamps Twitter and Reddit rows. The shared writer will omit the field. The resume path will stamp rows from the timestamp folder name, not from the full package-relative path. Row models keep their timestamp column. Raw row-count field names stay as they are.
+
+## Happy flow
+
+An operator starts a raw ingest, then resumes into the same run directory. The second wave appends rows whose timestamps equal the folder name. The new metadata file has no timestamp field.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    MetaOld["Metadata stores timestamp"]
+    ResumeOld["Resume reads metadata field"]
+    MetaOld --> ResumeOld
+  end
+  subgraph after [After]
+    Folder["Run folder name"]
+    ResumeNew["Resume stamps rows from folder name"]
+    Folder --> ResumeNew
+  end
+```
+
+## Approach
+
+Match the child issue done list in the smallest way. Drop the timestamp field from the shared raw metadata mapping. Derive the row stamp from the last path segment of the package-relative run directory. Keep the timestamp column on Twitter and Reddit row models. Do not add that column to Bluesky rows. Do not rename `row_count` or `post_row_count`. Do not add a reader for the old field. Do not rewrite JSON already on disk. Do not drop the curated files map.
+
+The new writer has one mapping. There is no second path that still emits the dropped field. Resume of an old run that still has the field may keep that key on flush, because this work does not migrate historical JSON.
+
+## Steps
+
+### Step 1: Omit the metadata field and stamp rows from the folder name
+
+Stop writing the timestamp field on new raw metadata. Stamp Twitter and Reddit rows from the run folder name. Update checkpoint tests so resume still completes a second wave into the same directory, and so row timestamps equal that folder name.
+
+## What "done" looks like
+
+1. New raw metadata does not contain `sync_timestamp`.
+2. Resume tests complete a second wave into the same run directory, and row timestamps equal the run folder name.
+3. `PYTHONPATH=. uv run pytest tests/data_platform/ingestion tests/data_platform -q` exits 0.
+4. `row_count` and `post_row_count` are unchanged.
+5. Row models still have a `sync_timestamp` column.
+6. Historical JSON is not rewritten. There is no dual-key writer.
+7. Curated files-map work is not bundled.

--- a/docs/plans/2026-09-02_resume_raw_ingest_from_run_dir_9f2b18/steps/step1.md
+++ b/docs/plans/2026-09-02_resume_raw_ingest_from_run_dir_9f2b18/steps/step1.md
@@ -1,0 +1,203 @@
+# Step 1: Omit the metadata field and stamp rows from the folder name
+
+## Goal
+
+New raw `metadata.json` does not contain `sync_timestamp`. Twitter and Reddit resume stamps CSV row timestamps from the run folder name, which is the last path segment, not the full package-relative directory. `row_count` and `post_row_count` stay as they are. Row models keep their `sync_timestamp` column.
+
+## Caller / unit of work
+
+**Main caller:** `prepare_sync_run` in `/workspace/data_platform/ingestion/sync_checkpoint.py`, used by `sync_records` in `sync_twitter.py`, `sync_reddit.py`, and `sync_bluesky.py`. Twitter and Reddit then stamp rows during `run_sync_tasks`.
+
+**Slice:** write new raw metadata without `sync_timestamp`; on resume and on a new run, stamp Twitter and Reddit rows with `Path(relative_run_dir).name`; keep resume completing a second wave into the same run directory.
+
+**Out of scope:** dropping curated `files` (issue #85); rewriting JSON already on disk; a reader that still looks up `metadata["sync_timestamp"]`; adding `sync_timestamp` to Bluesky rows; renaming `row_count` or `post_row_count`; changing row models; experiments under `/workspace/experiments/`.
+
+## Decision (locked)
+
+Pick the option that most literally matches Done-when.
+
+1. `build_base_sync_metadata` in `/workspace/data_platform/ingestion/sync_checkpoint.py` does not include a `sync_timestamp` key. Remove the `sync_timestamp` parameter from that function. Do not write the key on any other path.
+2. `init_sync_metadata` in `/workspace/data_platform/ingestion/sync_twitter.py`, `/workspace/data_platform/ingestion/sync_reddit.py`, and `/workspace/data_platform/ingestion/sync_bluesky.py` drops the `sync_timestamp` parameter and stops passing it into `build_base_sync_metadata`.
+3. `prepare_sync_run` still creates a new run directory with `get_current_timestamp()`. Change `init_metadata_fn` to `Callable[[], dict[str, Any]]` and call it with no argument. The three `sync_records` lambdas become `lambda: init_sync_metadata(config, config_path, sync_tasks)`.
+4. Stamp value is `Path(relative_run_dir).name`. That is the timestamp folder, for example `2026_05_30-10:00:00`. It is not the package-relative directory, for example `data/twitter/{dataset_id}/raw/2026_05_30-10:00:00`. Inline `Path(...).name` at the two stamp sites. Do not add a new helper module. Do not add a named helper unless a third call site appears.
+5. Twitter: remove the `sync_timestamp` parameter from `run_sync_tasks`. Set `sync_timestamp = Path(relative_run_dir).name` inside `run_sync_tasks` and pass that string into `fetch_posts_for_keyword`. Remove `sync_timestamp = str(metadata["sync_timestamp"])` from `sync_records`.
+6. Reddit: in `run_sync_tasks`, replace `sync_timestamp = str(metadata["sync_timestamp"])` with `sync_timestamp = Path(relative_run_dir).name`. Keep passing that string into `fetch_records_for_subreddit`.
+7. Bluesky rows have no `sync_timestamp` column. Do not add one. Only drop the unused metadata parameter on Bluesky `init_sync_metadata`.
+8. Keep `sync_timestamp` on `SyncTwitterPostModel`, `SyncRedditPostModel`, and `SyncRedditCommentModel` in `/workspace/data_platform/models/sync.py`. Keep fixture rows in `twitter_conftest.py` and `reddit_conftest.py` with that column.
+9. Keep metadata keys `row_count` and `post_row_count` with the same names and meanings. Reddit still writes both.
+10. Do not strip `sync_timestamp` from metadata loaded on resume. Flush writes the dict that was loaded. Old JSON that still has the key may keep it. New JSON must not grow the key.
+11. Do not read `metadata["sync_timestamp"]` as a fallback. Do not add a dual-key writer.
+
+No new modules. Phases 2 and 3 have no new files. Do not stub `build_base_sync_metadata`, `prepare_sync_run`, or `run_sync_tasks`. Unattended: skip Phase 3 approval.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-02_resume_raw_ingest_from_run_dir_9f2b18/plan.md` | Parent plan |
+| `/workspace/data_platform/ingestion/sync_checkpoint.py` | Shared metadata writer and `prepare_sync_run` |
+| `/workspace/data_platform/ingestion/sync_twitter.py` | Reads metadata stamp; `run_sync_tasks` takes an explicit stamp |
+| `/workspace/data_platform/ingestion/sync_reddit.py` | Reads metadata stamp inside `run_sync_tasks` |
+| `/workspace/data_platform/ingestion/sync_bluesky.py` | `init_sync_metadata` still takes the unused stamp |
+| `/workspace/data_platform/models/sync.py` | Row models keep the column |
+| `/workspace/tests/data_platform/ingestion/test_sync_checkpoint.py` | `test_build_base_sync_metadata_includes_tasks` |
+| `/workspace/tests/data_platform/ingestion/test_sync_twitter_checkpoint.py` | Resume and `init_sync_metadata` / `run_sync_tasks` calls |
+| `/workspace/tests/data_platform/ingestion/test_sync_reddit_checkpoint.py` | Resume and `init_sync_metadata` calls |
+| `/workspace/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py` | `init_sync_metadata` calls |
+| `/workspace/data_platform/utils/storage.py` | `create_new_run_dir` returns a package-relative directory |
+
+## Files allowed to change
+
+- `/workspace/data_platform/ingestion/sync_checkpoint.py`
+- `/workspace/data_platform/ingestion/sync_twitter.py`
+- `/workspace/data_platform/ingestion/sync_reddit.py`
+- `/workspace/data_platform/ingestion/sync_bluesky.py`
+- `/workspace/tests/data_platform/ingestion/test_sync_checkpoint.py`
+- `/workspace/tests/data_platform/ingestion/test_sync_twitter_checkpoint.py`
+- `/workspace/tests/data_platform/ingestion/test_sync_reddit_checkpoint.py`
+- `/workspace/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py`
+
+## Files forbidden to change
+
+- `/workspace/data_platform/models/sync.py`
+- `/workspace/data_platform/ingestion/twitter_client.py`
+- `/workspace/tests/data_platform/ingestion/twitter_conftest.py`
+- `/workspace/tests/data_platform/ingestion/reddit_conftest.py`
+- `/workspace/data_platform/preprocessing/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/data_platform/generate_features/**`
+- Historical `metadata.json` under `experiments/` or `data_platform/data/`
+- Plan files under `/workspace/docs/plans/2026-09-02_resume_raw_ingest_from_run_dir_9f2b18/` during implementation
+
+## Contracts to lock
+
+`build_base_sync_metadata` writes this mapping plus optional `extra_fields`, and does not include `sync_timestamp`:
+
+```text
+{
+  "sync_status": SyncStatus.IN_PROGRESS.value,
+  "dataset_id": require_dataset_id(config),
+  "name": config["name"],
+  "description": config["description"],
+  "date": config["date"],
+  "ingestion_config": config_path.name,
+  "record_types": config["record_types"],
+  "ingestion_params": config["ingestion_params"],
+  "row_count": 0,
+  "tasks": {task.task_id: task_progress_builder(task) for task in sync_tasks},
+}
+```
+
+Signature:
+
+```text
+def build_base_sync_metadata(
+    config: dict[str, Any],
+    config_path: Path,
+    sync_tasks: Sequence[TTask],
+    *,
+    task_progress_builder: Callable[[TTask], dict[str, Any]],
+    extra_fields: dict[str, Any] | None = None,
+) -> dict[str, Any]
+```
+
+`prepare_sync_run`:
+
+```text
+init_metadata_fn: Callable[[], dict[str, Any]]
+...
+metadata = init_metadata_fn()
+```
+
+Twitter and Reddit row stamp:
+
+```text
+sync_timestamp = Path(relative_run_dir).name
+```
+
+`row_count` remains the comment or post count already stored today. Reddit `post_row_count` remains the post count.
+
+## Test design
+
+given `build_base_sync_metadata` for a Twitter config with extra_fields post_row_count 0
+when the function returns
+then "sync_timestamp" is not a key
+and metadata["row_count"] == 0
+and metadata["post_row_count"] == 0
+
+given Twitter, Reddit, and Bluesky `init_sync_metadata` without a timestamp argument
+when the function returns
+then "sync_timestamp" is not a key
+and the task ledger is unchanged
+
+given a Twitter run directory whose package-relative path ends with `2026_05_30-10:00:00`
+and task alpha already completed
+when `run_sync_tasks` resumes the remaining task
+then only beta is fetched
+and resumed metadata["row_count"] == 2
+and every stored row's `sync_timestamp` equals `Path(run_dir).name`
+and that value is not equal to `run_dir`
+and "sync_timestamp" is not a key in resumed metadata
+
+given a Reddit run directory whose package-relative path ends with `2026_05_30-10:00:00`
+and subreddit alphasub already completed
+when `run_sync_tasks` resumes the remaining subreddit
+then only betasub is fetched
+and resumed metadata["row_count"] == 2
+and stored comment and post rows from the second wave have `sync_timestamp` equal to `Path(run_dir).name`
+and that value is not equal to `run_dir`
+and "sync_timestamp" is not a key in resumed metadata
+
+given Bluesky resume of a completed task
+when `run_sync_tasks` runs the second wave
+then it still skips the completed task and finishes into the same run directory
+and "sync_timestamp" is not a key in resumed metadata
+
+Twitter resume `fake_fetch` must write `sync_timestamp` from the argument it receives onto the returned rows, using `mock_tweet_row(..., sync_timestamp=sync_timestamp)`. Reddit resume `fake_fetch` must do the same for `mock_post_row` and `mock_comment_row`. After Phase 4, drop `sync_timestamp=` from every Twitter `run_sync_tasks` call. After Phase 4, drop the timestamp positional argument from every `init_sync_metadata` and `build_base_sync_metadata` call.
+
+Load stored rows with `storage.load_records(f"{run_dir}/{POSTS_FILENAME}")` (and comments for Reddit). Assert the column values, not only that the key exists.
+
+Update existing tests. Do not add a second test module.
+
+## Implementation notes
+
+Follow implement-from-spec. Unattended.
+
+Phase 1: scope above.
+
+Phase 2: no new files. Do not commit an empty scaffold.
+
+Phase 3: contracts above. Do not stub the live writer. Skip approval.
+
+Phase 4: change the tests listed above. Commit. They must fail because metadata still contains `sync_timestamp`, Twitter `run_sync_tasks` still requires the stamp argument, and Reddit `run_sync_tasks` still reads `metadata["sync_timestamp"]`.
+
+Phase 5 units of work:
+
+1. `build_base_sync_metadata` omits `sync_timestamp` and drops that parameter. `init_sync_metadata` on all three platforms drops the parameter. `prepare_sync_run` calls `init_metadata_fn()` with no argument. Metadata tests go green.
+2. Twitter `run_sync_tasks` derives `Path(relative_run_dir).name` and no longer takes `sync_timestamp`. Twitter `sync_records` no longer reads the metadata field. Twitter resume tests go green.
+3. Reddit `run_sync_tasks` derives `Path(relative_run_dir).name` instead of `metadata["sync_timestamp"]`. Reddit resume tests go green.
+
+## Must pass
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion tests/data_platform -q
+```
+
+Expected: exit 0.
+
+A newly written raw metadata mapping has `"sync_timestamp" not in metadata`.
+
+Twitter and Reddit resume tests complete a second wave into the same `run_dir`. Stored row `sync_timestamp` values equal `Path(run_dir).name`.
+
+## Must fail / not happen
+
+- Writing `sync_timestamp` in new raw metadata.
+- Stamping rows with the full package-relative run directory string.
+- Reading `metadata["sync_timestamp"]` as the stamp source.
+- A second write path that still emits the dropped field.
+- Renaming `row_count` or `post_row_count`.
+- Removing `sync_timestamp` from row models.
+- Adding `sync_timestamp` to Bluesky rows.
+- Rewriting historical raw JSON under `experiments/` or `data_platform/data/`.
+- Dropping curated `files`.

--- a/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py
+++ b/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py
@@ -39,13 +39,13 @@ def test_init_sync_metadata_task_ledger() -> None:
     metadata = sync_bluesky.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
     assert metadata["sync_status"] == "in_progress"
     assert set(metadata["tasks"]) == {"alpha", "beta"}
     assert metadata["tasks"]["alpha"]["status"] == "pending"
     assert metadata["tasks"]["alpha"]["kind"] == "bluesky"
+    assert "sync_timestamp" not in metadata
 
 
 def test_run_sync_tasks_appends_per_keyword(
@@ -60,7 +60,6 @@ def test_run_sync_tasks_appends_per_keyword(
     metadata = sync_bluesky.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -124,7 +123,6 @@ def test_run_sync_tasks_skips_ids_from_other_dataset(
     metadata = sync_bluesky.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -190,7 +188,6 @@ def test_run_sync_tasks_respects_current_run_only_policy(
     metadata = sync_bluesky.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -232,7 +229,6 @@ def test_run_sync_tasks_dedupes_within_run(
     metadata = sync_bluesky.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
     duplicate_uri = "at://did:plc:ex/app.bsky.feed.post/dup"
@@ -275,7 +271,6 @@ def test_resume_skips_completed_tasks(
     metadata = sync_bluesky.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
     metadata["tasks"]["alpha"]["status"] = "completed"
@@ -323,6 +318,7 @@ def test_resume_skips_completed_tasks(
     assert calls == ["beta"]
     assert resumed_metadata["tasks"]["beta"]["status"] == "completed"
     assert resumed_metadata["row_count"] == 2
+    assert "sync_timestamp" not in resumed_metadata
 
 
 def test_resume_dedupes_against_records_from_completed_tasks(
@@ -337,7 +333,6 @@ def test_resume_dedupes_against_records_from_completed_tasks(
     metadata = sync_bluesky.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -419,7 +414,6 @@ def test_run_sync_tasks_caps_fetch_by_remaining_max_rows(
     metadata = sync_bluesky.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 

--- a/tests/data_platform/ingestion/test_sync_checkpoint.py
+++ b/tests/data_platform/ingestion/test_sync_checkpoint.py
@@ -117,14 +117,15 @@ def test_build_base_sync_metadata_includes_tasks() -> None:
     metadata = build_base_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         [_StubTask("alpha")],
         task_progress_builder=lambda task: {"status": TaskStatus.PENDING.value, "id": task.task_id},
         extra_fields={"post_row_count": 0},
     )
     assert metadata["sync_status"] == SyncStatus.IN_PROGRESS.value
     assert metadata["tasks"]["alpha"]["status"] == TaskStatus.PENDING.value
+    assert metadata["row_count"] == 0
     assert metadata["post_row_count"] == 0
+    assert "sync_timestamp" not in metadata
 
 
 def test_find_resume_run_dir_specific_run(data_root) -> None:

--- a/tests/data_platform/ingestion/test_sync_reddit_checkpoint.py
+++ b/tests/data_platform/ingestion/test_sync_reddit_checkpoint.py
@@ -23,13 +23,13 @@ def test_init_sync_metadata_subreddit_task_ledger() -> None:
     metadata = sync_reddit.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
     assert metadata["sync_status"] == "in_progress"
     assert set(metadata["tasks"]) == {"alphasub", "betasub"}
     assert metadata["tasks"]["alphasub"]["status"] == "pending"
     assert metadata["tasks"]["alphasub"]["kind"] == "reddit"
+    assert "sync_timestamp" not in metadata
 
 
 def test_run_sync_tasks_appends_per_subreddit(
@@ -45,7 +45,6 @@ def test_run_sync_tasks_appends_per_subreddit(
     metadata = sync_reddit.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -119,7 +118,6 @@ def test_run_sync_tasks_skips_prior_run_comments(
     metadata = sync_reddit.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -187,7 +185,6 @@ def test_run_sync_tasks_skips_ids_from_other_dataset(
     metadata = sync_reddit.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -256,7 +253,6 @@ def test_run_sync_tasks_respects_current_run_only_policy(
     metadata = sync_reddit.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -313,7 +309,6 @@ def test_resume_skips_completed_subreddits(
     metadata = sync_reddit.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
     metadata["tasks"]["alphasub"]["status"] = "completed"
@@ -337,9 +332,13 @@ def test_resume_skips_completed_subreddits(
         include_comments: bool,
     ):
         calls.append(subreddit)
+        post_row = mock_post_row("t3_post_b1", subreddit="betasub")
+        post_row["sync_timestamp"] = sync_timestamp
+        comment_row = mock_comment_row("t1_comment_b1", subreddit="betasub")
+        comment_row["sync_timestamp"] = sync_timestamp
         return (
-            [mock_post_row("t3_post_b1", subreddit="betasub")],
-            [mock_comment_row("t1_comment_b1", subreddit="betasub")],
+            [post_row],
+            [comment_row],
             {
                 "subreddit": subreddit,
                 "listing": "hot",
@@ -367,6 +366,14 @@ def test_resume_skips_completed_subreddits(
     assert calls == ["BetaSub"]
     assert resumed_metadata["tasks"]["betasub"]["status"] == "completed"
     assert resumed_metadata["row_count"] == 2
+    assert "sync_timestamp" not in resumed_metadata
+    folder_name = Path(run_dir).name
+    assert folder_name != run_dir
+    comment_rows = comment_storage.load_records(f"{run_dir}/{COMMENTS_FILENAME}")
+    post_rows = post_storage.load_records(f"{run_dir}/{POSTS_FILENAME}")
+    second_wave_comments = comment_rows[comment_rows["comment_fullname"] == "t1_comment_b1"]
+    assert (second_wave_comments["sync_timestamp"] == folder_name).all()
+    assert (post_rows["sync_timestamp"] == folder_name).all()
 
 
 def test_build_sync_tasks_strips_r_prefix() -> None:

--- a/tests/data_platform/ingestion/test_sync_twitter_checkpoint.py
+++ b/tests/data_platform/ingestion/test_sync_twitter_checkpoint.py
@@ -36,13 +36,13 @@ def test_init_sync_metadata_task_ledger() -> None:
     metadata = sync_twitter.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
     assert metadata["sync_status"] == "in_progress"
     assert set(metadata["tasks"]) == {"alpha", "beta"}
     assert metadata["tasks"]["alpha"]["status"] == "pending"
     assert metadata["tasks"]["alpha"]["kind"] == "twitter"
+    assert "sync_timestamp" not in metadata
 
 
 def test_run_sync_tasks_appends_per_keyword(
@@ -57,7 +57,6 @@ def test_run_sync_tasks_appends_per_keyword(
     metadata = sync_twitter.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -90,7 +89,6 @@ def test_run_sync_tasks_appends_per_keyword(
         storage,
         metadata,
         sync_tasks,
-        sync_timestamp="2026_05_30-10:00:00",
         csv_filename=POSTS_FILENAME,
     )
 
@@ -121,7 +119,6 @@ def test_run_sync_tasks_skips_prior_run_tweets_when_enabled(
     metadata = sync_twitter.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -151,7 +148,6 @@ def test_run_sync_tasks_skips_prior_run_tweets_when_enabled(
         storage,
         metadata,
         sync_tasks[:1],
-        sync_timestamp="2026_05_30-10:00:00",
         csv_filename=POSTS_FILENAME,
     )
 
@@ -182,7 +178,6 @@ def test_run_sync_tasks_does_not_skip_prior_runs_when_disabled(
     metadata = sync_twitter.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -212,7 +207,6 @@ def test_run_sync_tasks_does_not_skip_prior_runs_when_disabled(
         storage,
         metadata,
         sync_tasks[:1],
-        sync_timestamp="2026_05_30-10:00:00",
         csv_filename=POSTS_FILENAME,
     )
 
@@ -243,7 +237,6 @@ def test_run_sync_tasks_skips_ids_from_other_dataset(
     metadata = sync_twitter.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -273,7 +266,6 @@ def test_run_sync_tasks_skips_ids_from_other_dataset(
         storage,
         metadata,
         sync_tasks[:1],
-        sync_timestamp="2026_05_30-10:00:00",
         csv_filename=POSTS_FILENAME,
     )
 
@@ -305,7 +297,6 @@ def test_run_sync_tasks_respects_current_run_only_policy(
     metadata = sync_twitter.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
 
@@ -332,7 +323,6 @@ def test_run_sync_tasks_respects_current_run_only_policy(
         storage,
         metadata,
         sync_tasks[:1],
-        sync_timestamp="2026_05_30-10:00:00",
         csv_filename=POSTS_FILENAME,
     )
 
@@ -352,7 +342,6 @@ def test_resume_skips_completed_tasks(
     metadata = sync_twitter.init_sync_metadata(
         config,
         Path("test.yaml"),
-        "2026_05_30-10:00:00",
         sync_tasks,
     )
     metadata["tasks"]["alpha"]["status"] = "completed"
@@ -377,7 +366,13 @@ def test_resume_skips_completed_tasks(
     ):
         calls.append(keyword)
         return (
-            [mock_tweet_row("1000000000000000002", keyword=keyword)],
+            [
+                mock_tweet_row(
+                    "1000000000000000002",
+                    keyword=keyword,
+                    sync_timestamp=sync_timestamp,
+                )
+            ],
             {"pages_fetched": 1, "rows_collected": 1},
         )
 
@@ -391,10 +386,14 @@ def test_resume_skips_completed_tasks(
         storage,
         resumed_metadata,
         sync_tasks,
-        sync_timestamp="2026_05_30-10:00:00",
         csv_filename=POSTS_FILENAME,
     )
 
     assert calls == ["beta"]
     assert resumed_metadata["tasks"]["beta"]["status"] == "completed"
     assert resumed_metadata["row_count"] == 2
+    assert "sync_timestamp" not in resumed_metadata
+    folder_name = Path(run_dir).name
+    assert folder_name != run_dir
+    stored_rows = storage.load_records(f"{run_dir}/{POSTS_FILENAME}")
+    assert (stored_rows["sync_timestamp"] == folder_name).all()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #84
Part of #80

## Problem

New raw metadata still stored a sync timestamp whose value is already the run folder name. Resume read that field when it stamped Twitter and Reddit rows. After run directories became package-relative, using the full directory string as the stamp would be wrong.

## Solution

New raw metadata no longer contains `sync_timestamp`. Resume and new runs stamp Twitter and Reddit row timestamps from the run folder name, which is the last path segment, not the full package-relative path. `row_count` and `post_row_count` stay as they are. Row models still have a `sync_timestamp` column.

## Purpose

Keep new raw metadata as a checkpoint document that does not duplicate the run directory name. Historical JSON on disk is left alone. There is no dual-key writer and no reader that still looks up the old field. Dropping the curated files map is out of scope.

## How to run

From the repo root:

```bash
PYTHONPATH=. uv run pytest tests/data_platform/ingestion tests/data_platform -q
```

Expected: exit 0.

A newly written `raw/<timestamp>/metadata.json` does not contain `sync_timestamp`. Resume tests complete a second wave into the same run directory, and row timestamps equal the run folder name.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8737d289-34a7-48b1-9f23-38ab2b359133?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8737d289-34a7-48b1-9f23-38ab2b359133&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

