### PR TITLE
Generate `{integration}_{id}` record IDs during ingest writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2026-09-03
+
+1. Raw ingest now writes a stable `record_id` on every row using the same `{integration}_{id}` keys as study stimuli (`bluesky_{sha256(uri)}`, `twitter_{tweet_id}`, `reddit_{comment_fullname}`). [PR #138](https://github.com/METResearchGroup/mirrorView-task/pull/138)
+
 ## 2026-09-02
 
 1. Preprocess now owns length and English gates for stimuli-ready text. Reddit comments also need at least 30 characters. Ingest fetch filters are unchanged. [PR #132](https://github.com/METResearchGroup/mirrorView-task/pull/132)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-03
 
-1. Raw ingest now writes a stable `record_id` on every row using the same `{integration}_{id}` keys as study stimuli (`bluesky_{sha256(uri)}`, `twitter_{tweet_id}`, `reddit_{comment_fullname}`). [PR #138](https://github.com/METResearchGroup/mirrorView-task/pull/138)
+1. Raw ingest now writes a stable `record_id` on every row using the same `{integration}_{id}` keys as study stimuli (`bluesky_{sha256(uri)}`, `twitter_{tweet_id}`, `reddit_{post_reddit_id}_{comment_id}`). [PR #138](https://github.com/METResearchGroup/mirrorView-task/pull/138)
 
 ## 2026-09-02
 

--- a/data_platform/ingestion/generate_record_id.py
+++ b/data_platform/ingestion/generate_record_id.py
@@ -91,4 +91,17 @@ def attach_record_id(row: Mapping[str, Any], integration: str) -> dict[str, Any]
     ValueError
         When ``integration`` is unknown or the primary key value is empty.
     """
-    raise NotImplementedError
+    normalized_integration = integration.strip().lower()
+    primary_key_column = _INTEGRATION_PRIMARY_KEY_COLUMNS.get(normalized_integration)
+    if primary_key_column is None:
+        raise ValueError(f"Unknown integration `{integration}`.")
+
+    if primary_key_column not in row:
+        raise KeyError(primary_key_column)
+
+    out = dict(row)
+    out[RECORD_ID_COLUMN] = generate_record_id(
+        normalized_integration,
+        str(row[primary_key_column]),
+    )
+    return out

--- a/data_platform/ingestion/generate_record_id.py
+++ b/data_platform/ingestion/generate_record_id.py
@@ -19,6 +19,9 @@ from data_platform.utils.platform_specific_columns import (
 
 RECORD_ID_COLUMN = "record_id"
 REDDIT_POST_RECORDS_ID_COLUMN = "reddit_fullname"
+REDDIT_COMMENT_POST_ID_COLUMN = "post_reddit_id"
+REDDIT_COMMENT_ID_COLUMN = "comment_id"
+REDDIT_COMMENTS_FILE_STEM = "comments"
 
 INTEGRATION_BLUESKY = "bluesky"
 INTEGRATION_REDDIT = "reddit"
@@ -75,7 +78,8 @@ def generate_record_id(integration: str, primary_key: str) -> str:
         Platform name: ``bluesky``, ``reddit``, or ``twitter``.
     primary_key
         Platform-native unique id for the row (for example Bluesky ``uri``,
-        Reddit ``comment_fullname``, or Twitter ``tweet_id``).
+        Reddit ``{post_reddit_id}_{comment_id}`` for comments or
+        ``reddit_fullname`` for posts, or Twitter ``tweet_id``).
 
     Returns
     -------
@@ -102,10 +106,68 @@ def generate_record_id(integration: str, primary_key: str) -> str:
     return f"{normalized_integration}_{normalized_primary_key}"
 
 
+def resolve_primary_key_value(
+    row: Mapping[str, Any],
+    integration: str,
+    *,
+    records_file_stem: str | None = None,
+    primary_key_column: str | None = None,
+) -> str:
+    """Return the string that feeds :func:`generate_record_id` for one ingest row.
+
+    Parameters
+    ----------
+    row
+        One ingest record dict.
+    integration
+        Platform name: ``bluesky``, ``reddit``, or ``twitter``.
+    records_file_stem
+        Records filename stem, for example ``posts`` or ``comments``.
+    primary_key_column
+        Optional override for the source column on non-composite rows.
+
+    Returns
+    -------
+    str
+        Primary key value before the integration prefix is applied.
+
+    Raises
+    ------
+    KeyError
+        When a required source column is missing from ``row``.
+    ValueError
+        When ``integration`` is unknown or a required value is empty.
+    """
+    normalized_integration = integration.strip().lower()
+    if (
+        normalized_integration == INTEGRATION_REDDIT
+        and records_file_stem == REDDIT_COMMENTS_FILE_STEM
+    ):
+        post_id = str(row[REDDIT_COMMENT_POST_ID_COLUMN]).strip()
+        comment_id = str(row[REDDIT_COMMENT_ID_COLUMN]).strip()
+        if not post_id or not comment_id:
+            raise ValueError("Reddit comments need post_reddit_id and comment_id.")
+        return f"{post_id}_{comment_id}"
+
+    resolved_stem = records_file_stem or REDDIT_COMMENTS_FILE_STEM
+    resolved_column = primary_key_column or resolve_records_id_column(
+        integration,
+        resolved_stem,
+    )
+    if resolved_column not in row:
+        raise KeyError(resolved_column)
+
+    primary_key = str(row[resolved_column]).strip()
+    if not primary_key:
+        raise ValueError("Primary key must be a non-empty string.")
+    return primary_key
+
+
 def attach_record_id(
     row: Mapping[str, Any],
     integration: str,
     *,
+    records_file_stem: str | None = None,
     primary_key_column: str | None = None,
 ) -> dict[str, Any]:
     """Return a copy of ``row`` with ``record_id`` set from the platform primary key.
@@ -116,9 +178,10 @@ def attach_record_id(
         One ingest record dict. Must include the platform primary key column.
     integration
         Platform name passed to :func:`generate_record_id`.
+    records_file_stem
+        Records filename stem when one integration writes multiple record types.
     primary_key_column
-        Optional override when one integration writes multiple record types.
-        Defaults to the platform's usual ingest id column.
+        Optional override for the source column on non-composite rows.
 
     Returns
     -------
@@ -133,18 +196,19 @@ def attach_record_id(
         When ``integration`` is unknown or the primary key value is empty.
     """
     normalized_integration = integration.strip().lower()
-    resolved_column = primary_key_column or _INTEGRATION_PRIMARY_KEY_COLUMNS.get(
-        normalized_integration
-    )
-    if resolved_column is None:
+    if normalized_integration not in _INTEGRATION_PRIMARY_KEY_COLUMNS:
         raise ValueError(f"Unknown integration `{integration}`.")
 
-    if resolved_column not in row:
-        raise KeyError(resolved_column)
+    primary_key_value = resolve_primary_key_value(
+        row,
+        integration,
+        records_file_stem=records_file_stem,
+        primary_key_column=primary_key_column,
+    )
 
     out = dict(row)
     out[RECORD_ID_COLUMN] = generate_record_id(
         normalized_integration,
-        str(row[resolved_column]),
+        primary_key_value,
     )
     return out

--- a/data_platform/ingestion/generate_record_id.py
+++ b/data_platform/ingestion/generate_record_id.py
@@ -18,6 +18,7 @@ from data_platform.utils.platform_specific_columns import (
 )
 
 RECORD_ID_COLUMN = "record_id"
+REDDIT_POST_RECORDS_ID_COLUMN = "reddit_fullname"
 
 INTEGRATION_BLUESKY = "bluesky"
 INTEGRATION_REDDIT = "reddit"
@@ -28,6 +29,38 @@ _INTEGRATION_PRIMARY_KEY_COLUMNS: dict[str, str] = {
     INTEGRATION_REDDIT: REDDIT_COLUMNS.records_id_column,
     INTEGRATION_TWITTER: TWITTER_COLUMNS.records_id_column,
 }
+
+
+def resolve_records_id_column(platform: str, records_file_stem: str) -> str:
+    """Return the platform primary-key column for one ingest records file.
+
+    Parameters
+    ----------
+    platform
+        Platform name: ``bluesky``, ``reddit``, or ``twitter``.
+    records_file_stem
+        Records filename stem, for example ``posts`` or ``comments``.
+
+    Returns
+    -------
+    str
+        Column name whose value feeds :func:`generate_record_id`.
+
+    Raises
+    ------
+    ValueError
+        When ``platform`` is unknown.
+    """
+    normalized_platform = platform.strip().lower()
+    if normalized_platform == INTEGRATION_BLUESKY:
+        return BLUESKY_COLUMNS.records_id_column
+    if normalized_platform == INTEGRATION_TWITTER:
+        return TWITTER_COLUMNS.records_id_column
+    if normalized_platform == INTEGRATION_REDDIT:
+        if records_file_stem == "posts":
+            return REDDIT_POST_RECORDS_ID_COLUMN
+        return REDDIT_COLUMNS.records_id_column
+    raise ValueError(f"Unknown platform `{platform}`.")
 
 
 def generate_record_id(integration: str, primary_key: str) -> str:
@@ -69,7 +102,12 @@ def generate_record_id(integration: str, primary_key: str) -> str:
     return f"{normalized_integration}_{normalized_primary_key}"
 
 
-def attach_record_id(row: Mapping[str, Any], integration: str) -> dict[str, Any]:
+def attach_record_id(
+    row: Mapping[str, Any],
+    integration: str,
+    *,
+    primary_key_column: str | None = None,
+) -> dict[str, Any]:
     """Return a copy of ``row`` with ``record_id`` set from the platform primary key.
 
     Parameters
@@ -78,6 +116,9 @@ def attach_record_id(row: Mapping[str, Any], integration: str) -> dict[str, Any]
         One ingest record dict. Must include the platform primary key column.
     integration
         Platform name passed to :func:`generate_record_id`.
+    primary_key_column
+        Optional override when one integration writes multiple record types.
+        Defaults to the platform's usual ingest id column.
 
     Returns
     -------
@@ -92,16 +133,18 @@ def attach_record_id(row: Mapping[str, Any], integration: str) -> dict[str, Any]
         When ``integration`` is unknown or the primary key value is empty.
     """
     normalized_integration = integration.strip().lower()
-    primary_key_column = _INTEGRATION_PRIMARY_KEY_COLUMNS.get(normalized_integration)
-    if primary_key_column is None:
+    resolved_column = primary_key_column or _INTEGRATION_PRIMARY_KEY_COLUMNS.get(
+        normalized_integration
+    )
+    if resolved_column is None:
         raise ValueError(f"Unknown integration `{integration}`.")
 
-    if primary_key_column not in row:
-        raise KeyError(primary_key_column)
+    if resolved_column not in row:
+        raise KeyError(resolved_column)
 
     out = dict(row)
     out[RECORD_ID_COLUMN] = generate_record_id(
         normalized_integration,
-        str(row[primary_key_column]),
+        str(row[resolved_column]),
     )
     return out

--- a/data_platform/ingestion/generate_record_id.py
+++ b/data_platform/ingestion/generate_record_id.py
@@ -8,7 +8,14 @@ Run this import from the repo root with
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any, Mapping
+
+from data_platform.utils.platform_specific_columns import (
+    BLUESKY_COLUMNS,
+    REDDIT_COLUMNS,
+    TWITTER_COLUMNS,
+)
 
 RECORD_ID_COLUMN = "record_id"
 
@@ -16,10 +23,60 @@ INTEGRATION_BLUESKY = "bluesky"
 INTEGRATION_REDDIT = "reddit"
 INTEGRATION_TWITTER = "twitter"
 
+_INTEGRATION_PRIMARY_KEY_COLUMNS: dict[str, str] = {
+    INTEGRATION_BLUESKY: BLUESKY_COLUMNS.records_id_column,
+    INTEGRATION_REDDIT: REDDIT_COLUMNS.records_id_column,
+    INTEGRATION_TWITTER: TWITTER_COLUMNS.records_id_column,
+}
+
 
 def generate_record_id(integration: str, primary_key: str) -> str:
+    """Return the stable ``{integration}_{id}`` key used across study datasets.
+
+    Bluesky hashes ``uri`` with SHA-256. Twitter and Reddit use the platform
+    primary key string unchanged.
+
+    Parameters
+    ----------
+    integration
+        Platform name: ``bluesky``, ``reddit``, or ``twitter``.
+    primary_key
+        Platform-native unique id for the row (for example Bluesky ``uri``,
+        Reddit ``comment_fullname``, or Twitter ``tweet_id``).
+
+    Returns
+    -------
+    str
+        Stable record id with the integration prefix.
+
+    Raises
+    ------
+    ValueError
+        When ``integration`` is unknown or ``primary_key`` is empty.
+    """
     raise NotImplementedError
 
 
 def attach_record_id(row: Mapping[str, Any], integration: str) -> dict[str, Any]:
+    """Return a copy of ``row`` with ``record_id`` set from the platform primary key.
+
+    Parameters
+    ----------
+    row
+        One ingest record dict. Must include the platform primary key column.
+    integration
+        Platform name passed to :func:`generate_record_id`.
+
+    Returns
+    -------
+    dict[str, Any]
+        A new dict equal to ``row`` plus ``record_id``.
+
+    Raises
+    ------
+    KeyError
+        When the platform primary key column is missing from ``row``.
+    ValueError
+        When ``integration`` is unknown or the primary key value is empty.
+    """
     raise NotImplementedError

--- a/data_platform/ingestion/generate_record_id.py
+++ b/data_platform/ingestion/generate_record_id.py
@@ -1,0 +1,25 @@
+"""Build stable ``{integration}_{id}`` record ids for ingest writes.
+
+Run this import from the repo root with
+
+    PYTHONPATH=. uv run python -c \\
+        "from data_platform.ingestion.generate_record_id import generate_record_id"
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+RECORD_ID_COLUMN = "record_id"
+
+INTEGRATION_BLUESKY = "bluesky"
+INTEGRATION_REDDIT = "reddit"
+INTEGRATION_TWITTER = "twitter"
+
+
+def generate_record_id(integration: str, primary_key: str) -> str:
+    raise NotImplementedError
+
+
+def attach_record_id(row: Mapping[str, Any], integration: str) -> dict[str, Any]:
+    raise NotImplementedError

--- a/data_platform/ingestion/generate_record_id.py
+++ b/data_platform/ingestion/generate_record_id.py
@@ -54,7 +54,19 @@ def generate_record_id(integration: str, primary_key: str) -> str:
     ValueError
         When ``integration`` is unknown or ``primary_key`` is empty.
     """
-    raise NotImplementedError
+    normalized_integration = integration.strip().lower()
+    if normalized_integration not in _INTEGRATION_PRIMARY_KEY_COLUMNS:
+        raise ValueError(f"Unknown integration `{integration}`.")
+
+    normalized_primary_key = str(primary_key).strip()
+    if not normalized_primary_key:
+        raise ValueError("Primary key must be a non-empty string.")
+
+    if normalized_integration == INTEGRATION_BLUESKY:
+        digest = hashlib.sha256(normalized_primary_key.encode("utf-8")).hexdigest()
+        return f"{INTEGRATION_BLUESKY}_{digest}"
+
+    return f"{normalized_integration}_{normalized_primary_key}"
 
 
 def attach_record_id(row: Mapping[str, Any], integration: str) -> dict[str, Any]:

--- a/data_platform/ingestion/generate_record_id.py
+++ b/data_platform/ingestion/generate_record_id.py
@@ -13,7 +13,6 @@ from typing import Any, Mapping
 
 from data_platform.utils.platform_specific_columns import (
     BLUESKY_COLUMNS,
-    REDDIT_COLUMNS,
     TWITTER_COLUMNS,
 )
 
@@ -21,55 +20,25 @@ RECORD_ID_COLUMN = "record_id"
 REDDIT_POST_RECORDS_ID_COLUMN = "reddit_fullname"
 REDDIT_COMMENT_POST_ID_COLUMN = "post_reddit_id"
 REDDIT_COMMENT_ID_COLUMN = "comment_id"
-REDDIT_COMMENTS_FILE_STEM = "comments"
 
 INTEGRATION_BLUESKY = "bluesky"
 INTEGRATION_REDDIT = "reddit"
 INTEGRATION_TWITTER = "twitter"
 
+KNOWN_INTEGRATIONS = frozenset(
+    {INTEGRATION_BLUESKY, INTEGRATION_REDDIT, INTEGRATION_TWITTER}
+)
+
 _INTEGRATION_PRIMARY_KEY_COLUMNS: dict[str, str] = {
     INTEGRATION_BLUESKY: BLUESKY_COLUMNS.records_id_column,
-    INTEGRATION_REDDIT: REDDIT_COLUMNS.records_id_column,
     INTEGRATION_TWITTER: TWITTER_COLUMNS.records_id_column,
 }
-
-
-def resolve_records_id_column(platform: str, records_file_stem: str) -> str:
-    """Return the platform primary-key column for one ingest records file.
-
-    Parameters
-    ----------
-    platform
-        Platform name: ``bluesky``, ``reddit``, or ``twitter``.
-    records_file_stem
-        Records filename stem, for example ``posts`` or ``comments``.
-
-    Returns
-    -------
-    str
-        Column name whose value feeds :func:`generate_record_id`.
-
-    Raises
-    ------
-    ValueError
-        When ``platform`` is unknown.
-    """
-    normalized_platform = platform.strip().lower()
-    if normalized_platform == INTEGRATION_BLUESKY:
-        return BLUESKY_COLUMNS.records_id_column
-    if normalized_platform == INTEGRATION_TWITTER:
-        return TWITTER_COLUMNS.records_id_column
-    if normalized_platform == INTEGRATION_REDDIT:
-        if records_file_stem == "posts":
-            return REDDIT_POST_RECORDS_ID_COLUMN
-        return REDDIT_COLUMNS.records_id_column
-    raise ValueError(f"Unknown platform `{platform}`.")
 
 
 def generate_record_id(integration: str, primary_key: str) -> str:
     """Return the stable ``{integration}_{id}`` key used across study datasets.
 
-    Bluesky hashes ``uri`` with SHA-256. Twitter and Reddit use the platform
+    Bluesky hashes ``uri`` with SHA-256. Twitter and Reddit prefix the given
     primary key string unchanged.
 
     Parameters
@@ -77,9 +46,8 @@ def generate_record_id(integration: str, primary_key: str) -> str:
     integration
         Platform name: ``bluesky``, ``reddit``, or ``twitter``.
     primary_key
-        Platform-native unique id for the row (for example Bluesky ``uri``,
-        Reddit ``{post_reddit_id}_{comment_id}`` for comments or
-        ``reddit_fullname`` for posts, or Twitter ``tweet_id``).
+        Platform-native unique id for the row. For Reddit, pass the already
+        joined post-and-comment key or the post fullname.
 
     Returns
     -------
@@ -92,7 +60,7 @@ def generate_record_id(integration: str, primary_key: str) -> str:
         When ``integration`` is unknown or ``primary_key`` is empty.
     """
     normalized_integration = integration.strip().lower()
-    if normalized_integration not in _INTEGRATION_PRIMARY_KEY_COLUMNS:
+    if normalized_integration not in KNOWN_INTEGRATIONS:
         raise ValueError(f"Unknown integration `{integration}`.")
 
     normalized_primary_key = str(primary_key).strip()
@@ -106,71 +74,51 @@ def generate_record_id(integration: str, primary_key: str) -> str:
     return f"{normalized_integration}_{normalized_primary_key}"
 
 
-def resolve_primary_key_value(
-    row: Mapping[str, Any],
-    integration: str,
-    *,
-    records_file_stem: str | None = None,
-    primary_key_column: str | None = None,
-) -> str:
-    """Return the string that feeds :func:`generate_record_id` for one ingest row.
+def generate_reddit_record_id(row: Mapping[str, Any]) -> str:
+    """Return ``record_id`` for a Reddit post or comment row.
+
+    Comments use ``reddit_{post_reddit_id}_{comment_id}``. Posts use
+    ``reddit_{reddit_fullname}``.
 
     Parameters
     ----------
     row
-        One ingest record dict.
-    integration
-        Platform name: ``bluesky``, ``reddit``, or ``twitter``.
-    records_file_stem
-        Records filename stem, for example ``posts`` or ``comments``.
-    primary_key_column
-        Optional override for the source column on non-composite rows.
+        One Reddit ingest record. Comment rows must include ``post_reddit_id``
+        and ``comment_id``. Post rows must include ``reddit_fullname``.
 
     Returns
     -------
     str
-        Primary key value before the integration prefix is applied.
+        Stable Reddit record id.
 
     Raises
     ------
     KeyError
-        When a required source column is missing from ``row``.
+        When the row is neither a comment nor a post with the expected fields.
     ValueError
-        When ``integration`` is unknown or a required value is empty.
+        When a required id value is empty.
     """
-    normalized_integration = integration.strip().lower()
-    if (
-        normalized_integration == INTEGRATION_REDDIT
-        and records_file_stem == REDDIT_COMMENTS_FILE_STEM
-    ):
+    if REDDIT_COMMENT_POST_ID_COLUMN in row and REDDIT_COMMENT_ID_COLUMN in row:
         post_id = str(row[REDDIT_COMMENT_POST_ID_COLUMN]).strip()
         comment_id = str(row[REDDIT_COMMENT_ID_COLUMN]).strip()
         if not post_id or not comment_id:
             raise ValueError("Reddit comments need post_reddit_id and comment_id.")
-        return f"{post_id}_{comment_id}"
+        return generate_record_id(INTEGRATION_REDDIT, f"{post_id}_{comment_id}")
 
-    resolved_stem = records_file_stem or REDDIT_COMMENTS_FILE_STEM
-    resolved_column = primary_key_column or resolve_records_id_column(
-        integration,
-        resolved_stem,
-    )
-    if resolved_column not in row:
-        raise KeyError(resolved_column)
+    if REDDIT_POST_RECORDS_ID_COLUMN not in row:
+        raise KeyError(REDDIT_POST_RECORDS_ID_COLUMN)
 
-    primary_key = str(row[resolved_column]).strip()
-    if not primary_key:
+    reddit_fullname = str(row[REDDIT_POST_RECORDS_ID_COLUMN]).strip()
+    if not reddit_fullname:
         raise ValueError("Primary key must be a non-empty string.")
-    return primary_key
+    return generate_record_id(INTEGRATION_REDDIT, reddit_fullname)
 
 
-def attach_record_id(
-    row: Mapping[str, Any],
-    integration: str,
-    *,
-    records_file_stem: str | None = None,
-    primary_key_column: str | None = None,
-) -> dict[str, Any]:
+def attach_record_id(row: Mapping[str, Any], integration: str) -> dict[str, Any]:
     """Return a copy of ``row`` with ``record_id`` set from the platform primary key.
+
+    Reddit rows go through :func:`generate_reddit_record_id`. Bluesky and Twitter
+    rows use the usual platform id column.
 
     Parameters
     ----------
@@ -178,10 +126,6 @@ def attach_record_id(
         One ingest record dict. Must include the platform primary key column.
     integration
         Platform name passed to :func:`generate_record_id`.
-    records_file_stem
-        Records filename stem when one integration writes multiple record types.
-    primary_key_column
-        Optional override for the source column on non-composite rows.
 
     Returns
     -------
@@ -196,19 +140,20 @@ def attach_record_id(
         When ``integration`` is unknown or the primary key value is empty.
     """
     normalized_integration = integration.strip().lower()
-    if normalized_integration not in _INTEGRATION_PRIMARY_KEY_COLUMNS:
+    if normalized_integration not in KNOWN_INTEGRATIONS:
         raise ValueError(f"Unknown integration `{integration}`.")
 
-    primary_key_value = resolve_primary_key_value(
-        row,
-        integration,
-        records_file_stem=records_file_stem,
-        primary_key_column=primary_key_column,
-    )
+    if normalized_integration == INTEGRATION_REDDIT:
+        record_id = generate_reddit_record_id(row)
+    else:
+        primary_key_column = _INTEGRATION_PRIMARY_KEY_COLUMNS[normalized_integration]
+        if primary_key_column not in row:
+            raise KeyError(primary_key_column)
+        record_id = generate_record_id(
+            normalized_integration,
+            str(row[primary_key_column]),
+        )
 
     out = dict(row)
-    out[RECORD_ID_COLUMN] = generate_record_id(
-        normalized_integration,
-        primary_key_value,
-    )
+    out[RECORD_ID_COLUMN] = record_id
     return out

--- a/data_platform/models/sync.py
+++ b/data_platform/models/sync.py
@@ -7,6 +7,7 @@ class SyncBlueskyPostModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     uri: str
+    record_id: str
     url: str
     author_handle: str
     text: str
@@ -23,6 +24,7 @@ class SyncRedditPostModel(BaseModel):
 
     reddit_id: str
     reddit_fullname: str
+    record_id: str
     subreddit: str
     title: str
     selftext: str
@@ -41,6 +43,7 @@ class SyncTwitterPostModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     tweet_id: str
+    record_id: str
     text: str
     author_id: str
     username: str
@@ -62,6 +65,7 @@ class SyncRedditCommentModel(BaseModel):
     subreddit: str
     comment_id: str
     comment_fullname: str
+    record_id: str
     parent_id: str
     author: str
     body: str

--- a/data_platform/utils/platform_specific_columns.py
+++ b/data_platform/utils/platform_specific_columns.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 CANONICAL_TEXT_COLUMN = "text"
 CANONICAL_AUTHOR_HANDLE_COLUMN = "author_handle"
 CANONICAL_SOURCE_RECORD_ID_COLUMN = "source_record_id"
+CANONICAL_RECORD_ID_COLUMN = "record_id"
 REDDIT_ORIGINAL_PLATFORM_TEXT_COLUMN = "body"
 
 

--- a/data_platform/utils/storage.py
+++ b/data_platform/utils/storage.py
@@ -13,7 +13,6 @@ from pydantic import BaseModel
 from data_platform.ingestion.generate_record_id import (
     RECORD_ID_COLUMN,
     attach_record_id,
-    resolve_records_id_column,
 )
 from data_platform.models.sync import (
     PreprocessedBlueskyPostModel,
@@ -96,8 +95,6 @@ class StorageManager:
         self.format: ValidDataFormats = load_dataset_format(platform, dataset_id)
         stem = Path(records_filename).stem
         self.records_filename = f"{stem}.{self.format.value}"
-        self.records_file_stem = stem
-        self.records_id_column = resolve_records_id_column(platform, stem)
 
     @property
     def platform_data_root(self) -> Path:
@@ -162,14 +159,7 @@ class StorageManager:
             if row.get(RECORD_ID_COLUMN):
                 prepared.append(row)
             else:
-                prepared.append(
-                    attach_record_id(
-                        row,
-                        self.platform,
-                        records_file_stem=self.records_file_stem,
-                        primary_key_column=self.records_id_column,
-                    )
-                )
+                prepared.append(attach_record_id(row, self.platform))
         return prepared
 
     def write_records(

--- a/data_platform/utils/storage.py
+++ b/data_platform/utils/storage.py
@@ -10,6 +10,11 @@ from typing import Any
 import pandas as pd
 from pydantic import BaseModel
 
+from data_platform.ingestion.generate_record_id import (
+    RECORD_ID_COLUMN,
+    attach_record_id,
+    resolve_records_id_column,
+)
 from data_platform.models.sync import (
     PreprocessedBlueskyPostModel,
     PreprocessedRedditCommentModel,
@@ -91,6 +96,7 @@ class StorageManager:
         self.format: ValidDataFormats = load_dataset_format(platform, dataset_id)
         stem = Path(records_filename).stem
         self.records_filename = f"{stem}.{self.format.value}"
+        self.records_id_column = resolve_records_id_column(platform, stem)
 
     @property
     def platform_data_root(self) -> Path:
@@ -149,6 +155,21 @@ class StorageManager:
             return resolved
         raise ValueError("Either run_dir must be provided or latest=True")
 
+    def _prepare_rows_for_write(self, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        prepared: list[dict[str, Any]] = []
+        for row in rows:
+            if row.get(RECORD_ID_COLUMN):
+                prepared.append(row)
+            else:
+                prepared.append(
+                    attach_record_id(
+                        row,
+                        self.platform,
+                        primary_key_column=self.records_id_column,
+                    )
+                )
+        return prepared
+
     def write_records(
         self,
         rows: list[dict[str, Any]],
@@ -156,7 +177,10 @@ class StorageManager:
         *,
         filename: str | None = None,
     ) -> Path:
-        validated = [self.model.model_validate(row).model_dump() for row in rows]
+        validated = [
+            self.model.model_validate(row).model_dump()
+            for row in self._prepare_rows_for_write(rows)
+        ]
         out_path = run_dir / (filename or self.records_filename)
         fieldnames = list(self.model.model_fields.keys())
         if self.format == "parquet":
@@ -172,7 +196,10 @@ class StorageManager:
         *,
         filename: str | None = None,
     ) -> Path:
-        validated = [self.model.model_validate(row).model_dump() for row in rows]
+        validated = [
+            self.model.model_validate(row).model_dump()
+            for row in self._prepare_rows_for_write(rows)
+        ]
         out_path = run_dir / (filename or self.records_filename)
         if self.format == "parquet":
             if out_path.exists():

--- a/data_platform/utils/storage.py
+++ b/data_platform/utils/storage.py
@@ -96,6 +96,7 @@ class StorageManager:
         self.format: ValidDataFormats = load_dataset_format(platform, dataset_id)
         stem = Path(records_filename).stem
         self.records_filename = f"{stem}.{self.format.value}"
+        self.records_file_stem = stem
         self.records_id_column = resolve_records_id_column(platform, stem)
 
     @property
@@ -165,6 +166,7 @@ class StorageManager:
                     attach_record_id(
                         row,
                         self.platform,
+                        records_file_stem=self.records_file_stem,
                         primary_key_column=self.records_id_column,
                     )
                 )

--- a/tests/data_platform/conftest.py
+++ b/tests/data_platform/conftest.py
@@ -14,6 +14,7 @@ from tests.data_platform.constants import (
     SAMPLE_INGESTION_ROW,
     URI_POST_A,
     URI_POST_B,
+    expected_bluesky_record_id,
 )
 
 @pytest.fixture
@@ -37,6 +38,7 @@ def make_post_row(
     handle = author_handle.removesuffix(".bsky.social")
     return {
         "uri": uri,
+        "record_id": expected_bluesky_record_id(uri),
         "url": url or f"https://bsky.app/profile/{handle}/post/1",
         "author_handle": author_handle,
         "text": text,

--- a/tests/data_platform/constants.py
+++ b/tests/data_platform/constants.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+
 from lib.constants import REPO_ROOT
 
 VALID_DATASET_ID = "bluesky_00000000-0000-4000-8000-000000000001"
@@ -16,8 +18,17 @@ PREPROCESSED_RUN = "preprocessed/2026_01_01-00:00:00"
 PREPROCESSED_RUN_DIR = "2026_01_01-00:00:00"
 LABEL_TIMESTAMP = "2026_01_01-00:00:00"
 
+_BLUESKY_SAMPLE_URI = "at://did:plc:example/app.bsky.feed.post/abc"
+
+
+def expected_bluesky_record_id(uri: str) -> str:
+  """Return the bluesky_{sha256(uri)} id used in study datasets."""
+  return "bluesky_" + hashlib.sha256(uri.encode("utf-8")).hexdigest()
+
+
 SAMPLE_INGESTION_ROW = {
-    "uri": "at://did:plc:example/app.bsky.feed.post/abc",
+    "uri": _BLUESKY_SAMPLE_URI,
+    "record_id": expected_bluesky_record_id(_BLUESKY_SAMPLE_URI),
     "url": "https://bsky.app/profile/handle/post/abc",
     "author_handle": "handle",
     "text": "hello",

--- a/tests/data_platform/constants.py
+++ b/tests/data_platform/constants.py
@@ -22,8 +22,8 @@ _BLUESKY_SAMPLE_URI = "at://did:plc:example/app.bsky.feed.post/abc"
 
 
 def expected_bluesky_record_id(uri: str) -> str:
-  """Return the bluesky_{sha256(uri)} id used in study datasets."""
-  return "bluesky_" + hashlib.sha256(uri.encode("utf-8")).hexdigest()
+    """Return the bluesky_{sha256(uri)} id used in study datasets."""
+    return "bluesky_" + hashlib.sha256(uri.encode("utf-8")).hexdigest()
 
 
 SAMPLE_INGESTION_ROW = {

--- a/tests/data_platform/ingestion/reddit_conftest.py
+++ b/tests/data_platform/ingestion/reddit_conftest.py
@@ -38,7 +38,7 @@ def mock_comment_row(
         "subreddit": subreddit,
         "comment_id": comment_fullname.removeprefix("t1_"),
         "comment_fullname": comment_fullname,
-        "record_id": f"reddit_{comment_fullname}",
+        "record_id": f"reddit_{post_reddit_id}_{comment_fullname.removeprefix('t1_')}",
         "parent_id": f"t3_{post_reddit_id}",
         "author": "user",
         "body": "comment text long enough",

--- a/tests/data_platform/ingestion/reddit_conftest.py
+++ b/tests/data_platform/ingestion/reddit_conftest.py
@@ -38,6 +38,7 @@ def mock_comment_row(
         "subreddit": subreddit,
         "comment_id": comment_fullname.removeprefix("t1_"),
         "comment_fullname": comment_fullname,
+        "record_id": f"reddit_{comment_fullname}",
         "parent_id": f"t3_{post_reddit_id}",
         "author": "user",
         "body": "comment text long enough",
@@ -59,6 +60,7 @@ def mock_post_row(
     return {
         "reddit_id": reddit_id,
         "reddit_fullname": reddit_fullname,
+        "record_id": f"reddit_{reddit_fullname}",
         "subreddit": subreddit,
         "title": "title",
         "selftext": "body",

--- a/tests/data_platform/ingestion/test_generate_record_id.py
+++ b/tests/data_platform/ingestion/test_generate_record_id.py
@@ -71,12 +71,15 @@ class TestAttachRecordId:
     def test_adds_record_id_without_mutating_input(self) -> None:
         """attach_record_id copies the row and leaves the source dict unchanged."""
         source = mock_tweet_row(TWITTER_TWEET_ID)
+        source_without_record_id = {
+            key: value for key, value in source.items() if key != RECORD_ID_COLUMN
+        }
         expected_record_id = f"{INTEGRATION_TWITTER}_{TWITTER_TWEET_ID}"
 
-        result = attach_record_id(source, INTEGRATION_TWITTER)
+        result = attach_record_id(source_without_record_id, INTEGRATION_TWITTER)
 
         assert result[RECORD_ID_COLUMN] == expected_record_id
-        assert RECORD_ID_COLUMN not in source
+        assert RECORD_ID_COLUMN not in source_without_record_id
 
     def test_raises_when_primary_key_column_is_missing(self) -> None:
         """Missing platform primary key columns are caller errors."""

--- a/tests/data_platform/ingestion/test_generate_record_id.py
+++ b/tests/data_platform/ingestion/test_generate_record_id.py
@@ -1,14 +1,94 @@
 from __future__ import annotations
 
+import hashlib
+
+import pytest
+
 from data_platform.ingestion.generate_record_id import (
+    INTEGRATION_BLUESKY,
+    INTEGRATION_REDDIT,
+    INTEGRATION_TWITTER,
+    RECORD_ID_COLUMN,
     attach_record_id,
     generate_record_id,
 )
+from tests.data_platform.ingestion.reddit_conftest import mock_comment_row
+from tests.data_platform.ingestion.twitter_conftest import mock_tweet_row
+
+
+def _expected_bluesky_record_id(uri: str) -> str:
+    return f"{INTEGRATION_BLUESKY}_{hashlib.sha256(uri.encode('utf-8')).hexdigest()}"
+
+
+BLUESKY_URI = "at://did:plc:example/app.bsky.feed.post/abc"
+REDDIT_COMMENT_FULLNAME = "t1_keep"
+TWITTER_TWEET_ID = "1000000000000000001"
 
 
 class TestGenerateRecordId:
     """Tests for generate_record_id()."""
 
+    def test_hashes_bluesky_uri_with_integration_prefix(self) -> None:
+        """Bluesky ids use sha256(uri) after the bluesky_ prefix."""
+        expected = _expected_bluesky_record_id(BLUESKY_URI)
+
+        result = generate_record_id(INTEGRATION_BLUESKY, BLUESKY_URI)
+
+        assert result == expected
+
+    def test_prefixes_twitter_tweet_id(self) -> None:
+        """Twitter ids keep tweet_id after the twitter_ prefix."""
+        expected = f"{INTEGRATION_TWITTER}_{TWITTER_TWEET_ID}"
+
+        result = generate_record_id(INTEGRATION_TWITTER, TWITTER_TWEET_ID)
+
+        assert result == expected
+
+    def test_prefixes_reddit_comment_fullname(self) -> None:
+        """Reddit comment ids keep comment_fullname after the reddit_ prefix."""
+        expected = f"{INTEGRATION_REDDIT}_{REDDIT_COMMENT_FULLNAME}"
+
+        result = generate_record_id(INTEGRATION_REDDIT, REDDIT_COMMENT_FULLNAME)
+
+        assert result == expected
+
+    @pytest.mark.parametrize("integration", ["mastodon", ""])
+    def test_rejects_unknown_integration(self, integration: str) -> None:
+        """Unknown integrations fail before id formatting."""
+        with pytest.raises(ValueError, match="integration"):
+            generate_record_id(integration, "id")
+
+    @pytest.mark.parametrize("primary_key", ["", "   "])
+    def test_rejects_empty_primary_key(self, primary_key: str) -> None:
+        """Empty platform ids are invalid."""
+        with pytest.raises(ValueError, match="primary key"):
+            generate_record_id(INTEGRATION_TWITTER, primary_key)
+
 
 class TestAttachRecordId:
     """Tests for attach_record_id()."""
+
+    def test_adds_record_id_without_mutating_input(self) -> None:
+        """attach_record_id copies the row and leaves the source dict unchanged."""
+        source = mock_tweet_row(TWITTER_TWEET_ID)
+        expected_record_id = f"{INTEGRATION_TWITTER}_{TWITTER_TWEET_ID}"
+
+        result = attach_record_id(source, INTEGRATION_TWITTER)
+
+        assert result[RECORD_ID_COLUMN] == expected_record_id
+        assert RECORD_ID_COLUMN not in source
+
+    def test_raises_when_primary_key_column_is_missing(self) -> None:
+        """Missing platform primary key columns are caller errors."""
+        with pytest.raises(KeyError):
+            attach_record_id({"text": "hello"}, INTEGRATION_TWITTER)
+
+    def test_attaches_reddit_comment_record_id(self) -> None:
+        """Reddit rows use comment_fullname as the primary key source."""
+        source = mock_comment_row(REDDIT_COMMENT_FULLNAME, subreddit="politics")
+        expected_record_id = f"{INTEGRATION_REDDIT}_{REDDIT_COMMENT_FULLNAME}"
+
+        result = attach_record_id(source, INTEGRATION_REDDIT)
+
+        assert result[RECORD_ID_COLUMN] == expected_record_id
+        assert result["comment_fullname"] == REDDIT_COMMENT_FULLNAME

--- a/tests/data_platform/ingestion/test_generate_record_id.py
+++ b/tests/data_platform/ingestion/test_generate_record_id.py
@@ -22,6 +22,8 @@ def _expected_bluesky_record_id(uri: str) -> str:
 
 BLUESKY_URI = "at://did:plc:example/app.bsky.feed.post/abc"
 REDDIT_COMMENT_FULLNAME = "t1_keep"
+REDDIT_POST_ID = "abc123"
+REDDIT_COMMENT_ID = "keep"
 TWITTER_TWEET_ID = "1000000000000000001"
 
 
@@ -44,11 +46,14 @@ class TestGenerateRecordId:
 
         assert result == expected
 
-    def test_prefixes_reddit_comment_fullname(self) -> None:
-        """Reddit comment ids keep comment_fullname after the reddit_ prefix."""
-        expected = f"{INTEGRATION_REDDIT}_{REDDIT_COMMENT_FULLNAME}"
+    def test_prefixes_reddit_post_and_comment_id(self) -> None:
+        """Reddit comment ids join post_reddit_id and comment_id after the reddit_ prefix."""
+        expected = f"{INTEGRATION_REDDIT}_{REDDIT_POST_ID}_{REDDIT_COMMENT_ID}"
 
-        result = generate_record_id(INTEGRATION_REDDIT, REDDIT_COMMENT_FULLNAME)
+        result = generate_record_id(
+            INTEGRATION_REDDIT,
+            f"{REDDIT_POST_ID}_{REDDIT_COMMENT_ID}",
+        )
 
         assert result == expected
 
@@ -87,11 +92,15 @@ class TestAttachRecordId:
             attach_record_id({"text": "hello"}, INTEGRATION_TWITTER)
 
     def test_attaches_reddit_comment_record_id(self) -> None:
-        """Reddit rows use comment_fullname as the primary key source."""
+        """Reddit rows use post_reddit_id and comment_id as the primary key source."""
         source = mock_comment_row(REDDIT_COMMENT_FULLNAME, subreddit="politics")
-        expected_record_id = f"{INTEGRATION_REDDIT}_{REDDIT_COMMENT_FULLNAME}"
+        expected_record_id = f"{INTEGRATION_REDDIT}_{REDDIT_POST_ID}_{REDDIT_COMMENT_ID}"
 
-        result = attach_record_id(source, INTEGRATION_REDDIT)
+        result = attach_record_id(
+            source,
+            INTEGRATION_REDDIT,
+            records_file_stem="comments",
+        )
 
         assert result[RECORD_ID_COLUMN] == expected_record_id
         assert result["comment_fullname"] == REDDIT_COMMENT_FULLNAME

--- a/tests/data_platform/ingestion/test_generate_record_id.py
+++ b/tests/data_platform/ingestion/test_generate_record_id.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from data_platform.ingestion.generate_record_id import (
+    attach_record_id,
+    generate_record_id,
+)
+
+
+class TestGenerateRecordId:
+    """Tests for generate_record_id()."""
+
+
+class TestAttachRecordId:
+    """Tests for attach_record_id()."""

--- a/tests/data_platform/ingestion/test_generate_record_id.py
+++ b/tests/data_platform/ingestion/test_generate_record_id.py
@@ -11,8 +11,9 @@ from data_platform.ingestion.generate_record_id import (
     RECORD_ID_COLUMN,
     attach_record_id,
     generate_record_id,
+    generate_reddit_record_id,
 )
-from tests.data_platform.ingestion.reddit_conftest import mock_comment_row
+from tests.data_platform.ingestion.reddit_conftest import mock_comment_row, mock_post_row
 from tests.data_platform.ingestion.twitter_conftest import mock_tweet_row
 
 
@@ -46,14 +47,12 @@ class TestGenerateRecordId:
 
         assert result == expected
 
-    def test_prefixes_reddit_post_and_comment_id(self) -> None:
-        """Reddit comment ids join post_reddit_id and comment_id after the reddit_ prefix."""
-        expected = f"{INTEGRATION_REDDIT}_{REDDIT_POST_ID}_{REDDIT_COMMENT_ID}"
+    def test_prefixes_reddit_primary_key(self) -> None:
+        """Reddit ids prefix the already-joined primary key."""
+        primary_key = f"{REDDIT_POST_ID}_{REDDIT_COMMENT_ID}"
+        expected = f"{INTEGRATION_REDDIT}_{primary_key}"
 
-        result = generate_record_id(
-            INTEGRATION_REDDIT,
-            f"{REDDIT_POST_ID}_{REDDIT_COMMENT_ID}",
-        )
+        result = generate_record_id(INTEGRATION_REDDIT, primary_key)
 
         assert result == expected
 
@@ -68,6 +67,33 @@ class TestGenerateRecordId:
         """Empty platform ids are invalid."""
         with pytest.raises(ValueError, match="non-empty"):
             generate_record_id(INTEGRATION_TWITTER, primary_key)
+
+
+class TestGenerateRedditRecordId:
+    """Tests for generate_reddit_record_id()."""
+
+    def test_joins_comment_post_and_comment_id(self) -> None:
+        """Comment rows use reddit_{post_reddit_id}_{comment_id}."""
+        source = mock_comment_row(REDDIT_COMMENT_FULLNAME, subreddit="politics")
+        expected = f"{INTEGRATION_REDDIT}_{REDDIT_POST_ID}_{REDDIT_COMMENT_ID}"
+
+        result = generate_reddit_record_id(source)
+
+        assert result == expected
+
+    def test_prefixes_post_fullname(self) -> None:
+        """Post rows use reddit_{reddit_fullname}."""
+        source = mock_post_row("t3_abc123", subreddit="politics")
+        expected = f"{INTEGRATION_REDDIT}_t3_abc123"
+
+        result = generate_reddit_record_id(source)
+
+        assert result == expected
+
+    def test_raises_when_comment_and_post_fields_are_missing(self) -> None:
+        """Rows that are neither comments nor posts are caller errors."""
+        with pytest.raises(KeyError):
+            generate_reddit_record_id({"subreddit": "politics"})
 
 
 class TestAttachRecordId:
@@ -92,15 +118,11 @@ class TestAttachRecordId:
             attach_record_id({"text": "hello"}, INTEGRATION_TWITTER)
 
     def test_attaches_reddit_comment_record_id(self) -> None:
-        """Reddit rows use post_reddit_id and comment_id as the primary key source."""
+        """Reddit comment rows go through generate_reddit_record_id."""
         source = mock_comment_row(REDDIT_COMMENT_FULLNAME, subreddit="politics")
         expected_record_id = f"{INTEGRATION_REDDIT}_{REDDIT_POST_ID}_{REDDIT_COMMENT_ID}"
 
-        result = attach_record_id(
-            source,
-            INTEGRATION_REDDIT,
-            records_file_stem="comments",
-        )
+        result = attach_record_id(source, INTEGRATION_REDDIT)
 
         assert result[RECORD_ID_COLUMN] == expected_record_id
         assert result["comment_fullname"] == REDDIT_COMMENT_FULLNAME

--- a/tests/data_platform/ingestion/test_generate_record_id.py
+++ b/tests/data_platform/ingestion/test_generate_record_id.py
@@ -61,7 +61,7 @@ class TestGenerateRecordId:
     @pytest.mark.parametrize("primary_key", ["", "   "])
     def test_rejects_empty_primary_key(self, primary_key: str) -> None:
         """Empty platform ids are invalid."""
-        with pytest.raises(ValueError, match="primary key"):
+        with pytest.raises(ValueError, match="non-empty"):
             generate_record_id(INTEGRATION_TWITTER, primary_key)
 
 

--- a/tests/data_platform/ingestion/test_raw_row_timestamps.py
+++ b/tests/data_platform/ingestion/test_raw_row_timestamps.py
@@ -13,6 +13,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from data_platform.ingestion.generate_record_id import (
+    REDDIT_POST_RECORDS_ID_COLUMN,
+    attach_record_id,
+)
 from data_platform.ingestion.sync_bluesky import fetch_posts_for_keyword
 from data_platform.ingestion.sync_reddit import comment_to_row, submission_to_row
 from data_platform.ingestion.twitter_client import tweet_to_row
@@ -100,7 +104,7 @@ class TestFetchPostsForKeyword:
         expected_created_at = "2026-05-30T00:00:00.000Z"
         assert rows[0]["created_at"] == expected_created_at
         assert rows[0]["sync_timestamp"] == SYNC_TIMESTAMP
-        SyncBlueskyPostModel.model_validate(rows[0])
+        SyncBlueskyPostModel.model_validate(attach_record_id(rows[0], "bluesky"))
 
 
 class TestSubmissionToRow:
@@ -113,7 +117,13 @@ class TestSubmissionToRow:
         assert result["created_at"] == CREATED_AT_ISO
         assert "created_utc" not in result
         assert result["sync_timestamp"] == SYNC_TIMESTAMP
-        SyncRedditPostModel.model_validate(result)
+        SyncRedditPostModel.model_validate(
+            attach_record_id(
+                result,
+                "reddit",
+                primary_key_column=REDDIT_POST_RECORDS_ID_COLUMN,
+            )
+        )
 
 
 class TestCommentToRow:
@@ -132,7 +142,7 @@ class TestCommentToRow:
         assert result["created_at"] == CREATED_AT_ISO
         assert "created_utc" not in result
         assert result["sync_timestamp"] == SYNC_TIMESTAMP
-        SyncRedditCommentModel.model_validate(result)
+        SyncRedditCommentModel.model_validate(attach_record_id(result, "reddit"))
 
 
 class TestTweetToRow:
@@ -150,7 +160,7 @@ class TestTweetToRow:
 
         assert result["created_at"] == CREATED_AT_ISO
         assert result["sync_timestamp"] == SYNC_TIMESTAMP
-        SyncTwitterPostModel.model_validate(result)
+        SyncTwitterPostModel.model_validate(attach_record_id(result, "twitter"))
 
     def test_writes_empty_created_at_when_payload_time_is_missing(self) -> None:
         """tweet_to_row writes an empty created_at when the payload time is missing."""

--- a/tests/data_platform/ingestion/test_raw_row_timestamps.py
+++ b/tests/data_platform/ingestion/test_raw_row_timestamps.py
@@ -142,7 +142,9 @@ class TestCommentToRow:
         assert result["created_at"] == CREATED_AT_ISO
         assert "created_utc" not in result
         assert result["sync_timestamp"] == SYNC_TIMESTAMP
-        SyncRedditCommentModel.model_validate(attach_record_id(result, "reddit"))
+        SyncRedditCommentModel.model_validate(
+            attach_record_id(result, "reddit", records_file_stem="comments")
+        )
 
 
 class TestTweetToRow:

--- a/tests/data_platform/ingestion/test_raw_row_timestamps.py
+++ b/tests/data_platform/ingestion/test_raw_row_timestamps.py
@@ -13,10 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from data_platform.ingestion.generate_record_id import (
-    REDDIT_POST_RECORDS_ID_COLUMN,
-    attach_record_id,
-)
+from data_platform.ingestion.generate_record_id import attach_record_id
 from data_platform.ingestion.sync_bluesky import fetch_posts_for_keyword
 from data_platform.ingestion.sync_reddit import comment_to_row, submission_to_row
 from data_platform.ingestion.twitter_client import tweet_to_row
@@ -117,13 +114,7 @@ class TestSubmissionToRow:
         assert result["created_at"] == CREATED_AT_ISO
         assert "created_utc" not in result
         assert result["sync_timestamp"] == SYNC_TIMESTAMP
-        SyncRedditPostModel.model_validate(
-            attach_record_id(
-                result,
-                "reddit",
-                primary_key_column=REDDIT_POST_RECORDS_ID_COLUMN,
-            )
-        )
+        SyncRedditPostModel.model_validate(attach_record_id(result, "reddit"))
 
 
 class TestCommentToRow:
@@ -142,9 +133,7 @@ class TestCommentToRow:
         assert result["created_at"] == CREATED_AT_ISO
         assert "created_utc" not in result
         assert result["sync_timestamp"] == SYNC_TIMESTAMP
-        SyncRedditCommentModel.model_validate(
-            attach_record_id(result, "reddit", records_file_stem="comments")
-        )
+        SyncRedditCommentModel.model_validate(attach_record_id(result, "reddit"))
 
 
 class TestTweetToRow:

--- a/tests/data_platform/ingestion/twitter_conftest.py
+++ b/tests/data_platform/ingestion/twitter_conftest.py
@@ -11,6 +11,7 @@ def mock_tweet_row(tweet_id: str, **overrides: Any) -> dict[str, Any]:
     """Return a dict that satisfies SyncTwitterPostModel (preprocess-ready text)."""
     row: dict[str, Any] = {
         "tweet_id": tweet_id,
+        "record_id": f"twitter_{tweet_id}",
         "text": _DEFAULT_TWEET_TEXT,
         "author_id": "100",
         "username": "testuser",

--- a/tests/data_platform/utils/test_storage.py
+++ b/tests/data_platform/utils/test_storage.py
@@ -204,6 +204,46 @@ def test_write_records_validates_rows(bluesky_storage) -> None:
         )
 
 
+class TestWriteRecordsAddsRecordId:
+    """Tests for record_id generation during storage writes."""
+
+    def test_bluesky_write_adds_record_id_from_uri(self, bluesky_storage) -> None:
+        """Raw Bluesky writes persist bluesky_{sha256(uri)} without caller-supplied record_id."""
+        run_dir = bluesky_storage.create_new_run_dir("2026_05_30-11:00:00")
+        row = make_ingestion_row()
+        row_without_record_id = {key: value for key, value in row.items() if key != "record_id"}
+        expected_record_id = row["record_id"]
+
+        bluesky_storage.write_records([row_without_record_id], run_dir)
+        saved = bluesky_storage.load_records(run_dir=run_dir)
+
+        assert saved.iloc[0]["record_id"] == expected_record_id
+
+    def test_twitter_write_adds_record_id_from_tweet_id(self, data_root) -> None:
+        """Raw Twitter writes persist twitter_{tweet_id}."""
+        storage = TwitterStorageManager(StorageStage.RAW, VALID_TWITTER_DATASET_ID)
+        run_dir = storage.create_new_run_dir("2026_05_30-11:00:00")
+        row = mock_tweet_row("1000000000000000001")
+        row_without_record_id = {key: value for key, value in row.items() if key != "record_id"}
+
+        storage.write_records([row_without_record_id], run_dir)
+        saved = storage.load_records(run_dir=run_dir)
+
+        assert saved.iloc[0]["record_id"] == "twitter_1000000000000000001"
+
+    def test_reddit_write_adds_record_id_from_comment_fullname(self, data_root) -> None:
+        """Raw Reddit comment writes persist reddit_{comment_fullname}."""
+        storage = RedditStorageManager(StorageStage.RAW, VALID_REDDIT_DATASET_ID)
+        run_dir = storage.create_new_run_dir("2026_05_30-11:00:00")
+        row = mock_comment_row("t1_comment_a")
+        row_without_record_id = {key: value for key, value in row.items() if key != "record_id"}
+
+        storage.write_records([row_without_record_id], run_dir)
+        saved = storage.load_records(run_dir=run_dir)
+
+        assert saved.iloc[0]["record_id"] == "reddit_t1_comment_a"
+
+
 class TestTwitterStorageManagerRecordsFilename:
     """Tests for TwitterStorageManager.records_filename."""
 

--- a/tests/data_platform/utils/test_storage.py
+++ b/tests/data_platform/utils/test_storage.py
@@ -242,7 +242,7 @@ class TestWriteRecordsAddsRecordId:
         storage.write_records([row_without_record_id], run_dir)
         saved = storage.load_records(run_dir=run_dir)
 
-        assert saved.iloc[0]["record_id"] == "reddit_t1_comment_a"
+        assert saved.iloc[0]["record_id"] == "reddit_abc123_comment_a"
 
 
 class TestTwitterStorageManagerRecordsFilename:

--- a/tests/data_platform/utils/test_storage.py
+++ b/tests/data_platform/utils/test_storage.py
@@ -19,6 +19,7 @@ from tests.data_platform.constants import (
     VALID_TWITTER_DATASET_ID,
 )
 from tests.data_platform.ingestion.reddit_conftest import mock_comment_row
+from tests.data_platform.ingestion.twitter_conftest import mock_tweet_row
 
 
 def test_bluesky_storage_root_includes_dataset_id(data_root, bluesky_storage) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds stable `{integration}_{id}` record IDs to every raw ingest row at write time, matching the keys used in `shared/data` stimuli (`bluesky_{sha256(uri)}`, `twitter_{tweet_id}`, `reddit_{post_reddit_id}_{comment_id}`).

`StorageManager.write_records` and `append_records` call `attach_record_id` before Pydantic validation, so sync CLIs do not need to build IDs themselves. Reddit posts and comments use `generate_reddit_record_id`; Bluesky and Twitter keep the shared prefix helper.

## Purpose

Study stimuli and downstream transforms key posts on `{integration}_{id}` IDs, but the data platform previously stored only platform-native ids (`uri`, `tweet_id`, `comment_fullname`). Operators had to derive study keys after ingestion.

This change generates those IDs as part of ingest persistence. Preprocess `source_record_id` and historical stimuli CSVs are out of scope.

## Architecture

Components:

- `data_platform/ingestion/generate_record_id.py` — `generate_record_id`, `generate_reddit_record_id`, and `attach_record_id`
- `data_platform/utils/storage.py` — attaches `record_id` on every raw write
- `data_platform/models/sync.py` — sync row models now include `record_id`

Before:

```mermaid
flowchart LR
  subgraph before [Before]
    S1[Sync CLI] --> R1[Row dict with platform id only]
    R1 --> W1[Storage write]
  end
```

After:

```mermaid
flowchart LR
  subgraph after [After]
    S2[Sync CLI] --> R2[Row dict with platform id]
    R2 --> A2[attach_record_id]
    A2 --> R3[generate_reddit_record_id for Reddit]
    A2 --> G2[generate_record_id for Bluesky and Twitter]
    R3 --> W2[Storage write with record_id]
    G2 --> W2
  end
```

## Interfaces

### `generate_record_id(integration, primary_key) -> str`

Shared prefix helper. Bluesky hashes `uri`. Twitter and Reddit prefix the given primary key.

### `generate_reddit_record_id(row) -> str`

Reddit-only helper. Comments become `reddit_{post_reddit_id}_{comment_id}`. Posts become `reddit_{reddit_fullname}`.

| Integration | Primary key input | `record_id` format |
| ----------- | ----------------- | ------------------ |
| `bluesky` | `uri` | `bluesky_{sha256(uri)}` |
| `twitter` | `tweet_id` | `twitter_{tweet_id}` |
| `reddit` (comments) | `{post_reddit_id}_{comment_id}` | `reddit_{post_reddit_id}_{comment_id}` |
| `reddit` (posts) | `reddit_fullname` | `reddit_{reddit_fullname}` |

Raw sync models (`SyncBlueskyPostModel`, `SyncTwitterPostModel`, `SyncRedditCommentModel`, `SyncRedditPostModel`) include a required `record_id` column on disk.

## How to run

```bash
PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_generate_record_id.py tests/data_platform/utils/test_storage.py::TestWriteRecordsAddsRecordId -q
```

```bash
PYTHONPATH=. uv run pytest tests/data_platform -q
```

Expected: all tests pass.

Closes #137
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b3fa384-c53d-4c3e-84f3-2a486c75ea8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b3fa384-c53d-4c3e-84f3-2a486c75ea8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stable record IDs for Bluesky, Reddit, and Twitter records.
  * Record IDs are generated automatically when omitted during storage.
  * Existing record IDs are preserved during storage operations.
  * Reddit comments use deterministic identifiers based on their post and comment keys.
  * Bluesky identifiers are generated consistently from post URIs.

* **Bug Fixes**
  * Improved consistency when synchronizing posts and comments across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->