### PR TITLE
Drop leftover copy_flat_features docs after PR #93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-02
 
-1. Feature generation writes each run under `features/{timestamp}/`, which matches how the other pipeline stages store runs. Each run records prompt and model identity in metadata, and posts that already have labels are still skipped. Copy leftover flat `features/*.csv` files into a timestamp folder with `copy_flat_features.py`. [PR #93](https://github.com/METResearchGroup/mirrorView-task/pull/93)
+1. Feature generation writes each run under `features/{timestamp}/`, which matches how the other pipeline stages store runs. Each run records prompt and model identity in metadata, and posts that already have labels are still skipped. [PR #93](https://github.com/METResearchGroup/mirrorView-task/pull/93)
 2. Ingest YAML uses `prior_runs_same_dataset` to skip ids from earlier local runs of the same dataset. We removed `query_batch_size` and `dedupe_comments_from_prior_raw_runs`. [PR #87](https://github.com/METResearchGroup/mirrorView-task/pull/87)
 3. Ingest now writes ISO `created_at` and the run `sync_timestamp` on Bluesky, Reddit, and Twitter rows, so later stages can read those two fields. Reddit still also writes `created_utc` as the same ISO string. Current timestamps in `data_platform` use UTC `get_current_timestamp`. [PR #88](https://github.com/METResearchGroup/mirrorView-task/pull/88)
 4. The preprocess step adds a shared `text` column on Bluesky, Twitter, and Reddit comment rows that pass the filters. Reddit feature code now reads that column, and the original `body` field is still on the record so you can check it. [PR #91](https://github.com/METResearchGroup/mirrorView-task/pull/91)

--- a/data_platform/README.md
+++ b/data_platform/README.md
@@ -70,12 +70,7 @@ PYTHONPATH=. uv run python data_platform/curate/curate_bluesky.py \
 
 Same pattern for Twitter and Reddit (`preprocess_twitter.py` / `generate_twitter_features.py` / `curate_twitter.py`, and the Reddit equivalents). Feature generation writes each run into `features/<timestamp>/`. Pass `--run-dir <timestamp>` to keep writing into that folder after an interrupt.
 
-If a dataset still has leftover files directly under `features/` from the old layout, copy them into a timestamp folder once:
-
-```bash
-PYTHONPATH=. uv run python data_platform/generate_features/copy_flat_features.py \
-  --platform bluesky --dataset-id bluesky_<uuid>
-```
+If a dataset still has leftover files directly under `features/` from the old layout, move them into a new `features/<timestamp>/` folder and delete the leftover files at the features root.
 
 ## Curate (join + business rules)
 

--- a/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
+++ b/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
@@ -65,7 +65,7 @@ data_platform/data/
 
 Raw, preprocessed, features, and curated stages use timestamped run directories. The timestamp format comes from `lib.timestamp_utils.get_current_timestamp` (for example `2026_08_16-14:30:00`).
 
-Each new run of `generate_*_features.py` writes a new folder named `features/<timestamp>/`. Pass `--run-dir <timestamp>` to keep writing into that folder after an interrupt. When the script decides which posts still need labels, it reads labels from every feature folder, so a post that already has a label is not labeled again. For each feature, `metadata.json` records `model_id` and `prompt_hash`, so you can see when the model or the prompt changed. When the same post id appears in more than one feature folder, the curate step keeps the row with the latest `label_timestamp`. Leftover files from the old flat layout stay unused until you copy them with `data_platform/generate_features/copy_flat_features.py`.
+Each new run of `generate_*_features.py` writes a new folder named `features/<timestamp>/`. Pass `--run-dir <timestamp>` to keep writing into that folder after an interrupt. When the script decides which posts still need labels, it reads labels from every feature folder, so a post that already has a label is not labeled again. For each feature, `metadata.json` records `model_id` and `prompt_hash`, so you can see when the model or the prompt changed. When the same post id appears in more than one feature folder, the curate step keeps the row with the latest `label_timestamp`. Leftover files from the old flat layout stay unused until you move them into a `features/<timestamp>/` folder and delete the leftovers at the features root.
 
 Do not commit files under `data_platform/data/`.
 

--- a/docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md
+++ b/docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md
@@ -53,14 +53,7 @@ PYTHONPATH=. uv run python data_platform/curate/curate_bluesky.py \
 
 Feature generation writes each run into a new folder named `features/<timestamp>/`. If a run stops partway through, pass `--run-dir <timestamp>` so the same folder is reused. Feature generation still skips a post that already has a label, including labels written in earlier feature folders. When the same post appears in more than one feature folder, the curate step keeps the row with the latest `label_timestamp`.
 
-If this dataset still has leftover files directly under `features/` from the old layout (`is_political.csv`, `metadata.json`, `deadletter.jsonl`), copy them into a timestamp folder once:
-
-```bash
-PYTHONPATH=. uv run python data_platform/generate_features/copy_flat_features.py \
-  --platform bluesky --dataset-id bluesky_<uuid>
-```
-
-The originals stay in place. Skip and curate read only timestamped folders, so those leftover files are unused until you copy them.
+If this dataset still has leftover files directly under `features/` from the old layout (`is_political.csv`, `metadata.json`, `deadletter.jsonl`), move them into a new `features/<timestamp>/` folder and delete the leftover files at the features root.
 
 The smoke config uses `dataset_id: bluesky_c0ffee00-0000-4000-8000-000000000100`. Curation is the last stage. Files stay under `data_platform/data/`.
 

--- a/tests/data_platform/generate_features/test_platform_cli.py
+++ b/tests/data_platform/generate_features/test_platform_cli.py
@@ -56,7 +56,7 @@ def test_build_feature_config_uses_timestamped_features_dir(data_root) -> None:
     config = build_feature_config(
         BLUESKY_SPEC,
         FEATURES_DATASET_ID,
-        run_config=FeatureRunConfig(opik_enabled=False),
+        run_config=FeatureRunConfig(),
     )
 
     assert config.features_dir.parent.name == "features"
@@ -69,7 +69,7 @@ def test_build_feature_config_resumes_named_run_dir(data_root) -> None:
     config = build_feature_config(
         BLUESKY_SPEC,
         FEATURES_DATASET_ID,
-        run_config=FeatureRunConfig(opik_enabled=False),
+        run_config=FeatureRunConfig(),
         run_dir_name=PREPROCESSED_RUN_DIR,
     )
 
@@ -91,7 +91,7 @@ def test_feature_run_dir_rejects_path_escape(data_root: Path) -> None:
 
 def test_empty_twitter_input_does_not_create_feature_run(data_root: Path) -> None:
     """Given no preprocessed posts, when generating features, then no features run dir is created."""
-    result = generate_twitter_features(VALID_TWITTER_DATASET_ID, opik_enabled=False)
+    result = generate_twitter_features(VALID_TWITTER_DATASET_ID)
 
     assert result == {}
     features_root = data_root / "twitter" / VALID_TWITTER_DATASET_ID / "features"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #93 already removed `copy_flat_features.py`. This follow-up drops the remaining docs that still named that script, and it removes `opik_enabled` from platform CLI tests so they match the Opik-free `FeatureRunConfig`.

If a dataset still has leftover files at the features root, move them into `features/<timestamp>/` by hand and delete the leftovers.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d98849e-9002-4d85-87cc-b6b857b4814a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d98849e-9002-4d85-87cc-b6b857b4814a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated test coverage to validate feature generation using the default configuration and standard behavior.
  * Improved alignment between test scenarios and the application’s default feature-generation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->