### PR TITLE
Drop curated file maps and update in-repo readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 2. Storage load and write take an explicit package-relative file path, so csv versus parquet comes from the suffix, not from the dataset manifest. [PR #97](https://github.com/METResearchGroup/mirrorView-task/pull/97)
 3. New preprocess metadata is only dataset id, the raw runs considered, and row counts. [PR #98](https://github.com/METResearchGroup/mirrorView-task/pull/98)
 4. New raw metadata omits the sync timestamp field, and resume stamps Twitter and Reddit rows from the run folder name. [PR #99](https://github.com/METResearchGroup/mirrorView-task/pull/99)
+5. New curated metadata omits the files map, and in-repo readers join the run directory with the yaml export filename. [PR #100](https://github.com/METResearchGroup/mirrorView-task/pull/100)
 
 ## 2026-09-01
 

--- a/data_platform/curate/curate_bluesky.py
+++ b/data_platform/curate/curate_bluesky.py
@@ -32,7 +32,6 @@ BLUESKY_CURATE_SPEC = CuratePlatformSpec(
     platform="bluesky",
     storage_cls=BlueskyStorageManager,
     columns=BLUESKY_COLUMNS,
-    record_noun="posts",
 )
 
 

--- a/data_platform/curate/curate_bluesky.py
+++ b/data_platform/curate/curate_bluesky.py
@@ -41,6 +41,7 @@ def _is_up_to_date(
     all_preprocessed_run_dirs: list[Path],
     rules_hash: str,
     features_meta: FeatureRunMetadata,
+    config_path: Path,
 ) -> Path | None:
     """Return the existing output path if curation inputs haven't changed, else None."""
     current_runs = [to_package_relative(d) for d in all_preprocessed_run_dirs]
@@ -56,10 +57,7 @@ def _is_up_to_date(
         return None
     if latest_meta.get("rules_hash") != rules_hash:
         return None
-    output_filename = latest_meta.get("files", {}).get("export")
-    if not output_filename:
-        return None
-    output_path = run_dirs[-1] / output_filename
+    output_path = run_dirs[-1] / f"{config_path.stem}.csv"
     if not output_path.exists():
         return None
     return output_path
@@ -90,6 +88,7 @@ def curate(config_path: Path, dataset_id: str) -> Path:
         all_preprocessed_run_dirs,
         rules_hash,
         features_meta,
+        config_path,
     )
     if existing is not None:
         print(f"curate_bluesky: already up to date, skipping ({existing})")

--- a/data_platform/curate/curate_reddit.py
+++ b/data_platform/curate/curate_reddit.py
@@ -24,7 +24,6 @@ REDDIT_CURATE_SPEC = CuratePlatformSpec(
     platform="reddit",
     storage_cls=RedditStorageManager,
     columns=REDDIT_COLUMNS,
-    record_noun="comments",
 )
 
 ID_COLUMN = REDDIT_COLUMNS.records_id_column

--- a/data_platform/curate/curate_twitter.py
+++ b/data_platform/curate/curate_twitter.py
@@ -24,7 +24,6 @@ TWITTER_CURATE_SPEC = CuratePlatformSpec(
     platform="twitter",
     storage_cls=TwitterStorageManager,
     columns=TWITTER_COLUMNS,
-    record_noun="posts",
 )
 
 ID_COLUMN = TWITTER_COLUMNS.records_id_column

--- a/data_platform/curate/runner.py
+++ b/data_platform/curate/runner.py
@@ -29,7 +29,6 @@ class CuratePlatformSpec:
     platform: str
     storage_cls: StorageManagerFactory
     columns: PlatformSpecificColumns
-    record_noun: str
 
 
 def build_curate_metadata(
@@ -120,7 +119,7 @@ def run_curation(
 
     print(
         f"curate_{spec.platform}: kept {len(filtered_df)} of {len(wide_df)} "
-        f"{spec.record_noun} -> {relative_run_dir}"
+        f"records -> {relative_run_dir}"
     )
     return relative_file_path
 

--- a/data_platform/curate/runner.py
+++ b/data_platform/curate/runner.py
@@ -41,7 +41,6 @@ def build_curate_metadata(
     wide_df: pd.DataFrame,
     filtered_df: pd.DataFrame,
     rules_result: ApplyRulesResult,
-    export_filename: str,
 ) -> dict[str, Any]:
     return {
         "dataset_id": dataset_id,
@@ -61,7 +60,6 @@ def build_curate_metadata(
             }
             for step in rules_result.steps
         ],
-        "files": {"export": export_filename},
     }
 
 
@@ -117,7 +115,6 @@ def run_curation(
         wide_df=wide_df,
         filtered_df=filtered_df,
         rules_result=rules_result,
-        export_filename=rules.output.filename,
     )
     curated_storage.write_run_metadata(relative_run_dir, metadata)
 

--- a/docs/plans/2026-09-02_drop_curated_file_maps_c9f3a1/plan.md
+++ b/docs/plans/2026-09-02_drop_curated_file_maps_c9f3a1/plan.md
@@ -1,0 +1,50 @@
+# Drop the curated files map and recompute the export name
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+New curated metadata still stores a files map whose export name is already the yaml config stem plus `.csv`. The writer will omit that map. Skip-if-fresh and the two experiment scripts will join the curated run directory with that derived file name. Curation specs will stop carrying a separate log noun. Historical JSON on disk is left alone.
+
+## Happy flow
+
+An operator runs a curate CLI. The writer saves the export under the yaml file name with a `.csv` suffix, and it writes metadata with no files map. A second Bluesky curate with the same inputs skips, because the latest run directory already has that csv. Sampling scripts find the same csv by globbing metadata.json for run folders, then joining with the name derived from `mirrorview.yaml`.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    MetaOld["Metadata stores files map"]
+    ReadersOld["Skip and scripts read files.export"]
+    MetaOld --> ReadersOld
+  end
+  subgraph after [After]
+    YamlName["Config file stem plus .csv"]
+    ReadersNew["Skip and scripts join run dir with that name"]
+    YamlName --> ReadersNew
+  end
+```
+
+## Approach
+
+Match the child issue done list in the smallest way. Drop the files map from the shared curated metadata mapping. Derive the export file name as the curation config file stem plus `.csv`. Join that name onto the latest curated run directory in Bluesky skip-if-fresh, and onto each discovered run directory in the two experiment scripts. Remove the separate log noun from curation specs. Do not add a reader for the old files key. Do not rewrite JSON already on disk.
+
+The new writer has one mapping. There is no second path that still emits the dropped key. Readers do not fall back to `files.export` when old JSON still has it. The yaml `output.filename` used on write already matches the config stem plus `.csv` in every production config.
+
+## Steps
+
+### Step 1: Omit the files map and recompute the export name
+
+Stop writing the files map on new curated metadata. Skip-if-fresh joins the latest run directory with the yaml export file name. The two experiment scripts stop reading `files.export`. Curation specs drop the log noun. Tests and the architecture metadata list match.
+
+## What "done" looks like
+
+1. New curated metadata does not contain a `files` key.
+2. Bluesky skip-if-fresh joins the latest curated run directory with the yaml export file name.
+3. `experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py` and `count_missing_flips.py` do not read `files.export`.
+4. `PYTHONPATH=. uv run pytest tests/data_platform/curate tests/data_platform -q` exits 0.
+5. Historical JSON is not rewritten. There is no dual-key writer or reader.
+6. Curation specs do not carry a separate log noun.

--- a/docs/plans/2026-09-02_drop_curated_file_maps_c9f3a1/steps/step1.md
+++ b/docs/plans/2026-09-02_drop_curated_file_maps_c9f3a1/steps/step1.md
@@ -1,0 +1,229 @@
+# Step 1: Omit the files map and recompute the export name
+
+## Goal
+
+New curated `metadata.json` has no `files` key. Bluesky skip-if-fresh joins the latest curated run directory with the yaml export file name. The two experiment scripts recompute that name from `mirrorview.yaml` and do not read `files.export`. Curation specs drop `record_noun`. Historical JSON is not migrated.
+
+## Caller / unit of work
+
+**Main caller:** `run_curation` in `/workspace/data_platform/curate/runner.py` (writes metadata), plus `_is_up_to_date` in `/workspace/data_platform/curate/curate_bluesky.py` (skip-if-fresh).
+
+**Slice:** write new curated metadata without `files`; skip when the latest run dir already has `{config_path.stem}.csv`; experiment scripts load that same derived name; specs print "records" instead of a per-platform noun.
+
+**Out of scope:** rewriting JSON already on disk; a reader that still looks up `metadata["files"]["export"]`; changing yaml `output.filename` or how `run_curation` writes the csv; changing preprocess or raw metadata; S3 upload manifests that use a different `files` list.
+
+## Decision (locked)
+
+Pick the option that most literally matches Done-when.
+
+1. `build_curate_metadata` in `/workspace/data_platform/curate/runner.py` does not include a `files` key. Remove the `export_filename` parameter. Do not write the key on any other path.
+2. `run_curation` still writes `f"{relative_run_dir}/{rules.output.filename}"`. Do not change `OutputConfig.filename` or production yaml. Every production yaml already has `output.filename` equal to `{config stem}.csv`.
+3. Bluesky `_is_up_to_date` does not read `latest_meta["files"]`. Pass `config_path: Path`. The yaml export file name is `f"{config_path.stem}.csv"`. Join `run_dirs[-1] / f"{config_path.stem}.csv"`. If that path does not exist, return `None` and rerun. Do not call `load_rules_config` in the skip path. Do not fall back to `files.export` when old JSON still has it.
+4. `curate` in `/workspace/data_platform/curate/curate_bluesky.py` passes `config_path` into `_is_up_to_date`.
+5. Drop `record_noun` from `CuratePlatformSpec`. Drop `record_noun=` from `BLUESKY_CURATE_SPEC`, `TWITTER_CURATE_SPEC`, and `REDDIT_CURATE_SPEC`. The print in `run_curation` uses the word `records` instead of `spec.record_noun`.
+6. `sample_data_to_mirror.py` and `count_missing_flips.py` still glob `*/curated/*/metadata.json` to find run directories. They join `metadata_fp.parent / f"{Path('mirrorview.yaml').stem}.csv"`. They do not `json.loads` metadata for the export name. They do not read `files` or `files.export`. If `json` is then unused in that file, remove the import.
+7. Do not strip `files` from metadata loaded on disk. Flush is not in play here. Old JSON that still has the key stays on disk. New JSON must not grow the key.
+8. Do not add a helper module. Inline `f"{config_path.stem}.csv"` at the skip site. Inline `f"{Path('mirrorview.yaml').stem}.csv"` in each experiment script. Do not add a named helper.
+9. Update the Curated row in `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md` under `### metadata.json at each stage` so Main fields no longer names `files.export`. Replace the sentence that says curate writes export paths into metadata for `sample_data_to_mirror.py`. Update the sample-stage paragraph and `/workspace/docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md` handoff sentence so they say the script globs metadata.json to find run directories and loads `{stem of mirrorview.yaml}.csv`. Do not edit JSON under `experiments/`.
+
+No new modules. Phases 2 and 3 have no new files. Do not stub `build_curate_metadata`, `run_curation`, or `_is_up_to_date`. Unattended: skip Phase 3 approval.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-02_drop_curated_file_maps_c9f3a1/plan.md` | Parent plan |
+| `/workspace/data_platform/curate/runner.py` | Writer and spec log noun |
+| `/workspace/data_platform/curate/curate_bluesky.py` | Skip-if-fresh reads `files.export` |
+| `/workspace/data_platform/curate/curate_twitter.py` | Spec still has `record_noun` |
+| `/workspace/data_platform/curate/curate_reddit.py` | Spec still has `record_noun` |
+| `/workspace/data_platform/curate/apply_rules.py` | `OutputConfig.filename` stays |
+| `/workspace/tests/data_platform/curate/test_curate_bluesky.py` | Skip fixtures seed `files.export` |
+| `/workspace/tests/data_platform/curate/test_curate_twitter.py` | Asserts `metadata["files"]["export"]` |
+| `/workspace/tests/data_platform/curate/test_curate_reddit.py` | Asserts `metadata["files"]["export"]` |
+| `/workspace/experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py` | Reads `files.export` |
+| `/workspace/experiments/scaled_mirrors_generation_2026_06_02/count_missing_flips.py` | Reads `files.export` |
+| `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md` | Curated metadata fields row |
+| `/workspace/docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md` | Handoff still says the script reads metadata for the export |
+
+## Files allowed to change
+
+- `/workspace/data_platform/curate/runner.py`
+- `/workspace/data_platform/curate/curate_bluesky.py`
+- `/workspace/data_platform/curate/curate_twitter.py`
+- `/workspace/data_platform/curate/curate_reddit.py`
+- `/workspace/tests/data_platform/curate/test_curate_bluesky.py`
+- `/workspace/tests/data_platform/curate/test_curate_twitter.py`
+- `/workspace/tests/data_platform/curate/test_curate_reddit.py`
+- `/workspace/experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py`
+- `/workspace/experiments/scaled_mirrors_generation_2026_06_02/count_missing_flips.py`
+- `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md`
+- `/workspace/docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md`
+
+## Files forbidden to change
+
+- `/workspace/data_platform/curate/apply_rules.py`
+- `/workspace/data_platform/curate/configs/**`
+- `/workspace/data_platform/ingestion/**`
+- `/workspace/data_platform/preprocessing/**`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/data_platform/utils/storage.py`
+- Historical `metadata.json` under `experiments/` or `data_platform/data/`
+- Plan files under `/workspace/docs/plans/2026-09-02_drop_curated_file_maps_c9f3a1/` during implementation
+- Webapp S3 scripts whose `files` key is a different manifest
+
+## Contracts to lock
+
+`build_curate_metadata` writes this mapping and does not include `files`:
+
+```text
+{
+  "dataset_id": dataset_id,
+  "name": rules_name,
+  "rules_hash": rules_hash,
+  "source_preprocessed_runs": source_preprocessed_runs,
+  "row_counts": {
+    "preprocessed": len(wide_df),
+    "wide": len(wide_df),
+    "after_filters": len(filtered_df),
+  },
+  "filter_results": [
+    {
+      **step.rule.model_dump(),
+      "records_before": step.records_before,
+      "records_passing": step.records_passing,
+    }
+    for step in rules_result.steps
+  ],
+}
+```
+
+Signature:
+
+```text
+def build_curate_metadata(
+    *,
+    dataset_id: str,
+    rules_name: str,
+    rules_hash: str,
+    source_preprocessed_runs: list[str],
+    wide_df: pd.DataFrame,
+    filtered_df: pd.DataFrame,
+    rules_result: ApplyRulesResult,
+) -> dict[str, Any]
+```
+
+`CuratePlatformSpec`:
+
+```text
+@dataclass(frozen=True)
+class CuratePlatformSpec:
+    platform: str
+    storage_cls: StorageManagerFactory
+    columns: PlatformSpecificColumns
+```
+
+No `record_noun` field. The three platform specs pass only those three fields.
+
+`_is_up_to_date` signature adds `config_path: Path`. After the existing hash and source-run checks, the skip path is:
+
+```text
+output_path = run_dirs[-1] / f"{config_path.stem}.csv"
+if not output_path.exists():
+    return None
+return output_path
+```
+
+Do not read `latest_meta.get("files", ...)`.
+
+Experiment export path:
+
+```text
+export_fp = metadata_fp.parent / f"{Path('mirrorview.yaml').stem}.csv"
+```
+
+`run_curation` print:
+
+```text
+f"curate_{spec.platform}: kept {len(filtered_df)} of {len(wide_df)} records -> {relative_run_dir}"
+```
+
+## Test design
+
+given `run_curation` for Twitter and Reddit mirrorview yaml
+when the function returns
+then `"files" not in metadata`
+and `Path(relative_output).name == "mirrorview.csv"`
+and `source_preprocessed_runs` is unchanged
+
+given Bluesky skip fixtures whose curated metadata has no `files` key
+and the config path is `test.yaml` so the yaml export file name is `test.csv`
+and `test.csv` exists in the latest run dir
+when `curate` runs
+then `run_curation` is not called
+and the result is the existing run dir
+
+given Bluesky skip fixtures with matching hash and source runs
+and the config path is `test.yaml`
+and `test.csv` is missing from the latest run dir
+when `curate` runs
+then `run_curation` is called once
+
+given curated metadata that still contains `files.export` pointing at a different name than `{config_path.stem}.csv`
+and `{config_path.stem}.csv` is missing
+when skip-if-fresh runs
+then it does not treat the old files map as the export name
+and `run_curation` is called
+
+Do not add a second test module. Update existing tests. `_write_curated_run` must stop writing a `files` key. Drop the `export_filename` parameter from that helper if nothing else uses it. After Phase 4, Twitter and Reddit assertions that read `metadata["files"]["export"]` become `"files" not in metadata`.
+
+Experiment scripts have no pytest. After they stop reading `files.export`, grep of those two files must not match `files.export` or `metadata["files"]`.
+
+## Implementation notes
+
+Follow implement-from-spec. Unattended.
+
+Phase 1: scope above.
+
+Phase 2: no new files. Do not commit an empty scaffold.
+
+Phase 3: contracts above. Do not stub the live writer. Skip approval.
+
+Phase 4: change the tests listed above. Commit. They must fail because metadata still contains `files`, Bluesky skip still requires `files.export` in seeded metadata, and `_write_curated_run` no longer seeds that key.
+
+Phase 5 units of work:
+
+1. `build_curate_metadata` omits `files` and drops `export_filename`. `run_curation` stops passing that argument. Twitter and Reddit metadata tests go green.
+2. `_is_up_to_date` takes `config_path` and joins `run_dirs[-1] / f"{config_path.stem}.csv"`. `curate` passes `config_path`. Bluesky skip tests go green.
+3. Drop `record_noun` from `CuratePlatformSpec` and the three platform specs. Print uses `records`.
+4. Experiment scripts join the run dir with `{Path('mirrorview.yaml').stem}.csv` and stop reading metadata for the export name.
+5. Runbook Curated fields row and sample handoff sentences match the new readers.
+
+## Must pass
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run pytest tests/data_platform/curate tests/data_platform -q
+```
+
+Expected: exit 0.
+
+A newly written curated metadata mapping has `"files" not in metadata`.
+
+Bluesky skip-if-fresh succeeds when `{config_path.stem}.csv` exists in the latest run dir, even if metadata has no `files` key.
+
+```bash
+rg -n 'files\.export|metadata\["files"\]' experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py experiments/scaled_mirrors_generation_2026_06_02/count_missing_flips.py data_platform/curate
+```
+
+Expected: no matches.
+
+## Must fail / not happen
+
+- Writing `files` in new curated metadata.
+- Reading `latest_meta["files"]` or `metadata["files"]["export"]` as the export source.
+- A second write path that still emits the dropped key.
+- Falling back to `files.export` when old JSON still has it.
+- Rewriting historical curated JSON under `experiments/` or `data_platform/data/`.
+- Changing yaml `output.filename` or the `run_curation` write path.
+- Keeping `record_noun` on `CuratePlatformSpec`.

--- a/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
+++ b/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
@@ -105,9 +105,9 @@ Feature generation uses a separate checkpoint model in `data_platform/generate_f
 | Raw sync | `raw/<timestamp>/metadata.json` | `tasks`, `row_count`, `sync_status`, config snapshot |
 | Preprocessed | `preprocessed/<timestamp>/metadata.json` | `dataset_id`, `source_raw_runs`, `row_counts` |
 | Features | `features/metadata.json` | per-feature status, batch counts, source preprocessed runs |
-| Curated | `curated/<timestamp>/metadata.json` | filter results, `files.export`, `source_preprocessed_runs` |
+| Curated | `curated/<timestamp>/metadata.json` | filter results, `source_preprocessed_runs` |
 
-Curate writes export paths into metadata so `sample_data_to_mirror.py` can find the CSV without hardcoded timestamps.
+`sample_data_to_mirror.py` globs curated `metadata.json` files to find run directories, then loads the csv named from `mirrorview.yaml` (the stem plus `.csv`).
 
 ## Pipeline stages
 
@@ -155,7 +155,7 @@ Entrypoints:
 
 ### 5. Sample data to mirror
 
-`experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py` discovers curated exports by globbing `data_platform/data/*/*/curated/*/metadata.json`. It reads each metadata file and loads the export CSV. It normalizes rows, deduplicates, and samples by toxicity tier and platform. Output goes to `concatenated_records/<timestamp>/records.csv` under the experiment folder.
+`experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py` discovers curated exports by globbing `data_platform/data/*/*/curated/*/metadata.json`. It joins each run directory with the csv named from `mirrorview.yaml` (the stem plus `.csv`). It normalizes rows, deduplicates, and samples by toxicity tier and platform. Output goes to `concatenated_records/<timestamp>/records.csv` under the experiment folder.
 
 ## Platform differences
 

--- a/docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md
+++ b/docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md
@@ -105,7 +105,7 @@ After curated `mirrorview.csv` exists for all three platforms:
 PYTHONPATH=. uv run python experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py
 ```
 
-`sample_data_to_mirror.py` reads metadata under `data_platform/data/<platform>/<dataset_id>/curated/<timestamp>/metadata.json`, and it writes `concatenated_records/<timestamp>/records.csv` under the experiment folder.
+`sample_data_to_mirror.py` globs `metadata.json` under `data_platform/data/<platform>/<dataset_id>/curated/<timestamp>/` to find run directories, then loads the csv named from `mirrorview.yaml` (the stem plus `.csv`). It writes `concatenated_records/<timestamp>/records.csv` under the experiment folder.
 
 Then run flip generation and balancing in that experiment. Promote a job CSV, and follow the runbooks below.
 

--- a/experiments/scaled_mirrors_generation_2026_06_02/count_missing_flips.py
+++ b/experiments/scaled_mirrors_generation_2026_06_02/count_missing_flips.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pandas as pd
@@ -29,8 +28,7 @@ def load_data_records() -> pd.DataFrame:
         if integration not in INTEGRATIONS:
             continue
 
-        metadata = json.loads(metadata_fp.read_text(encoding="utf-8"))
-        export_fp = metadata_fp.parent / metadata["files"]["export"]
+        export_fp = metadata_fp.parent / f"{Path('mirrorview.yaml').stem}.csv"
         if not export_fp.exists():
             raise RuntimeError(f"Missing export for `{metadata_fp}` (expected `{export_fp}`).")
 

--- a/experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py
+++ b/experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py
@@ -17,7 +17,7 @@ PYTHONPATH=. uv run python experiments/scaled_mirrors_generation_2026_06_02/samp
 from __future__ import annotations
 
 import hashlib
-import json
+from pathlib import Path
 
 import pandas as pd
 
@@ -293,8 +293,7 @@ def main() -> None:
             # Ignore any unexpected folder names under `data/`.
             continue
 
-        metadata = json.loads(metadata_fp.read_text(encoding="utf-8"))
-        export_name = metadata["files"]["export"]
+        export_name = f"{Path('mirrorview.yaml').stem}.csv"
         export_fp = metadata_fp.parent / export_name
 
         if not export_fp.exists():

--- a/tests/data_platform/curate/test_curate_bluesky.py
+++ b/tests/data_platform/curate/test_curate_bluesky.py
@@ -60,19 +60,17 @@ def _write_curated_run(
     *,
     source_preprocessed_runs: list[str],
     rules_hash: str,
-    export_filename: str = "test.csv",
     write_output_file: bool = True,
 ) -> Path:
     run_dir = data_root / "bluesky" / dataset_id / "curated" / run_name
     run_dir.mkdir(parents=True)
     if write_output_file:
-        (run_dir / export_filename).write_text("uri\n", encoding="utf-8")
+        (run_dir / "test.csv").write_text("uri\n", encoding="utf-8")
     (run_dir / "metadata.json").write_text(
         json.dumps(
             {
                 "source_preprocessed_runs": source_preprocessed_runs,
                 "rules_hash": rules_hash,
-                "files": {"export": export_filename},
             }
         ),
         encoding="utf-8",
@@ -250,6 +248,39 @@ class TestCurateEarlyExit:
 
         fake_output = _make_fake_new_run(data_root, VALID_DATASET_ID)
         mock_run_curation = MagicMock(return_value=fake_output)
+        monkeypatch.setattr("data_platform.curate.curate_bluesky.run_curation", mock_run_curation)
+
+        curate(config_path, VALID_DATASET_ID)
+
+        mock_run_curation.assert_called_once()
+
+    def test_reruns_if_old_files_export_does_not_match_config_stem(
+        self, data_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_path, rules_hash = _config_and_hash(tmp_path)
+        _write_features_meta(
+            data_root,
+            VALID_DATASET_ID,
+            source_preprocessed_runs=[_package_preprocessed_run(VALID_DATASET_ID)],
+        )
+        _write_preprocessed_run(data_root, VALID_DATASET_ID, "2026_01_01-00:00:00")
+        run_dir = _write_curated_run(
+            data_root,
+            VALID_DATASET_ID,
+            "2026_06_01-00:00:00",
+            source_preprocessed_runs=[_package_preprocessed_run(VALID_DATASET_ID)],
+            rules_hash=rules_hash,
+            write_output_file=False,
+        )
+        (run_dir / "other.csv").write_text("uri\n", encoding="utf-8")
+        metadata_path = run_dir / "metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["files"] = {"export": "other.csv"}
+        metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+        mock_run_curation = MagicMock(
+            return_value=f"data/bluesky/{VALID_DATASET_ID}/curated/2026_06_26-00:00:00/test.csv"
+        )
         monkeypatch.setattr("data_platform.curate.curate_bluesky.run_curation", mock_run_curation)
 
         curate(config_path, VALID_DATASET_ID)

--- a/tests/data_platform/curate/test_curate_reddit.py
+++ b/tests/data_platform/curate/test_curate_reddit.py
@@ -199,7 +199,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
     curated = pd.read_csv(output_path, keep_default_na=False)
 
     assert Path(relative_output).name == "mirrorview.csv"
-    assert metadata["files"]["export"] == "mirrorview.csv"
+    assert "files" not in metadata
     assert metadata["source_preprocessed_runs"] == [
         f"data/reddit/{dataset_id}/preprocessed/2026_06_01-00:00:00"
     ]

--- a/tests/data_platform/curate/test_curate_twitter.py
+++ b/tests/data_platform/curate/test_curate_twitter.py
@@ -199,7 +199,7 @@ def test_curate_writes_export_and_metadata(data_root) -> None:
     curated = pd.read_csv(output_path, keep_default_na=False)
 
     assert Path(relative_output).name == "mirrorview.csv"
-    assert metadata["files"]["export"] == "mirrorview.csv"
+    assert "files" not in metadata
     assert metadata["source_preprocessed_runs"] == [
         f"data/twitter/{dataset_id}/preprocessed/2026_06_01-00:00:00"
     ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #85
Part of #80

## Problem

New curated metadata still named the export file in a files map, even though that name is the curation config stem plus `.csv`. Skip-if-fresh and the stimuli sampling scripts looked the name up from JSON, so they would break once the map was omitted.

## Solution

New curated metadata no longer contains a `files` key. Bluesky skip-if-fresh joins the latest run directory with the yaml export file name. The two experiment scripts glob `metadata.json` to find run directories, then load the csv named from `mirrorview.yaml`. Curation specs no longer carry a separate log noun.

## Purpose

Keep new curated metadata to provenance and filter results that cannot be reconstructed from the tree. Historical JSON on disk is left alone. There is no dual-key writer or reader. Old `files.export` is not used as a fallback.

## How to run

From the repo root:

```bash
PYTHONPATH=. uv run pytest tests/data_platform/curate tests/data_platform -q
```

Expected: exit 0.

A newly written `curated/<timestamp>/metadata.json` does not contain `files`. Bluesky skip-if-fresh succeeds when `{config stem}.csv` exists in the latest run directory.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8737d289-34a7-48b1-9f23-38ab2b359133?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8737d289-34a7-48b1-9f23-38ab2b359133&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

