### PR TITLE
Add the unify ingest contracts plan so the epic can ship one PR per step

### DIFF
--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/plan.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/plan.md
@@ -1,0 +1,115 @@
+# Unify ingest operator contracts and downstream record identity
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Ingest already shares one CLI wrapper, checkpoint ledger, and on-disk layout, but operator configs, raw row columns, and run metadata name the same knobs differently per platform. Downstream feature files then join on a column name that only matches one platform’s native id. This plan makes each selected cleanup its own mergeable PR, in an order that keeps overlapping files from colliding. Engagement-metric aliases and configs-folder hygiene are out of scope. Platform-native ids on raw rows stay.
+
+## Happy flow
+
+An operator writes one YAML shape per shared knob, runs the existing per-platform sync CLIs, and gets raw runs whose manifests and timestamps are honest. Preprocess adds shared author and identity columns. Feature labeling and curation join on that identity. Stimuli sampling reads preprocess text and fails if that column is missing.
+
+```mermaid
+flowchart LR
+  subgraph before [Before]
+    Yaml1[Per-platform YAML aliases] --> Sync1[Sync CLIs]
+    Sync1 --> Raw1[Mixed timestamps and filenames]
+    Raw1 --> Feat1[Features join on a Bluesky-shaped id name]
+    Feat1 --> Stim1[Stimuli reads a Reddit-only text column]
+  end
+  subgraph after [After]
+    Yaml2[Shared operator keys] --> Sync2[Same sync CLIs]
+    Sync2 --> Raw2[Declared format and ISO timestamps]
+    Raw2 --> Prep2[Preprocess adds shared identity and author]
+    Prep2 --> Feat2[Features and curate join on that identity]
+    Feat2 --> Stim2[Stimuli requires preprocess text]
+  end
+```
+
+## Approach
+
+Ship fourteen independently mergeable PRs. Isolated platform-only and metadata-path changes land first. Shared filename handling lands before other writers keep diverging. Config-key PRs that touch the same YAML files go one after another so they do not fight. Row-schema and downstream identity work wait until ingest writers are stable. Keep deprecation aliases for old YAML except stimuli sampling, which must require the preprocess text column with no fallback. Do not rename raw platform ids.
+
+Implementation order is for merge conflict reduction. GitHub `blocked-by` stays empty unless a later PR cannot behave correctly without an earlier one.
+
+## Steps
+
+### Step 1: Validate Twitter ingest record types at CLI startup
+
+Reject Twitter configs whose record-type list is not the allowed Twitter value, matching Bluesky and Reddit fail-fast behavior. Twitter-only files.
+
+### Step 2: Rename Bluesky YAML author filter away from login identity
+
+Give the optional Bluesky author filter a name that cannot be confused with the login environment handle. Bluesky configs and Bluesky sync only. Keep a short deprecation alias.
+
+### Step 3: Store repo-relative ingest config paths in manifests
+
+Write the same repo-relative config path into run metadata and the dataset manifest so two files named alike cannot be confused. Checkpoint and dataset helpers only.
+
+### Step 4: Honor declared output format for Twitter and Reddit raw files
+
+Route Twitter and Reddit writers through the same format-aware filename helper Bluesky already uses, and make the dataset manifest list the files that were actually written.
+
+### Step 5: Require list-form search terms on Twitter ingest configs
+
+Make Twitter accept the same search-term list key Bluesky already uses. Keep a one-release alias for the old singular key. Twitter configs and Twitter sync.
+
+### Step 6: Standardize per-task fetch caps across ingest platforms
+
+Use one YAML key for the per-keyword and per-subreddit fetch cap. Keep platform-specific aliases so existing configs still load. All three ingest YAML families and their sync scripts.
+
+### Step 7: Split global ingest row caps by posts versus comments
+
+Stop using one global cap name for Twitter/Bluesky posts and Reddit comments. New keys make the cap’s unit explicit; the old key remains a documented alias with Reddit-comment meaning.
+
+### Step 8: Collapse ingest dedupe policy keys and drop the unused current-run token
+
+One top-level policy plus an optional per-record-type override for Reddit posts versus comments. Document within-run dedupe as always on. Remove the unused current-run token from the documented policy set.
+
+### Step 9: Unify duplicate-skip counters in ingest run metadata
+
+Replace platform-specific skip counter names with one run-level count and an optional per-record-type breakdown.
+
+### Step 10: Write ISO creation timestamps and drop Reddit’s duplicate utc column
+
+Normalize all three platforms to UTC ISO-8601 creation time at raw write. Delete the redundant Reddit utc column. Fix Twitter so it no longer stores a Python datetime string.
+
+### Step 11: Point stimuli sampling at preprocess text with no fallback
+
+Read the preprocess text column for every platform, including Reddit. Do not fall back to the raw comment body field. Fail if text is missing.
+
+### Step 12: Add canonical author fields at preprocess
+
+Leave platform-native author columns on raw rows. Preprocess adds a shared handle column and an id column when the platform provides one.
+
+### Step 13: Add a canonical source record id through feature and curate joins
+
+Keep native ids on raw rows. Preprocess adds a shared source record id. Feature CSVs and curation joins use that name instead of overloading the Bluesky id column name.
+
+### Step 14: Own content-length and language policy at preprocess
+
+Document one length and language policy per record type, enforced at preprocess. Ingest keeps only cheap fetch-time filters. Do not import the PushShift experiment thresholds into sync.
+
+## What "done" looks like
+
+1. Twitter configs fail at startup when record types are invalid.
+2. Bluesky author filter YAML no longer shares a name with login identity.
+3. Run metadata and the dataset manifest store the same repo-relative config path.
+4. Twitter and Reddit raw files match the declared output format; the manifest lists those paths.
+5. Twitter search-term YAML uses the same list key as Bluesky, with a temporary alias for the old key.
+6. Per-task fetch caps share one operator key, with aliases for old names.
+7. Global row caps name posts versus comments explicitly; Reddit’s old cap still means comments.
+8. Dedupe policy is one key plus optional per-type override; current-run is not a switch.
+9. Duplicate-skip metadata uses one counter name for all platforms.
+10. Raw creation times are UTC ISO-8601; Reddit no longer writes a duplicate utc column.
+11. Stimuli sampling requires preprocess text and does not read Reddit body as a fallback.
+12. Preprocess rows expose shared author handle and optional author id without rewriting raw columns.
+13. Feature files and curation join on a shared source record id; raw platform ids remain.
+14. Length and language gates live in preprocess policy; ingest does not grow new content filters.
+15. Engagement-metric renaming and configs-folder README hygiene are not done.
+16. Each step is one PR and can merge without bundling a sibling step.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step1.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step1.md
@@ -1,0 +1,91 @@
+# Step 1: Validate Twitter ingest record types at CLI startup
+
+## Goal
+
+Twitter YAML lists `record_types: [twitter.tweet]` but `sync_twitter.sync_records` never checks it. Bluesky requires `app.bsky.feed.post`. Reddit requires `reddit.comment` and/or `reddit.post`. This PR makes Twitter fail fast the same way.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/ingestion/sync_twitter.py` → `sync_records`.
+
+**Slice:** load YAML → reject missing/wrong `record_types` → existing sync continues.
+
+**Out of scope:** Bluesky/Reddit validators, YAML key renames, output format, other steps.
+
+## Decision (locked)
+
+- Constant `POSTS_RECORD_TYPE = "twitter.tweet"` in `sync_twitter.py`, matching Bluesky’s `POSTS_RECORD_TYPE` pattern in `data_platform/ingestion/sync_bluesky.py`.
+- If `twitter.tweet` is not in `config["record_types"]`, raise `ValueError` with the same message shape Bluesky uses: `Unsupported record types for checkpoint sync: {record_types}`.
+- Empty or missing `record_types` is invalid (raise). Extra unknown strings in the list are invalid even if `twitter.tweet` is also present — Twitter ingest only produces tweets.
+- Do not add `twitter.tweet` to `RECORD_TYPE_FILENAMES` in this step (filename work is step 4).
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/plan.md` | Parent plan |
+| `data_platform/ingestion/sync_bluesky.py` | `POSTS_RECORD_TYPE` check around the `sync_records` record_types block |
+| `data_platform/ingestion/sync_reddit.py` | Reddit allow-list pattern |
+| `data_platform/ingestion/sync_twitter.py` | Current `sync_records` with no record_types check |
+| `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py` | Fixtures already set `record_types: ["twitter.tweet"]` |
+| `tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py` | Pattern for unsupported record_types tests if present |
+
+## Files allowed to change
+
+- `data_platform/ingestion/sync_twitter.py`
+- `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py`
+- `CHANGELOG.md` (after the PR exists, via write-changelog)
+
+## Files forbidden to change
+
+- `data_platform/ingestion/sync_bluesky.py`
+- `data_platform/ingestion/sync_reddit.py`
+- `data_platform/ingestion/sync_checkpoint.py`
+- All YAML under `data_platform/ingestion/configs/`
+- Preprocess, features, curate, stimuli
+
+## Contracts
+
+```text
+POSTS_RECORD_TYPE: str = "twitter.tweet"
+
+sync_records(...)
+  After load_yaml_config and require_dataset_id, before fetch:
+  if POSTS_RECORD_TYPE not in record_types or set(record_types) != {POSTS_RECORD_TYPE}:
+      raise ValueError(f"Unsupported record types for checkpoint sync: {record_types}")
+```
+
+Exact extra-type rule: the list must be exactly `["twitter.tweet"]` (order irrelevant). Duplicate `twitter.tweet` twice is invalid.
+
+## Tests (write first)
+
+`TestSyncRecordsRecordTypes` in `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py` (or a new `test_sync_twitter_record_types.py` if that file is already large).
+
+- given config with `record_types: ["twitter.tweet"]`, when `sync_records` is invoked with existing mocks, then it does not raise for record types (existing happy path still passes).
+- given `record_types: ["reddit.comment"]`, then `pytest.raises(ValueError, match="Unsupported record types")`.
+- given `record_types: ["twitter.tweet", "twitter.user"]`, then same `ValueError`.
+- given `record_types: []`, then `ValueError`.
+
+Follow `.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md`. One test class per function.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_sync_twitter_checkpoint.py tests/data_platform/ingestion/test_ingest_yaml_keys.py -q
+```
+
+Exit 0.
+
+## Must still pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
+```
+
+Exit 0. No new failures.
+
+## Must not happen
+
+- Twitter YAML rewritten in this PR.
+- Bluesky/Reddit record-type strings changed.
+- Fetch or checkpoint behavior changed for valid configs.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step10.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step10.md
@@ -1,0 +1,108 @@
+# Step 10: Write ISO creation timestamps and drop Reddit’s duplicate utc column
+
+## Goal
+
+All three ingest platforms write UTC ISO-8601 `created_at` at raw row write. Twitter currently uses `str(tweet.created_at)`, which yields a space-separated datetime string, not ISO. Reddit duplicates the same ISO value under both `created_at` and `created_utc`; drop the redundant column from raw rows and sync models.
+
+## Caller / unit of work
+
+**Main callers:** `tweet_to_row` in `data_platform/ingestion/twitter_client.py`; `submission_to_row` / `comment_to_row` in `data_platform/ingestion/sync_reddit.py`; `_posts_to_rows` in `data_platform/ingestion/sync_bluesky.py`.
+
+**Slice:** normalize `created_at` at row construction → update Reddit/Twitter sync models → align timestamp tests and Reddit fixtures.
+
+**Out of scope:** `sync_timestamp` format (`get_current_timestamp`), platform-native id column names, preprocess/features/curate, YAML configs, other plan steps.
+
+## Decision (locked)
+
+- **Canonical raw creation field:** `created_at` as UTC ISO-8601 string.
+- **Twitter:** `tweet_to_row` must use `datetime.isoformat()` (with timezone) when `tweet.created_at` is set. Do **not** use `str(tweet.created_at)`.
+- **Reddit:** keep converting PRAW `created_utc` (Unix float) via `datetime.fromtimestamp(..., tz=timezone.utc).isoformat()` into `created_at`. Remove `created_utc` from post and comment row dicts and from `SyncRedditPostModel` / `SyncRedditCommentModel` in `data_platform/models/sync.py`.
+- **Bluesky:** `_posts_to_rows` already passes through API `post.record.created_at` (e.g. `2026-05-30T00:00:00.000Z`). No change required if the value already parses as UTC ISO; do not reformat unnecessarily.
+- **`sync_timestamp`:** unchanged — still `get_current_timestamp` format on every row.
+- **Independently shippable:** one PR; do not rename platform id columns (`tweet_id`, `reddit_id`, `uri`, etc.).
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/plan.md` | Parent plan step 10 |
+| `data_platform/ingestion/twitter_client.py` | `tweet_to_row` uses `str(tweet.created_at)` today |
+| `data_platform/ingestion/sync_reddit.py` | `submission_to_row` / `comment_to_row` write duplicate `created_utc` |
+| `data_platform/ingestion/sync_bluesky.py` | `_posts_to_rows` passes API `created_at` |
+| `data_platform/models/sync.py` | `SyncRedditPostModel` / `SyncRedditCommentModel` include `created_utc` |
+| `tests/data_platform/ingestion/test_raw_row_timestamps.py` | Platform timestamp assertions and model validation |
+| `tests/data_platform/ingestion/reddit_conftest.py` | `mock_comment_row` / `mock_post_row` include `created_utc` |
+| `tests/data_platform/ingestion/conftest.py` | Bluesky `mock_post` `created_at` shape |
+
+## Files allowed to change
+
+- `data_platform/ingestion/twitter_client.py`
+- `data_platform/ingestion/sync_reddit.py`
+- `data_platform/models/sync.py` (Reddit sync models only)
+- `tests/data_platform/ingestion/test_raw_row_timestamps.py`
+- `tests/data_platform/ingestion/reddit_conftest.py`
+- `CHANGELOG.md` (after the PR exists, via write-changelog)
+
+## Files forbidden to change
+
+- `data_platform/ingestion/sync_bluesky.py` (unless Bluesky `created_at` is found not to be UTC ISO — then minimal fix only)
+- Preprocess, features, curate, stimuli
+- All YAML under `data_platform/ingestion/configs/`
+- `lib/timestamp_utils.py` / `get_current_timestamp`
+- Platform id column names on raw rows
+
+## Contracts
+
+```text
+tweet_to_row(...)
+  created_at: tweet.created_at.isoformat() when tweet.created_at is truthy, else ""
+  Must contain "T" between date and time (ISO-8601), not a space from str(datetime).
+
+submission_to_row(...) / comment_to_row(...)
+  created_at: datetime.fromtimestamp(praw_created_utc, tz=timezone.utc).isoformat()
+  Row dict must NOT include "created_utc".
+  sync_timestamp unchanged.
+
+_posts_to_rows(...)  [Bluesky, verify only]
+  created_at: post.record.created_at (API string, UTC ISO with Z suffix acceptable)
+
+SyncRedditPostModel / SyncRedditCommentModel
+  Fields include created_at: str; do NOT include created_utc.
+  PreprocessedRedditCommentModel inherits from SyncRedditCommentModel — no separate created_utc field.
+```
+
+## Tests (write first)
+
+Update `tests/data_platform/ingestion/test_raw_row_timestamps.py`:
+
+- **Bluesky** (`TestFetchPostsForKeyword`): keep asserting ISO `created_at` and `sync_timestamp`; `SyncBlueskyPostModel.model_validate` still passes.
+- **Reddit** (`TestSubmissionToRow`, `TestCommentToRow`): assert ISO `created_at` and `sync_timestamp`; assert `"created_utc" not in result`; rename tests to drop “keeps created_utc alias”; `SyncRedditPostModel` / `SyncRedditCommentModel` validation still passes.
+- **Twitter** (`TestTweetToRow`): assert `created_at` contains `"T"` (ISO separator); `datetime.fromisoformat(str(result["created_at"]))` round-trips to the source datetime; assert `str(created_at)` space-separated form is **not** produced (e.g. `"2026-05-30 00:00:00" not in result["created_at"]`); `SyncTwitterPostModel.model_validate` still passes.
+
+Update `tests/data_platform/ingestion/reddit_conftest.py`: remove `created_utc` from `mock_comment_row` and `mock_post_row`.
+
+Follow `.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md`. One test class per function.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_raw_row_timestamps.py -q
+```
+
+Exit 0.
+
+## Must still pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
+```
+
+Exit 0. No new failures.
+
+## Must not happen
+
+- Changing `sync_timestamp` format or source.
+- Renaming platform-native id columns (`tweet_id`, `reddit_id`, `comment_id`, `uri`, etc.).
+- Adding `created_utc` back as an alias anywhere in raw ingest or sync models.
+- Twitter `created_at` using `str(datetime)` (space-separated).
+- Touching preprocess, features, curate, or ingest YAML in this PR.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step11.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step11.md
@@ -1,0 +1,110 @@
+# Step 11: Point stimuli sampling at preprocess text with no fallback
+
+## Goal
+
+Stimuli sampling (`normalize_mirrorview_df`) reads Reddit comment text from `body` today. Preprocess already copies `body` → `text` via `add_canonical_text_column` / `PreprocessedRedditCommentModel`. This PR makes Reddit use the same `text` column as Bluesky and Twitter and fails if it is missing — no fallback to `body`.
+
+## Caller / unit of work
+
+**Main caller:** `experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py` → `normalize_mirrorview_df`.
+
+**Slice:** Reddit branch sets `text_col = "text"` → existing required-column and null checks apply → `original_text` is sourced from `text`.
+
+**Out of scope:** Preprocess (`add_canonical_text_column`, `PreprocessedRedditCommentModel`), ingest, features, curate, other experiment scripts that read `body` directly (e.g. `fix_primary_key_column_for_reddit_posts.py` lookup repair).
+
+## Decision (locked)
+
+- Reddit `text_col` becomes `"text"`, matching Bluesky and Twitter. Do not read `body` as a substitute.
+- If `text` is absent from the input frame, raise `ValueError` via the existing missing-column loop (`Integration \`reddit\` mirrorview export missing required column \`text\`.`). Do not add a `body` fallback branch.
+- Bluesky and Twitter branches stay on `text_col = "text"`; no behavior change.
+- Preprocess is already correct; do not change preprocess in this PR unless a test fixture needs a minimal row shape.
+- Independently shippable; no dependency on other plan steps.
+- `normalize_mirrorview_df` is a pure function and the production handoff for curated exports → stimuli records. Despite `UNIT_TESTING_STANDARDS` usually skipping `experiments/`, **add unit tests** for this function.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/plan.md` | Parent plan, step 11 summary |
+| `experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py` | `normalize_mirrorview_df` — Reddit `text_col = "body"` today (lines ~94–97) |
+| `experiments/scaled_mirrors_generation_2026_06_02/count_missing_flips.py` | Imports `normalize_mirrorview_df`; inherits stricter contract, no code change expected |
+| `data_platform/preprocessing/runner.py` | `add_canonical_text_column` — confirms preprocess copies Reddit `body` → `text` |
+| `.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md` | Test class naming and arrange-act-assert |
+
+**Grep note (experiment folder only):** Only `count_missing_flips.py` calls `normalize_mirrorview_df` besides `sample_data_to_mirror.py` itself. `fix_primary_key_column_for_reddit_posts.py` reads `body` for a one-off lookup repair and does not call this function.
+
+## Files allowed to change
+
+- `experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py`
+- `tests/experiments/test_sample_data_to_mirror.py` (new — no `tests/` folder exists under the experiment directory)
+- `CHANGELOG.md` (after the PR exists, via write-changelog)
+
+## Files forbidden to change
+
+- `data_platform/preprocessing/**` (including `preprocess_reddit.py`, `runner.py`, models)
+- `data_platform/ingestion/**`
+- `data_platform/generate_features/**`
+- `data_platform/curate/**`
+- `experiments/scaled_mirrors_generation_2026_06_02/fix_primary_key_column_for_reddit_posts.py`
+- Other experiment scripts in that folder unless a test import requires none
+
+## Contracts
+
+```text
+normalize_mirrorview_df(df_raw: pd.DataFrame, *, integration: str) -> pd.DataFrame
+
+integration == "reddit":
+  text_col = "text"          # was "body"
+  id_col = "post_reddit_id"
+  comment_id_col = "comment_id"
+  required_cols includes text_col, id_col, comment_id_col, tox_col, "political_stance"
+
+integration in ("twitter", "bluesky"):
+  text_col = "text"          # unchanged
+
+If text_col not in df_raw.columns:
+  raise ValueError(
+    f"Integration `{integration}` mirrorview export missing required column `{text_col}`."
+  )
+
+normalized["original_text"] = df_raw[text_col].astype(str)   # never df_raw["body"]
+```
+
+No `body` fallback, alias, or `df_raw.get("text", df_raw["body"])` pattern.
+
+## Tests (write first)
+
+**Location:** `tests/experiments/test_sample_data_to_mirror.py` (import from `experiments.scaled_mirrors_generation_2026_06_02.sample_data_to_mirror`).
+
+`TestNormalizeMirrorviewDf` — one class per function.
+
+Minimal Reddit fixture columns: `post_reddit_id`, `comment_id`, `text`, `toxicity_tier` (or `sample_toxicity_type`), `political_stance` with non-null values and a binary stance (not `unclear` / `neutral`, which the function filters out).
+
+- given Reddit frame with `text` and required columns, when `normalize_mirrorview_df(..., integration="reddit")`, then it returns a frame whose `original_text` matches `text` (and does not require `body`).
+- given Reddit frame with only `body` (no `text`) and other required columns, then `pytest.raises(ValueError, match="missing required column `text`")`.
+- given Bluesky or Twitter frame with `text`, then existing behavior unchanged (smoke: `original_text` populated).
+
+Follow `.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md`. Use `PYTHONPATH=.` for imports.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/experiments/test_sample_data_to_mirror.py -q
+```
+
+Exit 0.
+
+## Must still pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform -q
+```
+
+Exit 0. No new failures.
+
+## Must not happen
+
+- Reading `body` when `text` is missing (no fallback).
+- Changing Bluesky/Twitter text column selection.
+- Modifying preprocess to add or rename columns for this PR.
+- Changing `fix_primary_key_column_for_reddit_posts.py` or other body-based repair scripts.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step12.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step12.md
@@ -1,0 +1,159 @@
+# Step 12: Add canonical author fields at preprocess
+
+## Goal
+
+Downstream stages need one author-handle column name across platforms. Raw ingest keeps platform-native author fields; preprocess adds shared `author_handle` (and `author_id` only when the platform already has one).
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/preprocessing/runner.py` → `preprocess_records` (after `add_canonical_text_column`, before `apply_text_transform`).
+
+**Slice:** copy or passthrough author fields onto canonical columns → validate preprocessed rows on write → existing filter/save unchanged in meaning.
+
+**Out of scope:** raw ingest column names; `source_record_id` (step 13); stimuli sampling (step 11); feature/curate consumers switching to `author_handle` (they may read it later; this PR only writes it).
+
+## Decision (locked)
+
+- **Raw ingest unchanged:** Bluesky `author_handle`; Reddit `author`; Twitter `username` + `author_id`. Do not add `author_handle` to `SyncRedditCommentModel`, `SyncRedditPostModel`, or `SyncTwitterPostModel`.
+- **Preprocess adds `author_handle` on every platform:**
+  - Bluesky: passthrough — column already named `author_handle` on raw rows; helper must not duplicate or overwrite.
+  - Reddit: copy `author` → `author_handle`; keep `author`.
+  - Twitter: copy `username` → `author_handle`; keep `username`.
+- **`author_id` only when native:** Twitter passthrough (`author_id` already on raw). Bluesky and Reddit: **omit the column** from preprocessed output — do not write empty strings or `None` placeholders.
+- **Pydantic `extra="forbid"`:** extend preprocess-only models so new columns validate on preprocessed load/write. `PreprocessedRedditCommentModel` already exists (`text`). Add `author_handle` there. Add `PreprocessedTwitterPostModel` with `author_handle` (inherits `author_id` from `SyncTwitterPostModel`). Bluesky needs no new model — `SyncBlueskyPostModel` already declares `author_handle` and matches preprocessed shape.
+- **Mirror the text helper:** `add_canonical_author_columns(df, spec)` alongside `add_canonical_text_column`, with platform source columns on `PreprocessPlatformSpec` (see Contracts).
+- **Row validators unchanged:** Reddit `filter_records` / `check_if_not_automoderator` still read native `author`, not `author_handle`.
+- **Independently shippable:** one PR; no bundled step 11 or 13 work.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/plan.md` | Parent plan step 12 |
+| `data_platform/preprocessing/runner.py` | `add_canonical_text_column`, `preprocess_records`, `AUTHOR_COLUMN`, `PreprocessPlatformSpec` |
+| `data_platform/preprocessing/preprocess_bluesky.py` | `BLUESKY_SPEC` |
+| `data_platform/preprocessing/preprocess_reddit.py` | `REDDIT_SPEC`, row validators on `author` |
+| `data_platform/preprocessing/preprocess_twitter.py` | `TWITTER_SPEC` |
+| `data_platform/models/sync.py` | `Sync*` vs `PreprocessedRedditCommentModel` |
+| `data_platform/utils/storage.py` | `RedditStorageManager` preprocessed model swap; Bluesky/Twitter model wiring |
+| `data_platform/utils/platform_specific_columns.py` | `CANONICAL_TEXT_COLUMN` pattern |
+| `tests/data_platform/preprocessing/test_add_canonical_text_column.py` | Helper test shape |
+| `tests/data_platform/preprocessing/test_preprocess_reddit.py` | End-to-end preprocess assertions |
+| `tests/data_platform/preprocessing/test_preprocess_twitter.py` | End-to-end preprocess assertions |
+| `tests/data_platform/preprocessing/test_preprocess_bluesky.py` | Bluesky preprocess coverage |
+| `tests/data_platform/ingestion/reddit_conftest.py` | `mock_comment_row` (`author`) |
+| `tests/data_platform/ingestion/twitter_conftest.py` | `mock_tweet_row` (`username`, `author_id`) |
+| `tests/data_platform/conftest.py` | `make_post_row` (`author_handle`) |
+
+## Files allowed to change
+
+- `data_platform/preprocessing/runner.py`
+- `data_platform/preprocessing/preprocess_bluesky.py` (spec fields only, if needed)
+- `data_platform/preprocessing/preprocess_reddit.py` (spec fields only, if needed)
+- `data_platform/preprocessing/preprocess_twitter.py` (spec fields only, if needed)
+- `data_platform/models/sync.py` (`PreprocessedRedditCommentModel`, new `PreprocessedTwitterPostModel`)
+- `data_platform/utils/platform_specific_columns.py` (canonical author column constant)
+- `data_platform/utils/storage.py` (Twitter preprocessed model on `StorageStage.PREPROCESSED`)
+- `tests/data_platform/preprocessing/test_add_canonical_author_columns.py` (new)
+- `tests/data_platform/preprocessing/test_add_canonical_text_column.py` (only if shared imports/fixtures move)
+- `tests/data_platform/preprocessing/test_preprocess_reddit.py`
+- `tests/data_platform/preprocessing/test_preprocess_twitter.py`
+- `tests/data_platform/preprocessing/test_preprocess_bluesky.py` (if adding author assertions)
+- `CHANGELOG.md`
+
+## Files forbidden to change
+
+- `data_platform/ingestion/**` (raw author columns and sync writers)
+- `SyncBlueskyPostModel`, `SyncRedditCommentModel`, `SyncRedditPostModel`, `SyncTwitterPostModel` field lists (no new fields on raw sync models)
+- Stimuli / curate / feature generation (unless a test breaks only because preprocessed CSV schema changed — fix the test assertion, not downstream readers)
+- `source_record_id` or any step 13 join renames
+- Ingest YAML configs
+
+## Contracts
+
+```text
+CANONICAL_AUTHOR_HANDLE_COLUMN: str = "author_handle"
+CANONICAL_AUTHOR_ID_COLUMN: str = "author_id"   # documentation only; not written on Bluesky/Reddit
+
+@dataclass(frozen=True)
+class PreprocessPlatformSpec:
+  ...
+  author_handle_source_column: str | None = None
+    None → author_handle already on the frame (Bluesky).
+    Non-None → copy str(source) onto author_handle (Reddit: "author"; Twitter: "username").
+  preprocessed_model_cls: type[BaseModel] | None = None
+    When set, validate each output row with this model before write (Reddit/Twitter).
+    Bluesky may omit (SyncBlueskyPostModel already matches).
+
+add_canonical_author_columns(df: pd.DataFrame, spec: PreprocessPlatformSpec) -> pd.DataFrame
+  Returns a new frame; does not mutate input.
+  When author_handle_source_column is None:
+    require CANONICAL_AUTHOR_HANDLE_COLUMN present; leave values unchanged.
+  Else:
+    require source column present; set author_handle = source.map(str); keep source column.
+  Do not add author_id unless it already exists on the input frame (Twitter only today).
+  Do not add author_id with empty values for Bluesky/Reddit.
+
+preprocess_records(...):
+  records = add_canonical_text_column(records, spec)
+  records = add_canonical_author_columns(records, spec)
+  ... apply_text_transform / filter_records / save_preprocessed unchanged ...
+
+PreprocessedRedditCommentModel(SyncRedditCommentModel):
+  text: str
+  author_handle: str
+
+PreprocessedTwitterPostModel(SyncTwitterPostModel):
+  author_handle: str
+  # author_id inherited from SyncTwitterPostModel
+```
+
+Platform spec wiring:
+
+- Bluesky: `author_handle_source_column=None`; `preprocessed_model_cls=None` (or `SyncBlueskyPostModel`).
+- Reddit: `author_handle_source_column="author"`; `preprocessed_model_cls=PreprocessedRedditCommentModel`.
+- Twitter: `author_handle_source_column="username"`; `preprocessed_model_cls=PreprocessedTwitterPostModel`; `TwitterStorageManager` uses `PreprocessedTwitterPostModel` when `stage == PREPROCESSED` (mirror Reddit).
+
+## Tests (write first)
+
+New `TestAddCanonicalAuthorColumns` in `tests/data_platform/preprocessing/test_add_canonical_author_columns.py` (mirror `test_add_canonical_text_column.py`).
+
+- given Reddit frame with `author="regular_user"`, when `add_canonical_author_columns` with `REDDIT_SPEC`, then `author_handle == "regular_user"` and `author` unchanged; `author_id` not in columns.
+- given Twitter frame with `username="handle"` and `author_id="123"`, when helper runs with `TWITTER_SPEC`, then `author_handle == "handle"`, `username` and `author_id` unchanged.
+- given Bluesky frame with `author_handle="a.bsky.social"`, when helper runs with `BLUESKY_SPEC`, then value unchanged; `author_id` not in columns.
+- given Reddit frame missing `author`, then `KeyError`.
+- given Bluesky frame missing `author_handle`, then `KeyError`.
+
+Extend end-to-end preprocess tests:
+
+- `test_preprocess_records_writes_output` (Reddit): saved row has `author_handle == author`; no `author_id` column.
+- `test_preprocess_records_writes_output` (Twitter): saved row has `author_handle == username` and `author_id` preserved.
+- Add or extend Bluesky test: preprocessed CSV still has `author_handle` equal to raw value; no `author_id` column.
+
+Reload preprocessed CSVs through `StorageManager(StorageStage.PREPROCESSED, ...)` so pydantic validation runs.
+
+Follow `.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md`. One test class per function for the new helper.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/preprocessing -q
+```
+
+Exit 0.
+
+## Must still pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform -q
+```
+
+Exit 0. No new failures outside preprocessing.
+
+## Must not happen
+
+- Raw ingest writers renamed or duplicated (`author` → `author_handle` at sync time).
+- `author_id` column added to Bluesky or Reddit preprocessed CSVs.
+- `author_handle` added to any `Sync*` model except the existing Bluesky field.
+- Stimuli, curate, or feature code changed to depend on `author_handle` in this PR.
+- `source_record_id` or step 13 join column work bundled here.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step13.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step13.md
@@ -1,0 +1,209 @@
+# Step 13: Add a canonical source record id through feature and curate joins
+
+## Goal
+
+Feature CSVs today write a Bluesky-shaped `uri` id column for every platform, while preprocessed records keep native ids (`uri`, `tweet_id`, `comment_fullname`). Curation already special-cases non-Bluesky joins in `curate/runner.py`. This PR adds a shared `source_record_id` at preprocess, writes that name in feature files, and joins preprocessed native ids to feature `source_record_id` without renaming raw or curated native columns.
+
+## Caller / unit of work
+
+**Main callers:** `preprocess_records` in `data_platform/preprocessing/runner.py`; `generate_features` / engines in `data_platform/generate_features/`; `run_curation` → `build_wide_table` in `data_platform/curate/`.
+
+**Slice:** preprocess adds `source_record_id` → feature labeling writes `source_record_id` in CSVs → curation joins native `records_id_column` to feature `source_record_id`.
+
+**Out of scope:** Renaming raw Bluesky `uri`, Twitter `tweet_id`, Reddit `comment_fullname` / `reddit_fullname`. Stimuli sampling (`sample_data_to_mirror.py`) — it reads curated native id columns (`uri`, `tweet_id`, `post_reddit_id`), not feature file column names. Ingest sync. Step 11 text-column work.
+
+## Decision (locked)
+
+- Module constant `SOURCE_RECORD_ID_COLUMN = "source_record_id"` in `data_platform/utils/platform_specific_columns.py`.
+- Do **not** rename platform-native id columns on raw rows or curated exports.
+- Preprocess: after `add_canonical_text_column`, copy `spec.columns.records_id_column` into `source_record_id` (string). Native id column stays on the frame.
+- `PlatformSpecificColumns.feature_file_id_column` becomes `"source_record_id"` for Bluesky, Twitter, and Reddit (replace today’s `"uri"` default on all three constants).
+- Feature pydantic output models (`IsPoliticalModel`, `IsToxicTieredModel`, and the other five `*Model` classes under `generate_features/*/generate_feature.py`): rename field `uri` → `source_record_id`. Keep `generate_feature(uri: str, text: str)` parameter name `uri` (seven modules + `__main__` samples); construct models with `source_record_id=uri`. LangChain engine row assembly must use `source_record_id`, not `"uri"`.
+- **`LabelTask.uri` → `LabelTask.record_id` (locked).** Blast is confined to `generate_features/` engines, orchestrator, and feature tests (~10 files). Do **not** rename `generate_feature(uri, …)` signatures in this PR.
+- Curation: always pass both `id_column=spec.columns.records_id_column` and `feature_file_id_column=spec.columns.feature_file_id_column` into `ConsolidateConfig`. Remove the `if spec.columns.records_id_column != "uri"` guard in `curate/runner.py` — Bluesky now also needs explicit kwargs because feature files no longer use `uri`.
+- `ConsolidateConfig` join contract unchanged: cast feature `source_record_id` to varchar and alias as preprocessed `id_column` for `USING` joins (`consolidate.py` `_feature_cte_sql`).
+- Preprocessed storage models: add `source_record_id: str` to `PreprocessedRedditCommentModel`; add `PreprocessedBlueskyPostModel` and `PreprocessedTwitterPostModel` (sync fields + `source_record_id`; Reddit model keeps `text`). Wire `BlueskyStorageManager` and `TwitterStorageManager` to use preprocessed models when `stage == PREPROCESSED` (mirror `RedditStorageManager` today). Update feature platform specs’ `model_cls` to the preprocessed models so `load_preprocessed_records` validates the new column.
+- `FeatureLabelQuery.feature_file_id_column` default becomes `"source_record_id"`.
+- Independently shippable one PR. Existing on-disk feature CSVs with `uri` are out of scope — operators re-run feature generation or accept empty joins until relabeled.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/plan.md` | Parent plan step 13 |
+| `data_platform/utils/platform_specific_columns.py` | `records_id_column`, `feature_file_id_column` today |
+| `data_platform/preprocessing/runner.py` | `preprocess_records` pipeline, `save_preprocessed` |
+| `data_platform/models/sync.py` | `PreprocessedRedditCommentModel`; raw sync models |
+| `data_platform/utils/storage.py` | `write_records` validation; Reddit preprocessed model switch |
+| `data_platform/generate_features/models.py` | `LabelTask` |
+| `data_platform/generate_features/generate_features.py` | `tasks_from_dataframe`, `id_column` wiring |
+| `data_platform/generate_features/platform_cli.py` | `FeatureLabelQuery` construction |
+| `data_platform/generate_features/engines/base.py` | `filter_seen_tasks`, deadletter `uris` list |
+| `data_platform/generate_features/engines/langchain_engine.py` | hardcoded `"uri"` row key |
+| `data_platform/generate_features/engines/thread_pool_engine.py` | `task.uri` → `generate_feature` |
+| `data_platform/generate_features/*/generate_feature.py` | seven `*Model` classes with `uri: str` |
+| `data_platform/generate_features/registry.py` | feature → model mapping |
+| `data_platform/curate/consolidate.py` | `ConsolidateConfig`, `_feature_cte_sql` join |
+| `data_platform/curate/runner.py` | `records_id_column != "uri"` special case |
+| `data_platform/utils/feature_labels.py` | `feature_file_id_column` default |
+| `experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py` | confirm stimuli uses curated native ids only |
+| `tests/data_platform/preprocessing/` | preprocess output columns |
+| `tests/data_platform/generate_features/` | feature CSV id column, `LabelTask`, engines |
+| `tests/data_platform/curate/` | consolidate join fixtures |
+| `tests/data_platform/conftest.py` | `make_political_feature_rows`, `write_feature_csv` |
+| `tests/data_platform/utils/test_platform_specific_columns.py` | column constants |
+
+## Files allowed to change
+
+- `data_platform/utils/platform_specific_columns.py`
+- `data_platform/models/sync.py`
+- `data_platform/utils/storage.py` (preprocessed model selection for Bluesky/Twitter)
+- `data_platform/preprocessing/runner.py` (`add_source_record_id_column`, call site in `preprocess_records`)
+- `data_platform/utils/feature_labels.py`
+- `data_platform/generate_features/models.py`
+- `data_platform/generate_features/generate_features.py`
+- `data_platform/generate_features/platform_cli.py`
+- `data_platform/generate_features/engines/base.py`
+- `data_platform/generate_features/engines/langchain_engine.py`
+- `data_platform/generate_features/engines/thread_pool_engine.py`
+- `data_platform/generate_features/is_news_or_opinion/generate_feature.py`
+- `data_platform/generate_features/is_political/generate_feature.py`
+- `data_platform/generate_features/is_likely_spam/generate_feature.py`
+- `data_platform/generate_features/is_self_contained/generate_feature.py`
+- `data_platform/generate_features/is_structurally_complete/generate_feature.py`
+- `data_platform/generate_features/is_toxic_tiered/generate_feature.py`
+- `data_platform/generate_features/political_stance/generate_feature.py`
+- `data_platform/generate_features/generate_bluesky_features.py` (preprocessed `model_cls`)
+- `data_platform/generate_features/generate_twitter_features.py` (preprocessed `model_cls`)
+- `data_platform/curate/runner.py`
+- `tests/data_platform/preprocessing/test_add_canonical_text_column.py` or new `test_add_source_record_id_column.py`
+- `tests/data_platform/preprocessing/test_preprocess_bluesky.py`
+- `tests/data_platform/preprocessing/test_preprocess_twitter.py`
+- `tests/data_platform/preprocessing/test_preprocess_reddit.py`
+- `tests/data_platform/utils/test_platform_specific_columns.py`
+- `tests/data_platform/generate_features/test_engine_skip.py`
+- `tests/data_platform/generate_features/test_langchain_engine.py`
+- `tests/data_platform/generate_features/test_thread_pool_engine.py`
+- `tests/data_platform/generate_features/test_is_likely_spam.py`
+- `tests/data_platform/generate_features/test_generate_bluesky_features.py` (if present)
+- `tests/data_platform/generate_features/test_generate_twitter_features.py`
+- `tests/data_platform/generate_features/test_generate_reddit_features.py`
+- `tests/data_platform/curate/test_consolidate.py`
+- `tests/data_platform/curate/test_curate_bluesky.py` (if present)
+- `tests/data_platform/curate/test_curate_twitter.py`
+- `tests/data_platform/curate/test_curate_reddit.py`
+- `tests/data_platform/conftest.py` (`make_political_feature_rows`, feature fixtures)
+- `tests/data_platform/test_models_exports.py` (if preprocessed models are exported)
+- `docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md` (`feature_file_id_column` table row only)
+- `CHANGELOG.md`
+
+## Files forbidden to change
+
+- `data_platform/ingestion/**`
+- `experiments/scaled_mirrors_generation_2026_06_02/sample_data_to_mirror.py` (no feature `uri` join; native curated columns unchanged)
+- Raw sync pydantic field names (`uri`, `tweet_id`, `comment_fullname`, `reddit_fullname`)
+- Curated export column selection beyond what `posts.*` already carries (do not drop native ids or add stimuli-only renames)
+- `data_platform/curate/consolidate.py` join SQL shape (only test/fixture column names unless a bug is found)
+
+## Contracts
+
+```text
+SOURCE_RECORD_ID_COLUMN: str = "source_record_id"
+
+add_source_record_id_column(df, records_id_column: str) -> pd.DataFrame
+  out = df.copy()
+  out[SOURCE_RECORD_ID_COLUMN] = out[records_id_column].astype(str)
+  return out
+
+PlatformSpecificColumns (all platforms):
+  feature_file_id_column = SOURCE_RECORD_ID_COLUMN
+  records_id_column unchanged (uri | tweet_id | comment_fullname)
+
+LabelTask:
+  record_id: str   # was uri; holds the platform record id from the input table
+  text: str
+
+Feature CSV row keys (all seven features):
+  source_record_id, label_timestamp, <feature fields…>
+  No uri column in new writes.
+
+ConsolidateConfig (curate/runner.py always sets):
+  id_column = spec.columns.records_id_column
+  feature_file_id_column = spec.columns.feature_file_id_column  # source_record_id
+
+Join (unchanged SQL semantics in consolidate.py):
+  posts.{records_id_column} = CAST(feat.{source_record_id} AS VARCHAR)
+  Wide table retains posts.* (native ids + source_record_id + text + features).
+```
+
+Preprocess call order in `preprocess_records`:
+
+```text
+records = add_canonical_text_column(records, spec)
+records = add_source_record_id_column(records, spec.columns.records_id_column)
+preprocessed = apply_text_transform(records, spec)
+preprocessed = filter_records(preprocessed, spec)
+```
+
+## Tests (write first)
+
+`TestAddSourceRecordIdColumn` in preprocessing tests:
+
+- given a frame with `comment_fullname`, when `add_source_record_id_column` runs, then `source_record_id` equals string copy and `comment_fullname` is unchanged.
+- given Bluesky `uri` column, then `source_record_id` matches `uri` and `uri` column remains.
+
+`TestPlatformSpecificColumns`:
+
+- all three platform constants set `feature_file_id_column == "source_record_id"`.
+
+`TestLabelTaskRecordId` / update `test_engine_skip.py`:
+
+- `filter_seen_tasks` matches on `task.record_id` against feature file `source_record_id` column.
+
+`test_langchain_engine.py` / `test_thread_pool_engine.py`:
+
+- written CSV rows include `source_record_id`, not `uri`.
+
+`test_consolidate.py`:
+
+- default Bluesky fixture feature rows use `source_record_id` key; Reddit mapping test uses `feature_file_id_column="source_record_id"` with `id_column="comment_fullname"`.
+
+`test_curate_twitter.py` / `test_curate_reddit.py`:
+
+- feature fixture dicts keyed by `TWITTER_COLUMNS.feature_file_id_column` / `REDDIT_COLUMNS.feature_file_id_column` (now `source_record_id`).
+
+Preprocess integration tests (`test_preprocess_*`):
+
+- saved preprocessed CSV includes `source_record_id` equal to native id.
+
+Follow `.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md`. One test class per new function.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest \
+  tests/data_platform/preprocessing \
+  tests/data_platform/generate_features \
+  tests/data_platform/curate \
+  tests/data_platform/utils/test_platform_specific_columns.py \
+  tests/data_platform/test_models_exports.py \
+  -q
+```
+
+Exit 0.
+
+## Must still pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform -q
+```
+
+Exit 0. No new failures.
+
+## Must not happen
+
+- Renaming raw `uri`, `tweet_id`, `comment_fullname`, or `reddit_fullname`.
+- Changing `sample_data_to_mirror.py` or stimuli native id columns on curated CSV (`uri`, `tweet_id`, `post_reddit_id`).
+- Renaming `generate_feature(uri, text)` function signatures across the seven feature modules.
+- Leaving feature CSVs writing `uri` while constants say `source_record_id`.
+- Bluesky curation regressing because `ConsolidateConfig` still relies on default `feature_file_id_column="uri"`.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step14.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step14.md
@@ -1,0 +1,140 @@
+# Step 14: Own content-length and language policy at preprocess
+
+## Goal
+
+Length and language gates for stimuli-ready text live in one preprocess-owned policy. Bluesky and Twitter already enforce length and English at preprocess; Reddit enforces English but not length. This PR centralizes the numeric thresholds as named constants, documents the per-record-type policy, and adds Reddit’s missing minimum-length gate at preprocess without changing ingest fetch filters or importing PushShift experiment thresholds.
+
+## Caller / unit of work
+
+**Main callers:** `preprocess_bluesky.py`, `preprocess_twitter.py`, `preprocess_reddit.py` → `COMMENT_TEXT_VALIDATORS` / `POST_TEXT_VALIDATORS` tuples → validator functions in `data_platform/preprocessing/validators/`.
+
+**Slice:** add `content_filter_policy.py` → wire constants into existing length validators → add Reddit min-length validator → tests.
+
+**Out of scope:** Bluesky/Twitter ingest filters, Reddit ingest `min_comment_body_length` behavior, PushShift experiment code, features/curate/stimuli, runbook edits.
+
+## Decision (locked)
+
+- New module `data_platform/preprocessing/content_filter_policy.py` is the single source of truth for per-record-type length bounds and a short policy docstring stating that **English is required at preprocess for all platforms** via `check_if_text_english`.
+- **Do not change numeric thresholds** — only replace literals with named constants:
+  - Bluesky post: min `100`, max `300` (`check_if_valid_post_length` in `validators.py`).
+  - Twitter post: min `50`, max `280` (`check_if_valid_twitter_post_length` in `twitter_validators.py`).
+  - Reddit comment: min `30`, **no max** (new validator; aligns with ingest default `min_comment_body_length: 30`, not PushShift `20`–`300`).
+- **Language:** keep `check_if_text_english` as the preprocess English gate; it already appears in all three `preprocess_*.py` validator tuples — no new language validator.
+- **Reddit preprocess** currently has no length validator — add one using `REDDIT_COMMENT_MIN_LENGTH` and append it to `COMMENT_TEXT_VALIDATORS` (place after `check_if_body_not_removed`, before mention/URL validators).
+- **Ingest:** Reddit `min_comment_body_length` stays a cheap fetch-time filter in `sync_reddit.py` (YAML default `30`). Do **not** add length or language filters to Bluesky or Twitter ingest. Do **not** import `content_filter_policy` from ingest.
+- Do **not** wire `experiments/fetch_reddit_pushshift_dump_2026_06_15/` (`MIN_BODY_LEN = 20`, `MAX_BODY_LEN = 300`) into sync or preprocess.
+- Independently shippable; no dependency on other plan steps.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/plan.md` | Parent plan step 14 summary |
+| `data_platform/preprocessing/validators/validators.py` | `check_if_valid_post_length`, `check_if_text_english` |
+| `data_platform/preprocessing/validators/twitter_validators.py` | `check_if_valid_twitter_post_length` |
+| `data_platform/preprocessing/validators/reddit_validators.py` | Reddit-specific validators; home for new min-length check |
+| `data_platform/preprocessing/preprocess_bluesky.py` | `POST_TEXT_VALIDATORS` tuple |
+| `data_platform/preprocessing/preprocess_twitter.py` | `POST_TEXT_VALIDATORS` tuple |
+| `data_platform/preprocessing/preprocess_reddit.py` | `COMMENT_TEXT_VALIDATORS` — no length gate today |
+| `data_platform/ingestion/sync_reddit.py` | `min_comment_body_length` fetch filter (~line 289) |
+| `data_platform/ingestion/configs/reddit/default.yaml` | `min_comment_body_length: 30` |
+| `experiments/fetch_reddit_pushshift_dump_2026_06_15/config.py` | Out-of-scope `20`/`300` — do not import |
+| `tests/data_platform/preprocessing/test_preprocess_twitter.py` | Existing Twitter length parametrized tests |
+| `tests/data_platform/preprocessing/test_preprocess_reddit.py` | Reddit validator / filter tests |
+| `tests/data_platform/preprocessing/test_preprocess_bluesky.py` | Bluesky preprocess integration tests |
+
+## Files allowed to change
+
+- `data_platform/preprocessing/content_filter_policy.py` (new)
+- `data_platform/preprocessing/validators/validators.py`
+- `data_platform/preprocessing/validators/twitter_validators.py`
+- `data_platform/preprocessing/validators/reddit_validators.py`
+- `data_platform/preprocessing/preprocess_reddit.py`
+- `tests/data_platform/preprocessing/test_content_filter_policy.py` (new)
+- `tests/data_platform/preprocessing/test_preprocess_reddit.py`
+- `tests/data_platform/preprocessing/test_preprocess_twitter.py` (only if imports move; behavior unchanged)
+- `CHANGELOG.md`
+
+## Files forbidden to change
+
+- `data_platform/ingestion/sync_bluesky.py`
+- `data_platform/ingestion/sync_twitter.py`
+- `data_platform/ingestion/sync_reddit.py`
+- All YAML under `data_platform/ingestion/configs/`
+- `experiments/fetch_reddit_pushshift_dump_2026_06_15/`
+- `data_platform/generate_features/`, `data_platform/curate/`, stimuli sampling
+- `docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md` (follow-up doc pass optional; not required for this PR)
+
+## Contracts
+
+```text
+# data_platform/preprocessing/content_filter_policy.py
+
+BLUESKY_POST_MIN_LENGTH: int = 100
+BLUESKY_POST_MAX_LENGTH: int = 300
+TWITTER_POST_MIN_LENGTH: int = 50
+TWITTER_POST_MAX_LENGTH: int = 280
+REDDIT_COMMENT_MIN_LENGTH: int = 30
+# Module docstring: per-record-type bounds above; English required at preprocess
+# for bluesky.post, twitter.tweet, reddit.comment via check_if_text_english.
+
+check_if_valid_post_length(text) -> bool
+  return BLUESKY_POST_MIN_LENGTH <= len(text) <= BLUESKY_POST_MAX_LENGTH
+
+check_if_valid_twitter_post_length(text) -> bool
+  return TWITTER_POST_MIN_LENGTH <= len(text) <= TWITTER_POST_MAX_LENGTH
+
+check_if_valid_reddit_comment_min_length(text) -> bool   # new, in reddit_validators.py
+  return len(text) >= REDDIT_COMMENT_MIN_LENGTH
+
+COMMENT_TEXT_VALIDATORS (preprocess_reddit.py)
+  ... existing validators ...
+  includes check_if_valid_reddit_comment_min_length
+  still ends with check_if_text_english
+```
+
+Ingest contract unchanged: `sync_reddit` continues `min_comment_body_length = int(ingestion_params.get("min_comment_body_length", 30))` at fetch time only.
+
+## Tests (write first)
+
+`TestContentFilterPolicy` in `tests/data_platform/preprocessing/test_content_filter_policy.py`:
+
+- given module constants, then Bluesky/Twitter/Reddit values match locked thresholds (`100`/`300`, `50`/`280`, `30` min only).
+
+`TestBlueskyPostLength` (same file or colocated with policy tests):
+
+- given text at `99`, `100`, `300`, `301` chars, then `check_if_valid_post_length` matches prior behavior.
+
+`TestRedditCommentMinLength` in `test_preprocess_reddit.py` or `test_content_filter_policy.py`:
+
+- given body shorter than 30 chars (but otherwise valid), then `passes_all_validators` is False.
+- given body at exactly 30 chars (otherwise valid English comment), then True.
+- given `filter_comments` with one short and one valid row, then only the valid row remains.
+
+Existing `test_check_if_valid_twitter_post_length` in `test_preprocess_twitter.py` must still pass unchanged thresholds.
+
+Follow `.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md`. One test class per function under test.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/preprocessing/test_content_filter_policy.py tests/data_platform/preprocessing/test_preprocess_reddit.py tests/data_platform/preprocessing/test_preprocess_twitter.py -q
+```
+
+Exit 0.
+
+## Must still pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/preprocessing -q
+```
+
+Exit 0. No new failures.
+
+## Must not happen
+
+- Bluesky `100`–`300` or Twitter `50`–`280` numeric bounds changed.
+- PushShift `20`–`300` imported into sync or preprocess.
+- Length or language validators added to Bluesky or Twitter ingest.
+- Reddit ingest `min_comment_body_length` removed or wired to preprocess constants.
+- Replacing `check_if_text_english` with a new language implementation.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step2.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step2.md
@@ -1,0 +1,85 @@
+# Step 2: Rename Bluesky YAML author filter away from login identity
+
+## Goal
+
+Bluesky YAML `ingestion_params.handle` is an API author filter. Env `BLUESKY_HANDLE` is login identity. Rename the YAML key so operators cannot confuse them.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/ingestion/sync_bluesky.py` → `_search_posts_page` / `fetch_posts_for_keyword` reading the author filter.
+
+**Slice:** read `author_filter` (preferred) or deprecated `handle` → pass to AppView `author` param as today.
+
+**Out of scope:** Env var names, Twitter/Reddit, other YAML keys.
+
+## Decision (locked)
+
+- Canonical YAML key: `author_filter` (string, optional).
+- If both `author_filter` and `handle` are set and differ, raise `ValueError` naming both keys.
+- If only `handle` is set, use it and emit a `warnings.warn` (`DeprecationWarning`) that `handle` is deprecated in favor of `author_filter`.
+- Update committed Bluesky YAML that currently set `handle` (`data_platform/ingestion/configs/bluesky/default.yaml`) to `author_filter`.
+- Do not change `BLUESKY_HANDLE` / `BLUESKY_PASSWORD` in `data_platform/ingestion/sync_clients.py`.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `data_platform/ingestion/sync_bluesky.py` | `ingestion_params.get("handle")` in `_search_posts_page` |
+| `data_platform/ingestion/sync_clients.py` | Login env; do not change |
+| `data_platform/ingestion/configs/bluesky/default.yaml` | Has `handle: user.bsky.social` |
+| `tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py` | Search/fetch tests |
+
+## Files allowed to change
+
+- `data_platform/ingestion/sync_bluesky.py`
+- `data_platform/ingestion/configs/bluesky/*.yaml` (only the `handle` key → `author_filter`; no other key changes)
+- `tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py`
+- `CHANGELOG.md`
+
+## Files forbidden to change
+
+- `data_platform/ingestion/sync_clients.py`
+- `data_platform/ingestion/sync_twitter.py`
+- `data_platform/ingestion/sync_reddit.py`
+- Twitter and Reddit YAML
+- Preprocess / features / curate
+
+## Contracts
+
+```text
+resolve_bluesky_author_filter(ingestion_params: dict) -> str | None
+  Returns author_filter if set (non-empty string).
+  Else returns handle if set, after DeprecationWarning.
+  Else None.
+  Raise ValueError if both set and not equal.
+
+_search_posts_page uses resolve_bluesky_author_filter; API query param remains "author".
+```
+
+Put `resolve_bluesky_author_filter` in `sync_bluesky.py` (not a new module).
+
+## Tests (write first)
+
+`TestResolveBlueskyAuthorFilter`:
+
+- `author_filter` only → that string; no warning.
+- `handle` only → that string; `DeprecationWarning`.
+- both equal → that string; still warn because `handle` is present.
+- both differ → `ValueError`.
+- neither → `None`.
+
+Existing fetch tests that omit both still work. If a test passed `handle` in params, update it to `author_filter` except one alias test.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py tests/data_platform/ingestion/test_ingest_yaml_keys.py -q
+```
+
+Exit 0.
+
+## Must not happen
+
+- Renaming env `BLUESKY_HANDLE`.
+- Changing the AppView query parameter name (`author`).
+- Dropping author-scoped search.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step3.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step3.md
@@ -1,0 +1,78 @@
+# Step 3: Store repo-relative ingest config paths in manifests
+
+## Goal
+
+`build_base_sync_metadata` writes `ingestion_config` as `config_path.name` (basename). `ensure_dataset_manifest` already writes `config_path.relative_to(REPO_ROOT)`. Two configs named `mirrorview.yaml` on different platforms then look identical in run metadata.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/ingestion/sync_checkpoint.py` → `build_base_sync_metadata` and `ensure_dataset_manifest`.
+
+**Slice:** new runs stamp the same repo-relative POSIX path in run `metadata.json` and `dataset.json`.
+
+**Out of scope:** Migrating existing on-disk metadata. Output format. YAML key renames.
+
+## Decision (locked)
+
+- Helper `ingestion_config_repo_path(config_path: Path) -> str` in `sync_checkpoint.py`: `config_path.resolve().relative_to(REPO_ROOT).as_posix()`. Raise `ValueError` if the file is outside the repo.
+- `build_base_sync_metadata` uses that helper instead of `config_path.name`.
+- `ensure_dataset_manifest` uses the same helper (replace the inline `relative_to`).
+- Do not rewrite old run directories. Resume continues to accept whatever string is already in metadata.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `data_platform/ingestion/sync_checkpoint.py` | `build_base_sync_metadata` `ingestion_config`; `ensure_dataset_manifest` |
+| `data_platform/utils/dataset.py` | Manifest schema `ingestion_config` |
+| `lib/constants.py` | `REPO_ROOT` |
+| `tests/data_platform/ingestion/test_sync_checkpoint.py` | Metadata builder tests |
+| `tests/data_platform/utils/test_dataset.py` | Manifest writer already uses repo-relative examples |
+
+## Files allowed to change
+
+- `data_platform/ingestion/sync_checkpoint.py`
+- `tests/data_platform/ingestion/test_sync_checkpoint.py`
+- `CHANGELOG.md`
+
+## Files forbidden to change
+
+- Platform `sync_*.py` except via the shared helper they already call
+- `data_platform/utils/dataset.py` unless a test-only import is required (prefer not)
+- YAML configs
+- Preprocess / features / curate
+
+## Contracts
+
+```text
+ingestion_config_repo_path(config_path: Path) -> str
+  POSIX path relative to REPO_ROOT, e.g.
+  "data_platform/ingestion/configs/bluesky/mirrorview.yaml"
+  Raise ValueError if config_path.resolve() is not inside REPO_ROOT.
+
+build_base_sync_metadata[...]["ingestion_config"] == ingestion_config_repo_path(config_path)
+ensure_dataset_manifest passes the same string to write_dataset_manifest(..., ingestion_config=...)
+```
+
+## Tests (write first)
+
+`TestIngestionConfigRepoPath` and update `TestBuildBaseSyncMetadata` (or equivalent) so expected `ingestion_config` is the relative path, not the basename.
+
+- given a path under repo `data_platform/ingestion/configs/twitter/default.yaml`, result is that POSIX relative string.
+- given `/tmp/outside.yaml`, `ValueError`.
+
+If existing checkpoint tests assert `config_path.name`, change the expected value to the relative path.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_sync_checkpoint.py tests/data_platform/utils/test_dataset.py -q
+```
+
+Exit 0.
+
+## Must not happen
+
+- Storing absolute paths.
+- Backslashes in the stored string.
+- Requiring operators to rewrite old `metadata.json`.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step4.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step4.md
@@ -1,0 +1,99 @@
+# Step 4: Honor declared output format for Twitter and Reddit raw files
+
+## Goal
+
+YAML `output_format` and `dataset.json` `format` already exist. Bluesky writes `storage.records_filename` (stem + manifest suffix). Twitter hardcodes `POSTS_CSV = "posts.csv"`. Reddit uses `record_type_to_filename`, which always returns `.csv`. Parquet configs then lie.
+
+## Caller / unit of work
+
+**Main caller:** `sync_twitter.sync_records` and `sync_reddit.sync_records` when appending records.
+
+**Slice:** after `ensure_dataset_manifest`, use the storage manager’s format-aware `records_filename` (and Reddit post/comment managers) for append and dedupe filenames.
+
+**Out of scope:** The explicit-pipeline-paths plan (`docs/plans/2026-09-01_explicit_pipeline_paths_ebe7ae`). Do not redesign StorageManager APIs beyond using `records_filename` already implemented in `data_platform/utils/storage.py`.
+
+## Decision (locked)
+
+- Twitter: drop the write path’s dependency on a hardcoded `posts.csv` string. Pass `storage.records_filename` into `run_sync_tasks` the way Bluesky passes `filename=storage.records_filename`.
+- Reddit: `record_type_to_filename` must take the dataset format (or return a stem and let StorageManager restem). Result files are `posts.csv`/`comments.csv` or `posts.parquet`/`comments.parquet` matching `ValidDataFormats` from the manifest.
+- `RECORD_TYPE_FILENAMES` in `sync_checkpoint.py` may store stems (`posts`, `comments`) plus suffix from format, or keep `.csv` names and let `StorageManager` restem as it already does (`Path(records_filename).stem` + `format.value`). Prefer the existing restem: pass `posts.csv` / `comments.csv` into the manager, then write using `manager.records_filename`.
+- Tests that pass `csv_filename=sync_twitter.POSTS_CSV` must pass the storage manager’s `records_filename` instead (still `posts.csv` when format is csv).
+- Do not add new YAML keys.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `data_platform/ingestion/sync_bluesky.py` | `filename = storage.records_filename` |
+| `data_platform/ingestion/sync_twitter.py` | `POSTS_CSV` and `csv_filename` |
+| `data_platform/ingestion/sync_reddit.py` | `record_type_to_filename` |
+| `data_platform/ingestion/sync_checkpoint.py` | `RECORD_TYPE_FILENAMES`, `record_type_to_filename` |
+| `data_platform/utils/storage.py` | restem in `StorageManager.__init__` |
+| `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py` | `csv_filename=sync_twitter.POSTS_CSV` |
+| `data_platform/ingestion/configs/bluesky/mirrorview2.yaml` | `output_format: parquet` example |
+
+## Files allowed to change
+
+- `data_platform/ingestion/sync_twitter.py`
+- `data_platform/ingestion/sync_reddit.py`
+- `data_platform/ingestion/sync_checkpoint.py` (`record_type_to_filename` / `RECORD_TYPE_FILENAMES` only if required)
+- `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py`
+- `tests/data_platform/ingestion/test_sync_reddit_checkpoint.py`
+- `tests/data_platform/ingestion/test_sync_checkpoint.py` if filename helper tests live there
+- `tests/data_platform/utils/test_storage.py` for `StorageManager.records_filename` / restem assertions
+- `CHANGELOG.md`
+
+## Files forbidden to change
+
+- `data_platform/utils/storage.py` unless a one-line bugfix is required for restem (prefer not)
+- Preprocess / features / curate
+- YAML except if a test fixture YAML must declare parquet (prefer tmp configs in tests)
+
+## Contracts
+
+```text
+TwitterStorageManager(RAW, dataset_id).records_filename
+  == "posts.csv" when dataset.json format is csv
+  == "posts.parquet" when format is parquet
+
+Reddit comment_storage().records_filename similarly comments.{csv|parquet}
+Reddit post_storage().records_filename similarly posts.{csv|parquet}
+
+append_deduped_records(..., filename=that records_filename)
+```
+
+## Tests (write first)
+
+`TestStorageManagerRecordsFilename` in `tests/data_platform/utils/test_storage.py` — use `data_root`, `write_dataset_manifest(..., data_format=ValidDataFormats.CSV|PARQUET)`, then construct managers with the default stem (`posts.csv` / `comments.csv`) and assert restem:
+
+- given `dataset.json` `format: csv`, when `TwitterStorageManager(RAW, dataset_id)` is constructed, then `records_filename == "posts.csv"`.
+- given `format: parquet`, when the same manager is constructed, then `records_filename == "posts.parquet"`.
+- given `format: parquet`, when `RedditStorageManager(RAW, dataset_id).comment_storage()` / `.post_storage()` are constructed, then `records_filename` is `comments.parquet` / `posts.parquet` respectively.
+
+`TestTwitterSyncRecordsFilename` in `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py`:
+
+- given a parquet manifest and existing `run_sync_tasks` mocks, when `sync_records` or `run_sync_tasks` runs, then `append_deduped_records` / `append_records` is called with `filename="posts.parquet"` (spy or assert output path under `run_dir / "posts.parquet"`).
+- given csv manifest (default), existing checkpoint tests still pass when they pass `storage.records_filename` instead of `sync_twitter.POSTS_CSV` (still `posts.csv`).
+
+`TestRedditSyncRecordsFilename` in `tests/data_platform/ingestion/test_sync_reddit_checkpoint.py`:
+
+- given parquet manifest, when `run_sync_tasks` appends comments and posts, then writers use `comment_storage.records_filename` and `post_storage.records_filename` (`comments.parquet`, `posts.parquet`) — not hardcoded `.csv` from `record_type_to_filename` alone.
+- given csv manifest, filenames remain `comments.csv` / `posts.csv`.
+
+If `record_type_to_filename` gains a format parameter, extend `TestRecordTypeToFilename` in `tests/data_platform/ingestion/test_sync_checkpoint.py`; if restem-only, add one test that passing `posts.csv` into `TwitterStorageManager` with a parquet manifest still yields `posts.parquet` on write.
+
+Follow `.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md`. One test class per function or manager under test.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion tests/data_platform/utils/test_storage.py tests/data_platform/utils/test_dataset.py -q
+```
+
+Exit 0.
+
+## Must not happen
+
+- Bluesky write path regressed to a hardcoded csv name.
+- Manifest `format` parquet with Twitter still creating `posts.csv` in a new run.
+- Changing preprocess file discovery in this PR.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step5.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step5.md
@@ -1,0 +1,82 @@
+# Step 5: Require list-form search terms on Twitter ingest configs
+
+## Goal
+
+Bluesky YAML uses `keywords: [str, ...]`. Twitter uses `keyword` as a string or a list. Unify Twitter on `keywords`.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/ingestion/sync_twitter.py` → `build_sync_tasks`.
+
+**Slice:** parse `keywords` (list) or deprecated `keyword` → `list[TwitterTask]`.
+
+**Out of scope:** Bluesky `keywords` parser, Reddit subreddits, limit keys (step 6).
+
+## Decision (locked)
+
+- Canonical key: `keywords` as a non-empty list of non-empty strings (same rules as Bluesky `build_sync_tasks`).
+- Alias: `keyword` as `str` or `list[str]`. If only `keyword` is present, build tasks from it and `warnings.warn` `DeprecationWarning`.
+- If both `keywords` and `keyword` are present, raise `ValueError` (do not merge).
+- Update all committed files under `data_platform/ingestion/configs/twitter/` from `keyword:` to `keywords:` (wrap a scalar `example` as a one-item list).
+- Task ledger field stays `keyword` (the term for that task). Row field `keyword` on `SyncTwitterPostModel` stays.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `data_platform/ingestion/sync_twitter.py` | `build_sync_tasks` |
+| `data_platform/ingestion/sync_bluesky.py` | list validation to copy |
+| `data_platform/ingestion/configs/twitter/*.yaml` | `keyword:` |
+| `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py` | fixtures using `keyword` |
+| `tests/data_platform/ingestion/conftest.py` | twitter params |
+
+## Files allowed to change
+
+- `data_platform/ingestion/sync_twitter.py`
+- `data_platform/ingestion/configs/twitter/*.yaml`
+- `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py`
+- `tests/data_platform/ingestion/conftest.py` (twitter ingest params only)
+- `tests/data_platform/ingestion/test_ingest_yaml_keys.py` only if a dead-key set must allow neither (prefer not)
+- `CHANGELOG.md`
+
+## Files forbidden to change
+
+- Bluesky and Reddit sync/YAML except if a shared helper is extracted into a new function in `sync_twitter.py` only
+- `data_platform/models/sync.py` (row `keyword` stays)
+- Preprocess / features / curate
+
+## Contracts
+
+```text
+build_sync_tasks(ingestion_params) -> list[TwitterTask]
+  Prefer ingestion_params["keywords"] as list[str], non-empty, each stripped non-empty.
+  Else ingestion_params["keyword"] as str or list[str] (deprecated).
+  Else ValueError: must include 'keywords' as a non-empty list of strings.
+```
+
+## Tests (write first)
+
+`TestBuildSyncTasks`:
+
+- `keywords: ["a", "b"]` → two tasks, ids `a` and `b`.
+- `keyword: "a"` → one task, `DeprecationWarning`.
+- `keyword: ["a"]` → one task, warning.
+- both keys → `ValueError`.
+- `keywords: []` → `ValueError`.
+- `keywords: ["  "]` → `ValueError`.
+
+Existing checkpoint tests: switch fixtures to `keywords` except the alias tests.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_sync_twitter_checkpoint.py tests/data_platform/ingestion/test_ingest_yaml_keys.py tests/data_platform/ingestion/test_query_terms.py -q
+```
+
+Exit 0.
+
+## Must not happen
+
+- Changing Bluesky’s `keywords` key.
+- Removing per-row `keyword` from Twitter CSV schema.
+- Silently ignoring one of two conflicting keys.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step6.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step6.md
@@ -1,0 +1,93 @@
+# Step 6: Standardize per-task fetch caps across ingest platforms
+
+## Goal
+
+Bluesky uses `limit`, Twitter `limit_per_keyword`, Reddit `limit_per_subreddit` for the same knob: max items fetched for one checkpoint task.
+
+## Caller / unit of work
+
+**Main caller:** `build_sync_tasks` / fetch loops in `sync_bluesky.py`, `sync_twitter.py`, `sync_reddit.py`.
+
+**Slice:** resolve `limit_per_task` with aliases → existing fetch limits unchanged in meaning.
+
+**Out of scope:** `max_rows` (step 7). Output filenames.
+
+## Decision (locked)
+
+- Canonical YAML key: `limit_per_task` (int > 0).
+- Aliases, platform-specific: Bluesky `limit`; Twitter `limit_per_keyword`; Reddit `limit_per_subreddit`.
+- Resolution order: `limit_per_task` if present, else the platform alias. If both present and unequal, `ValueError`. If both present and equal, use it and warn if the alias is present (`DeprecationWarning`).
+- Twitter default when neither is set remains `25` (today’s `limit_per_keyword` default). Bluesky and Reddit keep requiring an explicit value (today they require `limit` / `limit_per_subreddit`).
+- Update committed YAML to `limit_per_task` and remove the old key from those files.
+- Helper `resolve_limit_per_task(ingestion_params, *, alias_key: str, default: int | None) -> int` in `sync_checkpoint.py` so all three CLIs share it.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `data_platform/ingestion/sync_bluesky.py` | `limit` |
+| `data_platform/ingestion/sync_twitter.py` | `_effective_limit_per_keyword` |
+| `data_platform/ingestion/sync_reddit.py` | `limit_per_subreddit` |
+| `data_platform/ingestion/sync_checkpoint.py` | shared helper home |
+| All `data_platform/ingestion/configs/**/*.yaml` | current cap keys |
+| Existing checkpoint tests | fixtures |
+
+## Files allowed to change
+
+- `data_platform/ingestion/sync_checkpoint.py`
+- `data_platform/ingestion/sync_bluesky.py`
+- `data_platform/ingestion/sync_twitter.py`
+- `data_platform/ingestion/sync_reddit.py`
+- `data_platform/ingestion/configs/**/*.yaml` (cap keys only)
+- `tests/data_platform/ingestion/test_sync_checkpoint.py` (helper tests)
+- `tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py`
+- `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py`
+- `tests/data_platform/ingestion/test_sync_reddit_checkpoint.py`
+- `tests/data_platform/ingestion/conftest.py` and `reddit_conftest.py` / `twitter_conftest.py` as needed
+- `CHANGELOG.md`
+
+## Files forbidden to change
+
+- Preprocess / features / curate
+- `max_rows` semantics
+- Models
+
+## Contracts
+
+```text
+resolve_limit_per_task(
+    ingestion_params: dict[str, Any],
+    *,
+    alias_key: str,
+    default: int | None = None,
+) -> int
+  Canonical key "limit_per_task".
+  Raise ValueError if missing and default is None.
+  Raise ValueError if the resolved int is <= 0.
+  Raise ValueError if canonical and alias both set and int(canonical) != int(alias).
+```
+
+Bluesky: `alias_key="limit", default=None`.
+Twitter: `alias_key="limit_per_keyword", default=25`.
+Reddit: `alias_key="limit_per_subreddit", default=None`.
+
+Twitter `_effective_limit_per_keyword` still mins with remaining `max_rows` budget; rename the function to `_effective_limit_per_task` in this PR.
+
+## Tests (write first)
+
+`TestResolveLimitPerTask` covering canonical, alias+warning, conflict, missing, non-positive.
+
+Platform checkpoint tests still collect the same number of rows when YAML uses `limit_per_task` equal to the old value.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
+```
+
+Exit 0.
+
+## Must not happen
+
+- Changing numeric defaults except via the documented Twitter 25.
+- Removing alias support in this PR (configs outside the repo may still use old keys).

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step7.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step7.md
@@ -1,0 +1,174 @@
+# Step 7: Split global ingest row caps by posts versus comments
+
+## Goal
+
+One YAML key `max_rows` names a global run cap for Bluesky/Twitter posts and Reddit comments, but the unit differs by platform. This PR introduces explicit canonical keys (`max_posts`, `max_comments`), keeps `max_rows` as a deprecated alias with platform-specific meaning, and renames checkpoint helpers so “row cap” is not confused with Reddit `post_row_count`.
+
+## Caller / unit of work
+
+**Main callers:** `run_sync_tasks` in `sync_bluesky.py`, `sync_twitter.py`, `sync_reddit.py`; shared stop logic in `sync_checkpoint.py` (`run_checkpointed_sync`, `stop_at_max_rows`).
+
+**Slice:** resolve global run cap from YAML → pass cap into checkpoint loop and per-task remaining budget → committed configs use canonical keys.
+
+**Out of scope:** per-task fetch caps (`limit_per_task`, step 6). Preprocess, features, curate. Changing what `metadata["row_count"]` counts (still deduped primary output rows: posts for Bluesky/Twitter, comments for Reddit).
+
+## Decision (locked)
+
+- Bluesky/Twitter canonical YAML key: `max_posts`.
+- Reddit canonical YAML key: `max_comments` (still compared to `metadata["row_count"]`, which is comment count, **not** `post_row_count`).
+- Deprecated alias on all three platforms: `max_rows`. Bluesky/Twitter: means `max_posts`. Reddit: means `max_comments`.
+- If canonical and alias both set and unequal → `ValueError`. If equal, use it and emit `DeprecationWarning` when the alias is present.
+- Shared helper in `data_platform/ingestion/sync_checkpoint.py`: `parse_run_row_cap(ingestion_params, *, canonical_key: str) -> int | None`.
+- Rename `stop_at_max_rows` → `stop_at_run_row_cap`; update all callers. Rename `run_checkpointed_sync(..., max_rows_int=...)` kwarg to `run_row_cap_int`.
+- `parse_max_rows` is only referenced from ingest sync modules and `test_sync_checkpoint.py` (grep the repo). **Delete** `parse_max_rows`; do not leave a wrapper.
+- Update committed YAML: Bluesky/Twitter `max_rows` → `max_posts`; Reddit `max_rows` → `max_comments`. Files without a cap stay uncapped.
+- Bluesky `fetch_posts_for_keyword(..., max_rows=remaining)` parameter renames to `max_posts` (remaining post budget for one task, same semantics).
+- Twitter `_remaining_row_budget` renames to `_remaining_run_row_cap` (or equivalent); it still subtracts `metadata["row_count"]` from the resolved cap. If step 6 landed, `_effective_limit_per_task` still mins with this remaining budget.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/plan.md` | Parent plan step 7 |
+| `data_platform/ingestion/sync_checkpoint.py` | `parse_max_rows`, `stop_at_max_rows`, `run_checkpointed_sync` |
+| `data_platform/ingestion/sync_bluesky.py` | `parse_max_rows`, `fetch_posts_for_keyword(max_rows=...)`, `run_sync_tasks` remaining budget |
+| `data_platform/ingestion/sync_twitter.py` | `parse_max_rows`, `_remaining_row_budget`, `run_sync_tasks` |
+| `data_platform/ingestion/sync_reddit.py` | `parse_max_rows`, `metadata["row_count"]` vs `post_row_count` |
+| `data_platform/ingestion/configs/bluesky/default.yaml` | `max_rows: 200` |
+| `data_platform/ingestion/configs/bluesky/smoke.yaml` | `max_rows: 100` |
+| `data_platform/ingestion/configs/bluesky/mirrorview_scale.yaml` | `max_rows: 20000` |
+| `data_platform/ingestion/configs/twitter/default.yaml` | `max_rows: 50` |
+| `data_platform/ingestion/configs/twitter/mirrorview.yaml` | `max_rows: 1000` |
+| `data_platform/ingestion/configs/twitter/mirrorview_scale.yaml` | `max_rows: 10000` |
+| `data_platform/ingestion/configs/twitter/mirrorview_scale_2.yaml` | `max_rows: 15000` |
+| `data_platform/ingestion/configs/twitter/keyword_politics_econ_7000.yaml` | `max_rows: 10000` |
+| `data_platform/ingestion/configs/reddit/default.yaml` | `max_rows: 100` |
+| `tests/data_platform/ingestion/test_sync_checkpoint.py` | `test_parse_max_rows_*`, `test_stop_at_max_rows_*` |
+| `tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py` | `test_run_sync_tasks_caps_fetch_by_remaining_max_rows` |
+
+## Files allowed to change
+
+- `data_platform/ingestion/sync_checkpoint.py`
+- `data_platform/ingestion/sync_bluesky.py`
+- `data_platform/ingestion/sync_twitter.py`
+- `data_platform/ingestion/sync_reddit.py`
+- `data_platform/ingestion/configs/bluesky/default.yaml`
+- `data_platform/ingestion/configs/bluesky/smoke.yaml`
+- `data_platform/ingestion/configs/bluesky/mirrorview_scale.yaml`
+- `data_platform/ingestion/configs/twitter/default.yaml`
+- `data_platform/ingestion/configs/twitter/mirrorview.yaml`
+- `data_platform/ingestion/configs/twitter/mirrorview_scale.yaml`
+- `data_platform/ingestion/configs/twitter/mirrorview_scale_2.yaml`
+- `data_platform/ingestion/configs/twitter/keyword_politics_econ_7000.yaml`
+- `data_platform/ingestion/configs/reddit/default.yaml`
+- `tests/data_platform/ingestion/test_sync_checkpoint.py`
+- `tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py`
+- `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py`
+- `tests/data_platform/ingestion/test_sync_reddit_checkpoint.py`
+- `tests/data_platform/ingestion/conftest.py` and `reddit_conftest.py` / `twitter_conftest.py` as needed for fixture cap keys
+- `CHANGELOG.md`
+
+## Files forbidden to change
+
+- Preprocess (`data_platform/preprocessing/**`)
+- Features / curate / stimuli
+- `data_platform/models/**`
+- Ingest YAML files that have no global cap (leave uncapped): `data_platform/ingestion/configs/bluesky/mirrorview.yaml`, `mirrorview2.yaml`, `trump_econ_iran.yaml`; `data_platform/ingestion/configs/reddit/mirrorview.yaml`, `mirrorview_scale.yaml`, `mirrorview_scale_run_2.yaml`
+- Per-task limit keys and resolution (`limit`, `limit_per_keyword`, `limit_per_subreddit`, `limit_per_task` — step 6)
+
+## Contracts
+
+```text
+DEPRECATED_RUN_ROW_CAP_ALIAS: str = "max_rows"
+
+parse_run_row_cap(
+    ingestion_params: dict[str, Any],
+    *,
+    canonical_key: str,
+) -> int | None
+  canonical = ingestion_params.get(canonical_key)
+  alias = ingestion_params.get(DEPRECATED_RUN_ROW_CAP_ALIAS)
+  If canonical is not None and alias is not None and int(canonical) != int(alias):
+      raise ValueError (message names both keys and the conflict)
+  If canonical is not None:
+      if alias is not None: warnings.warn(DeprecationWarning) for max_rows
+      return int(canonical)
+  If alias is not None:
+      warnings.warn(DeprecationWarning) for max_rows
+      return int(alias)
+  return None
+
+stop_at_run_row_cap(
+    metadata, storage, output_dir, run_row_cap_int: int | None,
+) -> bool
+  Same behavior as stop_at_max_rows today:
+  if run_row_cap_int is None or metadata["row_count"] < run_row_cap_int: return False
+  else mark remaining tasks skipped, flush metadata, return True
+
+run_checkpointed_sync(..., run_row_cap_int: int | None, ...)
+  Calls stop_at_run_row_cap before and after each process_task (unchanged control flow).
+```
+
+Platform wiring:
+
+- Bluesky: `parse_run_row_cap(ingestion_params, canonical_key="max_posts")`.
+- Twitter: `parse_run_row_cap(ingestion_params, canonical_key="max_posts")`.
+- Reddit: `parse_run_row_cap(ingestion_params, canonical_key="max_comments")`; cap still gates on `metadata["row_count"]` (comments), never `post_row_count`.
+
+Committed YAML after this PR (numeric values unchanged, keys only):
+
+| File | Old | New |
+|------|-----|-----|
+| `configs/bluesky/default.yaml` | `max_rows: 200` | `max_posts: 200` |
+| `configs/bluesky/smoke.yaml` | `max_rows: 100` | `max_posts: 100` |
+| `configs/bluesky/mirrorview_scale.yaml` | `max_rows: 20000` | `max_posts: 20000` |
+| `configs/twitter/default.yaml` | `max_rows: 50` | `max_posts: 50` |
+| `configs/twitter/mirrorview.yaml` | `max_rows: 1000` | `max_posts: 1000` |
+| `configs/twitter/mirrorview_scale.yaml` | `max_rows: 10000` | `max_posts: 10000` |
+| `configs/twitter/mirrorview_scale_2.yaml` | `max_rows: 15000` | `max_posts: 15000` |
+| `configs/twitter/keyword_politics_econ_7000.yaml` | `max_rows: 10000` | `max_posts: 10000` |
+| `configs/reddit/default.yaml` | `max_rows: 100` | `max_comments: 100` |
+
+## Tests (write first)
+
+`TestParseRunRowCap` in `tests/data_platform/ingestion/test_sync_checkpoint.py` (replace `TestParseMaxRows` / `test_parse_max_rows_*`):
+
+- given `{}`, then returns `None`.
+- given `{"max_posts": 100}` with `canonical_key="max_posts"`, then `100`.
+- given `{"max_comments": 50}` with `canonical_key="max_comments"`, then `50`.
+- given only `{"max_rows": 100}` and `canonical_key="max_posts"`, then `100` and `pytest.warns(DeprecationWarning)`.
+- given `{"max_posts": 100, "max_rows": 100}`, then `100` and `DeprecationWarning`.
+- given `{"max_posts": 100, "max_rows": 99}`, then `pytest.raises(ValueError)`.
+
+`TestStopAtRunRowCap` (rename from `test_stop_at_max_rows_*`): pending tasks skipped when `metadata["row_count"] >= run_row_cap_int`; no-op when cap is `None` or count below cap.
+
+Platform checkpoint tests:
+
+- Bluesky: update `test_run_sync_tasks_caps_fetch_by_remaining_max_rows` to set `max_posts` (add a sibling test that `max_rows` alias still caps the same way with warning).
+- Twitter: if a cap test exists or is added, assert stop/skip behavior with `max_posts` and alias `max_rows`.
+- Reddit: assert run stops when comment `row_count` reaches `max_comments`; `post_row_count` above cap does not trigger early stop (posts-only growth must not satisfy the comment cap).
+
+Follow `.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md`. One test class per helper function.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_sync_checkpoint.py tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py tests/data_platform/ingestion/test_sync_twitter_checkpoint.py tests/data_platform/ingestion/test_sync_reddit_checkpoint.py tests/data_platform/ingestion/test_ingest_yaml_keys.py -q
+```
+
+Exit 0.
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
+```
+
+Exit 0. No new failures.
+
+## Must not happen
+
+- Removing `max_rows` alias support in this PR (external configs may still use it).
+- Capping Reddit ingest on `post_row_count` or renaming `metadata["row_count"]` for Reddit.
+- Changing numeric cap values in committed YAML (key rename only).
+- Adding `max_posts` to Reddit YAML or `max_comments` to Bluesky/Twitter YAML.
+- Leaving `parse_max_rows` or `stop_at_max_rows` exported after rename (grep must be clean).
+- Touching per-task limit resolution (step 6) or preprocess.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step8.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step8.md
@@ -1,0 +1,163 @@
+# Step 8: Collapse ingest dedupe policy keys and drop the unused current-run token
+
+## Goal
+
+Bluesky and Twitter use `dedupe_policy`; Reddit uses `comments_dedupe_policy` and `posts_dedupe_policy`. All committed YAML lists `current_run`, but within-run dedupe is always on via `DedupeSession.warm` → `load_seen_ids` — only `prior_runs_same_dataset` toggles cross-run loading. This PR unifies the YAML shape, drops the no-op `current_run` token, and keeps Reddit per-type overrides optional.
+
+## Caller / unit of work
+
+**Main callers:** `sync_bluesky.run_sync_tasks`, `sync_twitter.run_sync_tasks`, `sync_reddit._open_reddit_dedupe_sessions` (via `policy_includes_prior_runs` on resolved policy lists).
+
+**Slice:** resolve `dedupe_policy` (+ optional Reddit per-record-type override and aliases) → `policy_includes_prior_runs` → existing `DedupeSession.warm` behavior unchanged for valid configs.
+
+**Out of scope:** skip-counter key names (step 9), `DedupeSession` method renames, experiments YAML outside `data_platform/ingestion/configs/`.
+
+## Decision (locked)
+
+- Canonical YAML: `dedupe_policy: list[str]` on all platforms.
+- Optional Reddit override: `dedupe_policy_by_record_type: { "reddit.post": [...], "reddit.comment": [...] }`. When a record type is missing from the map, use top-level `dedupe_policy`.
+- Keep aliases `comments_dedupe_policy` / `posts_dedupe_policy` this PR: if present without the new override map, map them to `reddit.comment` / `reddit.post` and emit `DeprecationWarning`. If both an old alias and the new override map entry for the same record type are set and the lists differ → `ValueError`.
+- `current_run` is **not** a policy switch. Within-run dedupe always happens via `DedupeSession.warm` → `load_seen_ids`. Remove `current_run` from documented/allowed policy tokens.
+- Code only honors `prior_runs_same_dataset` (`PRIOR_RUN_POLICY` in `data_platform/utils/deduplication.py`). `policy_includes_prior_runs` stays; it ignores unknown tokens (including leftover `current_run`) and returns True only when `PRIOR_RUN_POLICY` is in the list.
+- `test_ingest_yaml_keys.py` `ALLOWED_DEDUPE_POLICY_TOKENS` becomes only `{PRIOR_RUN_POLICY}`. Committed YAML must not list `current_run`.
+- Update all committed ingest YAML under `data_platform/ingestion/configs/` to drop `current_run` and use `dedupe_policy`. Reddit: one shared list today (posts and comments policies match), so replace `comments_dedupe_policy` / `posts_dedupe_policy` with a single `dedupe_policy` — no `dedupe_policy_by_record_type` map unless a file truly needs differing lists.
+- Configs that today include `prior_runs_same_dataset` keep that token after removing `current_run` (e.g. `[prior_runs_same_dataset]`). Configs that were `current_run`-only become `dedupe_policy: []` or omit the key.
+- Independently shippable one PR.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/plan.md` | Parent plan step 8 |
+| `data_platform/utils/deduplication.py` | `PRIOR_RUN_POLICY`, `policy_includes_prior_runs`, `DedupeSession.warm` |
+| `data_platform/ingestion/sync_bluesky.py` | `ingestion_params.get("dedupe_policy")` |
+| `data_platform/ingestion/sync_twitter.py` | same |
+| `data_platform/ingestion/sync_reddit.py` | `_open_reddit_dedupe_sessions`, per-type policy keys |
+| `data_platform/ingestion/sync_checkpoint.py` | shared resolver home (pattern from step 6 `resolve_limit_per_task`) |
+| `data_platform/ingestion/configs/**/*.yaml` | `current_run`, split Reddit keys |
+| `tests/data_platform/ingestion/test_ingest_yaml_keys.py` | `ALLOWED_DEDUPE_POLICY_TOKENS`, `DEDUPE_POLICY_KEYS` |
+| `tests/data_platform/utils/test_deduplication.py` | `TestPolicyIncludesPriorRuns`, `current_run` fixtures |
+| `tests/data_platform/ingestion/test_sync_*_checkpoint.py` | `test_run_sync_tasks_respects_current_run_only_policy` |
+| `tests/data_platform/ingestion/conftest.py`, `reddit_conftest.py` | default policy fixtures |
+
+## Files allowed to change
+
+- `data_platform/utils/deduplication.py` (docstrings; `policy_includes_prior_runs` ignores unknown tokens)
+- `data_platform/ingestion/sync_checkpoint.py` (shared `resolve_dedupe_policy` helper)
+- `data_platform/ingestion/sync_bluesky.py`
+- `data_platform/ingestion/sync_twitter.py`
+- `data_platform/ingestion/sync_reddit.py`
+- `data_platform/ingestion/configs/**/*.yaml` (dedupe keys/tokens only)
+- `tests/data_platform/ingestion/test_ingest_yaml_keys.py`
+- `tests/data_platform/utils/test_deduplication.py`
+- `tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py`
+- `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py`
+- `tests/data_platform/ingestion/test_sync_reddit_checkpoint.py`
+- `tests/data_platform/ingestion/conftest.py`
+- `tests/data_platform/ingestion/reddit_conftest.py`
+- `tests/data_platform/ingestion/test_sync_checkpoint.py` (resolver unit tests, if added there)
+- `CHANGELOG.md`
+
+## Files forbidden to change
+
+- Preprocess / features / curate / stimuli
+- `experiments/**` YAML (outside committed ingest configs)
+- Skip-counter metadata field names (step 9)
+- `DedupeSession` public method names
+
+## Contracts
+
+```text
+PRIOR_RUN_POLICY: str = "prior_runs_same_dataset"
+
+policy_includes_prior_runs(policy: object) -> bool
+  Non-lists → False.
+  True iff PRIOR_RUN_POLICY in policy list.
+  Ignore all other tokens (including "current_run", "unknown_policy").
+
+resolve_dedupe_policy(
+    ingestion_params: dict[str, Any],
+    *,
+    record_type: str | None = None,
+) -> list[str]
+  Canonical top-level key "dedupe_policy" (default [] when absent).
+  When record_type is set (Reddit only):
+    - If dedupe_policy_by_record_type has record_type → use that list.
+    - Else if record_type-specific alias present:
+        "reddit.comment" → comments_dedupe_policy
+        "reddit.post" → posts_dedupe_policy
+      DeprecationWarning when alias used without override map.
+    - Else → top-level dedupe_policy.
+  Raise ValueError if alias and override map both set for same record_type and lists differ.
+  Raise ValueError if record_type not in {"reddit.comment", "reddit.post", None}.
+```
+
+Bluesky/Twitter call sites:
+
+```text
+include_prior_runs = policy_includes_prior_runs(
+    resolve_dedupe_policy(ingestion_params)
+)
+```
+
+Reddit `_open_reddit_dedupe_sessions`:
+
+```text
+comments: resolve_dedupe_policy(ingestion_params, record_type="reddit.comment")
+posts:    resolve_dedupe_policy(ingestion_params, record_type="reddit.post")
+```
+
+Within-run dedupe: unchanged — every session still calls `warm(storage, output_dir)` which always runs `load_seen_ids` for the current run directory.
+
+## Tests (write first)
+
+`TestResolveDedupePolicy` in `tests/data_platform/ingestion/test_sync_checkpoint.py` (or `tests/data_platform/utils/test_deduplication.py`):
+
+- given top-level `dedupe_policy: [PRIOR_RUN_POLICY]`, when `record_type` is None, then returns that list.
+- given `dedupe_policy: []`, then `policy_includes_prior_runs` is False; `warm` still loads current-run ids (existing `test_session_warm_loads_current_run_only_by_default` behavior).
+- given Reddit alias `comments_dedupe_policy` without override map, then resolves for `reddit.comment` and warns.
+- given `dedupe_policy_by_record_type` and matching alias, then no error.
+- given override map and alias with different lists, then `ValueError`.
+
+Update `TestPolicyIncludesPriorRuns`:
+
+- `["current_run"]` → False (unchanged outcome; documents ignored token).
+- `[PRIOR_RUN_POLICY]` → True (drop `current_run` from the combined case).
+- `["current_run", "unknown_policy"]` → False.
+
+Rename or repurpose `test_run_sync_tasks_respects_current_run_only_policy` in each platform checkpoint file:
+
+- set `dedupe_policy: []` (or omit `prior_runs_same_dataset`) instead of `["current_run"]`.
+- assert ids from another dataset's prior run are **not** skipped, but within-run dedupe still works.
+
+`test_ingest_yaml_keys.py`:
+
+- `ALLOWED_DEDUPE_POLICY_TOKENS = frozenset({PRIOR_RUN_POLICY})`.
+- extend validation to walk `dedupe_policy_by_record_type` values.
+- add assertion that committed YAML does not use `comments_dedupe_policy` / `posts_dedupe_policy` (migrate to canonical keys).
+
+Follow `.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md`.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_ingest_yaml_keys.py tests/data_platform/utils/test_deduplication.py tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py tests/data_platform/ingestion/test_sync_twitter_checkpoint.py tests/data_platform/ingestion/test_sync_reddit_checkpoint.py -q
+```
+
+Exit 0.
+
+## Must still pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
+```
+
+Exit 0. No new failures.
+
+## Must not happen
+
+- Treating `current_run` as a YAML switch (no branch on that token).
+- Removing within-run dedupe (`warm` must still call `load_seen_ids` every time).
+- Breaking alias support for `comments_dedupe_policy` / `posts_dedupe_policy` in this PR.
+- Changing skip-counter metadata field names (step 9).
+- Editing `experiments/data_ingestion_smoke_2026_08_28/smoke.yaml` in this PR.

--- a/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step9.md
+++ b/docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/steps/step9.md
@@ -1,0 +1,138 @@
+# Step 9: Unify duplicate-skip counters in ingest run metadata
+
+## Goal
+
+Each platform writes a different metadata key after `append_deduped_records` (`posts_skipped_as_duplicates`, `comments_skipped_as_duplicates`, `tweets_skipped_as_duplicates`). Operators and tooling should read one run-level total plus an optional per-record-type breakdown.
+
+## Caller / unit of work
+
+**Main callers:** post-append metadata updates in `sync_bluesky.py`, `sync_twitter.py`, and `sync_reddit.py` (`_append_task_records` / `_append_fetched_records`).
+
+**Slice:** replace per-platform skip counter writes with shared helpers → same dedupe behavior, new metadata shape.
+
+**Out of scope:** YAML operator keys, dedupe policy (step 8), `metadata.json` backfill for completed runs, preprocess/features/curate.
+
+## Decision (locked)
+
+- Canonical run-level key: `rows_skipped_as_duplicates` (`int`).
+- Optional breakdown: `skipped_as_duplicates_by_record_type: dict[str, int]` with keys `app.bsky.feed.post`, `twitter.tweet`, `reddit.post`, `reddit.comment` as applicable to the sync.
+- Stop writing `posts_skipped_as_duplicates`, `comments_skipped_as_duplicates`, and `tweets_skipped_as_duplicates` on new metadata flushes. Do not migrate old `metadata.json` files on disk.
+- **Resume:** on the first increment in a resumed run, if canonical keys are missing, seed them from legacy keys, then only increment canonical keys for the remainder of the run:
+  - Bluesky: `posts_skipped_as_duplicates` → `app.bsky.feed.post` (and run total).
+  - Twitter: `tweets_skipped_as_duplicates` → `twitter.tweet`.
+  - Reddit: `posts_skipped_as_duplicates` → `reddit.post`; `comments_skipped_as_duplicates` → `reddit.comment`; run total = sum of present legacy keys.
+- Independently shippable. No YAML changes.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/plan.md` | Parent plan step 9 |
+| `data_platform/ingestion/sync_bluesky.py` | `metadata["posts_skipped_as_duplicates"]` after `append_deduped_records` (~287) |
+| `data_platform/ingestion/sync_twitter.py` | `metadata["tweets_skipped_as_duplicates"]` (~156) |
+| `data_platform/ingestion/sync_reddit.py` | `posts_skipped_as_duplicates` / `comments_skipped_as_duplicates` in `_append_fetched_records` (~433–446) |
+| `data_platform/ingestion/sync_checkpoint.py` | Shared helper home (`RECORD_TYPE_FILENAMES`, metadata flush helpers) |
+| `tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py` | Asserts `posts_skipped_as_duplicates` (incl. resume dedupe ~392) |
+| `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py` | Asserts `tweets_skipped_as_duplicates` |
+| `tests/data_platform/ingestion/test_sync_reddit_checkpoint.py` | Asserts `comments_skipped_as_duplicates` |
+
+## Files allowed to change
+
+- `data_platform/ingestion/sync_checkpoint.py`
+- `data_platform/ingestion/sync_bluesky.py`
+- `data_platform/ingestion/sync_twitter.py`
+- `data_platform/ingestion/sync_reddit.py`
+- `tests/data_platform/ingestion/test_sync_checkpoint.py` (helper unit tests)
+- `tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py`
+- `tests/data_platform/ingestion/test_sync_twitter_checkpoint.py`
+- `tests/data_platform/ingestion/test_sync_reddit_checkpoint.py`
+- `CHANGELOG.md` (after the PR exists, via write-changelog)
+
+## Files forbidden to change
+
+- All YAML under `data_platform/ingestion/configs/`
+- `data_platform/utils/storage.py` (dedupe logic unchanged)
+- Preprocess, features, curate, stimuli
+- `experiments/` smoke artifacts and notes
+
+## Contracts
+
+```text
+ROWS_SKIPPED_AS_DUPLICATES_KEY = "rows_skipped_as_duplicates"
+SKIPPED_BY_RECORD_TYPE_KEY = "skipped_as_duplicates_by_record_type"
+
+def bootstrap_duplicate_skip_counters(
+    metadata: dict[str, Any],
+    *,
+    legacy_by_record_type: dict[str, str],
+) -> None
+  For each (record_type, legacy_key) in legacy_by_record_type:
+    if legacy_key in metadata and record_type not in breakdown:
+      add int(metadata[legacy_key]) to per-type breakdown seed.
+  If ROWS_SKIPPED_AS_DUPLICATES_KEY missing:
+    set it to sum of seeded breakdown values (or 0 if no legacy keys present).
+  If SKIPPED_BY_RECORD_TYPE_KEY missing:
+    set it to the seeded breakdown dict (may be {}).
+  Idempotent: no-op when both canonical keys already exist.
+  Does not delete or rewrite legacy keys (read-only for resume).
+
+def increment_duplicate_skip_counters(
+    metadata: dict[str, Any],
+    *,
+    record_type: str,
+    skipped: int,
+    legacy_by_record_type: dict[str, str],
+) -> None
+  Call bootstrap_duplicate_skip_counters first.
+  metadata[ROWS_SKIPPED_AS_DUPLICATES_KEY] += skipped
+  metadata[SKIPPED_BY_RECORD_TYPE_KEY][record_type] += skipped
+  Never write legacy_by_record_type values back to metadata.
+```
+
+Platform wiring:
+
+- Bluesky: `record_type=POSTS_RECORD_TYPE` (`app.bsky.feed.post`), `legacy_by_record_type={"app.bsky.feed.post": "posts_skipped_as_duplicates"}`.
+- Twitter: `record_type="twitter.tweet"`, `legacy_by_record_type={"twitter.tweet": "tweets_skipped_as_duplicates"}`.
+- Reddit `_append_fetched_records`: one increment per append path — posts use `reddit.post` / `posts_skipped_as_duplicates`; comments use `reddit.comment` / `comments_skipped_as_duplicates`. Pass the full Reddit legacy map on each call so bootstrap can seed both types when resuming.
+
+## Tests (write first)
+
+`TestDuplicateSkipCounters` in `tests/data_platform/ingestion/test_sync_checkpoint.py`:
+
+- given empty metadata, when `increment_duplicate_skip_counters(..., skipped=2)`, then `rows_skipped_as_duplicates == 2` and breakdown matches.
+- given metadata with only `posts_skipped_as_duplicates: 3`, when bootstrap then increment `skipped=1` for `app.bsky.feed.post`, then run total `4` and breakdown `app.bsky.feed.post: 4`.
+- given metadata with `rows_skipped_as_duplicates` already set, when bootstrap runs, then legacy keys are not copied again (idempotent).
+- given Reddit legacy `posts_skipped_as_duplicates: 2` and `comments_skipped_as_duplicates: 5`, when bootstrap with both legacy mappings, then run total `7` and both breakdown keys seeded.
+
+Update platform checkpoint tests to assert canonical keys instead of legacy names:
+
+- Bluesky dedupe and resume tests: `rows_skipped_as_duplicates` and `skipped_as_duplicates_by_record_type["app.bsky.feed.post"]`; assert legacy key absent after sync.
+- Twitter: same for `twitter.tweet`.
+- Reddit comment-dedupe test: `reddit.comment` breakdown; zero-skip paths still assert run total `0`.
+
+Add one resume test (Bluesky or Reddit): pre-write `metadata.json` with a legacy skip counter only, resume sync, expect canonical total = legacy + new skips.
+
+Follow `.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md`.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_sync_checkpoint.py tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py tests/data_platform/ingestion/test_sync_twitter_checkpoint.py tests/data_platform/ingestion/test_sync_reddit_checkpoint.py -q
+```
+
+Exit 0.
+
+## Must still pass
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
+```
+
+Exit 0. No new failures.
+
+## Must not happen
+
+- Writing `posts_skipped_as_duplicates`, `comments_skipped_as_duplicates`, or `tweets_skipped_as_duplicates` on new sync flushes.
+- Batch-rewriting existing run `metadata.json` on disk.
+- Changing YAML configs or dedupe/session behavior.
+- Changing `row_count` / `post_row_count` semantics.


### PR DESCRIPTION
## Summary
- Adds the plan package at `docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/` (plan + 14 independently mergeable steps). Plan and docs only; no product code.
- Tracks epic [#102](https://github.com/METResearchGroup/mirrorView-task/issues/102). Children: #103–#116 (one issue per step/PR).
- Implementation is `/implement-plan-and-open-pr` on one child at a time, in plan order to reduce merge conflicts. No GitHub `blocked-by`.

## Test plan
- [ ] Confirm the PR contains only `docs/plans/2026-09-02_unify_ingest_contracts_2aeaf9/`
- [ ] Confirm [#102](https://github.com/METResearchGroup/mirrorView-task/issues/102) lists children #103–#116
- [ ] Skim `plan.md` happy flow and step list against the child issue titles


Made with [Cursor](https://cursor.com)