### PR TITLE
Share ingest orchestration for Bluesky, Twitter, and Reddit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-03
 
-1. Ingest scripts now share one start and finish path for a raw sync. Bluesky and Twitter also share the keyword task loop. Reddit still writes posts and comments in its own loop. Operator commands and YAML stay the same. [PR #140](https://github.com/METResearchGroup/mirrorView-task/pull/140)
+1. Bluesky, Twitter, and Reddit ingest scripts now start and finish a raw sync through the same functions in `data_platform/ingestion/runner.py`. Bluesky and Twitter also share the keyword fetch loop. Reddit still writes posts and comments in `sync_reddit.py`. The same CLI commands and YAML configs still work. [PR #140](https://github.com/METResearchGroup/mirrorView-task/pull/140)
 
 ## 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2026-09-03
+
+1. Ingest scripts now share one start and finish path for a raw sync. Bluesky and Twitter also share the keyword task loop. Reddit still writes posts and comments in its own loop. Operator commands and YAML stay the same. [PR #140](https://github.com/METResearchGroup/mirrorView-task/pull/140)
+
 ## 2026-09-02
 
 1. Preprocess now owns length and English gates for stimuli-ready text. Reddit comments also need at least 30 characters. Ingest fetch filters are unchanged. [PR #132](https://github.com/METResearchGroup/mirrorView-task/pull/132)

--- a/data_platform/ingestion/runner.py
+++ b/data_platform/ingestion/runner.py
@@ -1,6 +1,6 @@
-"""Shared orchestration for ingestion sync entrypoints.
+"""Shared start, finish, and keyword fetch helpers for platform sync scripts.
 
-Run from the repo root:
+Run a sync from the repo root. For example:
 
     PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py \\
         --config data_platform/ingestion/configs/bluesky/mirrorview.yaml
@@ -28,7 +28,6 @@ from data_platform.ingestion.sync_checkpoint import (
     resolve_dedupe_policy,
     resolve_limit_per_task,
     run_checkpointed_sync,
-    run_sync_cli,
 )
 from data_platform.utils.config_paths import load_yaml_config
 from data_platform.utils.deduplication import (
@@ -51,7 +50,7 @@ SummarizeRunFn = Callable[[dict[str, Any], Path], None]
 
 @dataclass(frozen=True)
 class KeywordSyncParams:
-    """Dedupe identity and progress labels for one Bluesky or Twitter keyword loop."""
+    """Id column, record type, and progress bar text for the Bluesky or Twitter keyword loop."""
 
     id_column: str
     record_type: str
@@ -60,11 +59,13 @@ class KeywordSyncParams:
 
 @dataclass(frozen=True)
 class SyncPlatformSpec:
-    """Platform settings for shared ingest orchestration.
+    """Settings that one platform sync script passes into ``sync_with_spec``.
 
-    Each sync script supplies fetch, validation, and task-building hooks. The
-    runner owns load-config, dataset manifest, run resume, and finalize. Reddit
-    keeps its own dual-output loop; Bluesky and Twitter share the keyword loop.
+    Each sync script supplies the functions that fetch records, validate YAML,
+    and build the task list. ``sync_with_spec`` loads the YAML, writes
+    ``dataset.json``, resumes an unfinished run when one exists, and writes the
+    finished run metadata. Bluesky and Twitter use the shared keyword loop in
+    this module. Reddit still writes posts and comments in ``sync_reddit.py``.
     """
 
     platform: str
@@ -76,13 +77,11 @@ class SyncPlatformSpec:
     validate_config: Callable[[dict[str, Any]], None]
     run_sync_tasks: SyncRunHook
     summarize_run: SummarizeRunFn
-    parse_record_cap: Callable[[dict[str, Any]], int | None] = parse_max_posts
     metadata_extra_fields: dict[str, Any] | None = None
-    config_loader: Callable[[Path], dict[str, Any]] = load_yaml_config
 
 
 def remaining_record_budget(metadata: dict[str, Any], record_cap: int | None) -> int | None:
-    """Return how many records can still be written before the run cap is reached."""
+    """Return how many records can still be written before ``max_posts`` is reached."""
     if record_cap is None:
         return None
     return record_cap - int(metadata["row_count"])
@@ -92,7 +91,7 @@ def effective_limit_per_keyword(
     ingestion_params: dict[str, Any],
     remaining: int | None,
 ) -> int:
-    """Return the per-keyword fetch cap after applying any run-wide post budget."""
+    """Return the per-keyword fetch limit, capped by remaining run-wide posts."""
     per_keyword = resolve_limit_per_task(ingestion_params)
     if remaining is None:
         return per_keyword
@@ -111,10 +110,11 @@ def run_keyword_sync_tasks(
     params: KeywordSyncParams,
     fetch_for_task: KeywordFetchFn,
 ) -> None:
-    """Run the checkpointed keyword loop shared by Bluesky and Twitter.
+    """Run the keyword loop that Bluesky and Twitter share.
 
-    Opens one dedupe session, fetches each task, appends deduped rows, and updates
-    run metadata. Skips completed tasks on resume and honors ``max_posts``.
+    Opens one skip-id session, fetches each remaining task, appends rows that
+    are not duplicates, and updates run metadata. Skips tasks that already
+    completed on resume, and stops when ``max_posts`` is reached.
     """
     max_posts_int = parse_max_posts(ingestion_params)
     sync_timestamp = str(metadata["sync_timestamp"])
@@ -135,7 +135,7 @@ def run_keyword_sync_tasks(
         remaining = remaining_record_budget(metadata, max_posts_int)
         try:
             fetch_result = fetch_for_task(client, task, sync_timestamp, remaining)
-        except Exception as exc:  # noqa: BLE001 — record and continue
+        except Exception as exc:  # noqa: BLE001. Record the failure and continue.
             mark_task_failed(entry, exc, task.task_id, storage, output_dir, metadata)
             return
 
@@ -190,17 +190,18 @@ def sync_with_spec(
     *,
     run_dir_name: str | None = None,
     spec: SyncPlatformSpec,
-    config_loader: Callable[[Path], dict[str, Any]] | None = None,
+    config_loader: Callable[[Path], dict[str, Any]] = load_yaml_config,
 ) -> Path:
-    """Load config, prepare or resume a raw run, and delegate to the platform hook.
+    """Load the YAML and prepare or resume a raw run directory.
+
+    Then call the platform function that fetches and writes records.
 
     Returns
     -------
     Path
         Output run directory for the sync.
     """
-    load_config = config_loader or spec.config_loader
-    config = load_config(config_path)
+    config = config_loader(config_path)
     dataset_id = require_dataset_id(config, platform=spec.platform)
 
     ensure_dataset_manifest(
@@ -250,19 +251,3 @@ def sync_with_spec(
     finalize_local_disk_sync(storage, output_dir, metadata)
     spec.summarize_run(metadata, output_dir)
     return output_dir
-
-
-def make_sync_cli(spec: SyncPlatformSpec, *, config_help: str) -> Callable[[], None]:
-    """Return a Typer ``main`` function for a platform sync script."""
-
-    def main() -> None:
-        run_sync_cli(
-            sync_records_fn=lambda config_path, *, run_dir_name=None: sync_with_spec(
-                config_path,
-                run_dir_name=run_dir_name,
-                spec=spec,
-            ),
-            config_help=config_help,
-        )
-
-    return main

--- a/data_platform/ingestion/runner.py
+++ b/data_platform/ingestion/runner.py
@@ -51,7 +51,7 @@ SummarizeRunFn = Callable[[dict[str, Any], Path], None]
 
 @dataclass(frozen=True)
 class KeywordSyncParams:
-    """Dedupe and checkpoint settings for one keyword-platform sync loop."""
+    """Dedupe identity and progress labels for one Bluesky or Twitter keyword loop."""
 
     id_column: str
     record_type: str

--- a/data_platform/ingestion/runner.py
+++ b/data_platform/ingestion/runner.py
@@ -1,0 +1,268 @@
+"""Shared orchestration for ingestion sync entrypoints.
+
+Run from the repo root:
+
+    PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py \\
+        --config data_platform/ingestion/configs/bluesky/mirrorview.yaml
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from data_platform.ingestion.sync_checkpoint import (
+    HasTaskId,
+    build_base_sync_metadata,
+    ensure_dataset_manifest,
+    finalize_local_disk_sync,
+    increment_duplicate_skip_counters,
+    mark_task_completed,
+    mark_task_failed,
+    mark_task_in_progress,
+    parse_max_posts,
+    prepare_sync_run,
+    require_dataset_id,
+    resolve_dedupe_policy,
+    resolve_limit_per_task,
+    run_checkpointed_sync,
+    run_sync_cli,
+)
+from data_platform.utils.config_paths import load_yaml_config
+from data_platform.utils.deduplication import (
+    DedupeConfig,
+    DedupeSession,
+    policy_includes_prior_runs,
+)
+from data_platform.utils.storage import StorageManager, StorageStage
+
+StorageManagerFactory = Callable[..., StorageManager]
+
+KeywordFetchFn = Callable[
+    [Any, HasTaskId, str, int | None],
+    tuple[list[dict[str, Any]], dict[str, Any]] | None,
+]
+
+SyncRunHook = Callable[..., None]
+SummarizeRunFn = Callable[[dict[str, Any], Path], None]
+
+
+@dataclass(frozen=True)
+class KeywordSyncParams:
+    """Dedupe and checkpoint settings for one keyword-platform sync loop."""
+
+    id_column: str
+    record_type: str
+    tqdm_desc: str = "Syncing keywords"
+
+
+@dataclass(frozen=True)
+class SyncPlatformSpec:
+    """Platform settings for shared ingest orchestration.
+
+    Each sync script supplies fetch, validation, and task-building hooks. The
+    runner owns load-config, dataset manifest, run resume, and finalize. Reddit
+    keeps its own dual-output loop; Bluesky and Twitter share the keyword loop.
+    """
+
+    platform: str
+    storage_cls: StorageManagerFactory
+    entity_label: str
+    init_client: Callable[[], Any]
+    build_sync_tasks: Callable[[dict[str, Any]], Sequence[HasTaskId]]
+    task_progress_builder: Callable[[Any], dict[str, Any]]
+    validate_config: Callable[[dict[str, Any]], None]
+    run_sync_tasks: SyncRunHook
+    summarize_run: SummarizeRunFn
+    parse_record_cap: Callable[[dict[str, Any]], int | None] = parse_max_posts
+    metadata_extra_fields: dict[str, Any] | None = None
+    config_loader: Callable[[Path], dict[str, Any]] = load_yaml_config
+
+
+def remaining_record_budget(metadata: dict[str, Any], record_cap: int | None) -> int | None:
+    """Return how many records can still be written before the run cap is reached."""
+    if record_cap is None:
+        return None
+    return record_cap - int(metadata["row_count"])
+
+
+def effective_limit_per_keyword(
+    ingestion_params: dict[str, Any],
+    remaining: int | None,
+) -> int:
+    """Return the per-keyword fetch cap after applying any run-wide post budget."""
+    per_keyword = resolve_limit_per_task(ingestion_params)
+    if remaining is None:
+        return per_keyword
+    return max(0, min(per_keyword, remaining))
+
+
+def run_keyword_sync_tasks(
+    client: Any,
+    ingestion_params: dict[str, Any],
+    output_dir: Path,
+    storage: StorageManager,
+    metadata: dict[str, Any],
+    sync_tasks: Sequence[HasTaskId],
+    *,
+    filename: str,
+    params: KeywordSyncParams,
+    fetch_for_task: KeywordFetchFn,
+) -> None:
+    """Run the checkpointed keyword loop shared by Bluesky and Twitter.
+
+    Opens one dedupe session, fetches each task, appends deduped rows, and updates
+    run metadata. Skips completed tasks on resume and honors ``max_posts``.
+    """
+    max_posts_int = parse_max_posts(ingestion_params)
+    sync_timestamp = str(metadata["sync_timestamp"])
+    dedupe_session = DedupeSession(
+        DedupeConfig(
+            id_column=params.id_column,
+            filename=filename,
+            include_prior_runs=policy_includes_prior_runs(
+                resolve_dedupe_policy(ingestion_params)
+            ),
+        )
+    )
+    dedupe_session.warm(storage, output_dir)
+
+    def process_task(task: HasTaskId, entry: dict[str, Any]) -> None:
+        mark_task_in_progress(entry, storage, output_dir, metadata)
+
+        remaining = remaining_record_budget(metadata, max_posts_int)
+        try:
+            fetch_result = fetch_for_task(client, task, sync_timestamp, remaining)
+        except Exception as exc:  # noqa: BLE001 — record and continue
+            mark_task_failed(entry, exc, task.task_id, storage, output_dir, metadata)
+            return
+
+        if fetch_result is None:
+            return
+
+        rows, stats = fetch_result
+        result = storage.append_deduped_records(
+            rows,
+            output_dir,
+            dedupe_session=dedupe_session,
+            filename=filename,
+        )
+        increment_duplicate_skip_counters(
+            metadata,
+            record_type=params.record_type,
+            skipped=result.skipped,
+        )
+        metadata["row_count"] = len(dedupe_session.seen_ids)
+        entry_updates: dict[str, Any] = {
+            "pages_fetched": stats["pages_fetched"],
+            "rows_collected": stats["rows_collected"],
+        }
+        if "hits_total" in stats:
+            entry_updates["hits_total"] = stats["hits_total"]
+        mark_task_completed(
+            entry,
+            storage,
+            output_dir,
+            metadata,
+            entry_updates=entry_updates,
+        )
+
+        print(
+            f"sync_records: {task.task_id} -> {stats['rows_collected']} rows "
+            f"(appended {result.kept}, pages={stats['pages_fetched']})"
+        )
+
+    run_checkpointed_sync(
+        sync_tasks,
+        metadata,
+        storage,
+        output_dir,
+        record_cap=max_posts_int,
+        tqdm_desc=params.tqdm_desc,
+        process_task=process_task,
+    )
+
+
+def sync_with_spec(
+    config_path: Path,
+    *,
+    run_dir_name: str | None = None,
+    spec: SyncPlatformSpec,
+    config_loader: Callable[[Path], dict[str, Any]] | None = None,
+) -> Path:
+    """Load config, prepare or resume a raw run, and delegate to the platform hook.
+
+    Returns
+    -------
+    Path
+        Output run directory for the sync.
+    """
+    load_config = config_loader or spec.config_loader
+    config = load_config(config_path)
+    dataset_id = require_dataset_id(config, platform=spec.platform)
+
+    ensure_dataset_manifest(
+        spec.storage_cls(StorageStage.RAW, dataset_id),
+        spec.platform,
+        dataset_id,
+        config,
+        config_path,
+    )
+    storage = spec.storage_cls(StorageStage.RAW, dataset_id)
+
+    spec.validate_config(config)
+
+    ingestion_params = config["ingestion_params"]
+    sync_tasks = list(spec.build_sync_tasks(ingestion_params))
+    client = spec.init_client()
+
+    def init_metadata(sync_timestamp: str) -> dict[str, Any]:
+        return build_base_sync_metadata(
+            config,
+            config_path,
+            sync_timestamp,
+            sync_tasks,
+            task_progress_builder=spec.task_progress_builder,
+            extra_fields=spec.metadata_extra_fields,
+        )
+
+    output_dir, metadata = prepare_sync_run(
+        storage,
+        sync_tasks,
+        run_dir_name=run_dir_name,
+        init_metadata_fn=init_metadata,
+        entity_label=spec.entity_label,
+    )
+
+    spec.run_sync_tasks(
+        client,
+        ingestion_params,
+        output_dir,
+        storage,
+        metadata,
+        sync_tasks,
+        config=config,
+        config_path=config_path,
+    )
+
+    finalize_local_disk_sync(storage, output_dir, metadata)
+    spec.summarize_run(metadata, output_dir)
+    return output_dir
+
+
+def make_sync_cli(spec: SyncPlatformSpec, *, config_help: str) -> Callable[[], None]:
+    """Return a Typer ``main`` function for a platform sync script."""
+
+    def main() -> None:
+        run_sync_cli(
+            sync_records_fn=lambda config_path, *, run_dir_name=None: sync_with_spec(
+                config_path,
+                run_dir_name=run_dir_name,
+                spec=spec,
+            ),
+            config_help=config_help,
+        )
+
+    return main

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -26,7 +26,6 @@ from data_platform.ingestion.retry import retry_bluesky_request
 from data_platform.ingestion.runner import (
     KeywordSyncParams,
     SyncPlatformSpec,
-    make_sync_cli,
     run_keyword_sync_tasks,
     sync_with_spec,
 )
@@ -34,6 +33,7 @@ from data_platform.ingestion.sync_checkpoint import (
     TaskStatus,
     build_base_sync_metadata,
     resolve_limit_per_task,
+    run_sync_cli,
 )
 from data_platform.ingestion.sync_clients import init_bluesky_client
 from data_platform.utils.config_paths import load_yaml_config
@@ -338,13 +338,13 @@ def sync_records(
 
 def main() -> None:
     """CLI entrypoint for sync_bluesky.py (--config, --resume, --run-dir)."""
-    make_sync_cli(
-        BLUESKY_SYNC_SPEC,
+    run_sync_cli(
+        sync_records_fn=sync_records,
         config_help=(
             "Ingestion YAML path relative to the repo root "
             "(e.g. data_platform/ingestion/configs/bluesky/mirrorview.yaml)"
         ),
-    )()
+    )
 
 
 if __name__ == "__main__":

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -23,31 +23,21 @@ from typing import TYPE_CHECKING, Any
 
 from data_platform.ingestion.query_terms import quote_query_term
 from data_platform.ingestion.retry import retry_bluesky_request
+from data_platform.ingestion.runner import (
+    KeywordSyncParams,
+    SyncPlatformSpec,
+    make_sync_cli,
+    run_keyword_sync_tasks,
+    sync_with_spec,
+)
 from data_platform.ingestion.sync_checkpoint import (
     TaskStatus,
     build_base_sync_metadata,
-    ensure_dataset_manifest,
-    finalize_local_disk_sync,
-    increment_duplicate_skip_counters,
-    mark_task_completed,
-    mark_task_failed,
-    mark_task_in_progress,
-    parse_max_posts,
-    prepare_sync_run,
-    require_dataset_id,
-    resolve_dedupe_policy,
     resolve_limit_per_task,
-    run_checkpointed_sync,
-    run_sync_cli,
 )
 from data_platform.ingestion.sync_clients import init_bluesky_client
 from data_platform.utils.config_paths import load_yaml_config
-from data_platform.utils.deduplication import (
-    DedupeConfig,
-    DedupeSession,
-    policy_includes_prior_runs,
-)
-from data_platform.utils.storage import BlueskyStorageManager, StorageStage
+from data_platform.utils.storage import BlueskyStorageManager
 
 if TYPE_CHECKING:
     from atproto import Client
@@ -239,6 +229,12 @@ def init_sync_metadata(
     )
 
 
+def _validate_bluesky_config(config: dict[str, Any]) -> None:
+    record_types: list[str] = config["record_types"]
+    if POSTS_RECORD_TYPE not in record_types:
+        raise ValueError(f"Unsupported record types for checkpoint sync: {record_types}")
+
+
 def run_sync_tasks(
     client: Client,
     ingestion_params: dict[str, Any],
@@ -249,129 +245,25 @@ def run_sync_tasks(
     *,
     filename: str,
 ) -> None:
-    """Run the checkpointed keyword loop: fetch, dedupe-append, and flush metadata per task.
-
-    Skips completed tasks on resume, stops early when max_posts is reached, and records failures
-    without aborting the full run.
-    """
-    max_posts_int = parse_max_posts(ingestion_params)
-    dedupe_session = DedupeSession(
-        DedupeConfig(
-            id_column="uri",
-            filename=filename,
-            include_prior_runs=policy_includes_prior_runs(
-                resolve_dedupe_policy(ingestion_params)
-            ),
-        )
-    )
-    dedupe_session.warm(storage, output_dir)
-
-    def process_task(task: BlueskyTask, entry: dict[str, Any]) -> None:
-        """Fetch one keyword, persist deduped rows, and update the task ledger entry."""
-        mark_task_in_progress(entry, storage, output_dir, metadata)
-
-        remaining: int | None = None
-        if max_posts_int is not None:
-            remaining = max_posts_int - int(metadata["row_count"])
-            if remaining <= 0:
-                return
-
-        try:
-            rows, stats = fetch_posts_for_keyword(
-                client,
-                ingestion_params,
-                task.query,
-                task_id=task.task_id,
-                sync_timestamp=str(metadata["sync_timestamp"]),
-                remaining_posts=remaining,
-            )
-        except Exception as exc:  # noqa: BLE001 — record and continue
-            mark_task_failed(entry, exc, task.task_id, storage, output_dir, metadata)
-            return
-
-        result = storage.append_deduped_records(
-            rows,
-            output_dir,
-            dedupe_session=dedupe_session,
-            filename=filename,
-        )
-        increment_duplicate_skip_counters(
-            metadata,
-            record_type=POSTS_RECORD_TYPE,
-            skipped=result.skipped,
-        )
-        metadata["row_count"] = len(dedupe_session.seen_ids)
-        mark_task_completed(
-            entry,
-            storage,
-            output_dir,
-            metadata,
-            entry_updates={
-                "pages_fetched": stats["pages_fetched"],
-                "rows_collected": stats["rows_collected"],
-                "hits_total": stats["hits_total"],
-            },
+    """Run the checkpointed keyword loop: fetch, dedupe-append, and flush metadata per task."""
+    def fetch_for_task(
+        fetch_client: Client,
+        task: BlueskyTask,
+        sync_timestamp: str,
+        remaining: int | None,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]] | None:
+        if remaining is not None and remaining <= 0:
+            return None
+        return fetch_posts_for_keyword(
+            fetch_client,
+            ingestion_params,
+            task.query,
+            task_id=task.task_id,
+            sync_timestamp=sync_timestamp,
+            remaining_posts=remaining,
         )
 
-        print(
-            f"sync_records: {task.task_id} -> {stats['rows_collected']} rows "
-            f"(appended {result.kept}, pages={stats['pages_fetched']})"
-        )
-
-    run_checkpointed_sync(
-        sync_tasks,
-        metadata,
-        storage,
-        output_dir,
-        record_cap=max_posts_int,
-        tqdm_desc="Syncing keywords",
-        process_task=process_task,
-    )
-
-
-def sync_records(
-    config_path: Path,
-    *,
-    run_dir_name: str | None = None,
-) -> Path:
-    """Load config, prepare or resume a raw run, and sync all keyword tasks to posts.csv.
-
-    Creates the dataset manifest on first run and returns the output run directory path.
-    """
-    config = load_yaml_config(config_path)
-    dataset_id = require_dataset_id(config, platform="bluesky")
-
-    # Create a temporary storage just to locate the dataset root for the manifest.
-    # The manifest must exist before we create the real storage so that format is
-    # read correctly (new datasets have no dataset.json yet).
-    ensure_dataset_manifest(
-        BlueskyStorageManager(StorageStage.RAW, dataset_id),
-        "bluesky",
-        dataset_id,
-        config,
-        config_path,
-    )
-    storage = BlueskyStorageManager(StorageStage.RAW, dataset_id)
-
-    ingestion_params = config["ingestion_params"]
-    sync_tasks = build_sync_tasks(ingestion_params)
-    record_types: list[str] = config["record_types"]
-
-    if POSTS_RECORD_TYPE not in record_types:
-        raise ValueError(f"Unsupported record types for checkpoint sync: {record_types}")
-
-    filename = storage.records_filename
-    client = init_bluesky_client()
-
-    output_dir, metadata = prepare_sync_run(
-        storage,
-        sync_tasks,
-        run_dir_name=run_dir_name,
-        init_metadata_fn=lambda ts: init_sync_metadata(config, config_path, ts, sync_tasks),
-        entity_label="keywords",
-    )
-
-    run_sync_tasks(
+    run_keyword_sync_tasks(
         client,
         ingestion_params,
         output_dir,
@@ -379,26 +271,80 @@ def sync_records(
         metadata,
         sync_tasks,
         filename=filename,
+        params=KeywordSyncParams(
+            id_column="uri",
+            record_type=POSTS_RECORD_TYPE,
+        ),
+        fetch_for_task=fetch_for_task,
     )
 
-    finalize_local_disk_sync(storage, output_dir, metadata)
 
-    total_rows = metadata["row_count"]
+def _bluesky_run_sync_tasks(
+    client: Client,
+    ingestion_params: dict[str, Any],
+    output_dir: Path,
+    storage: BlueskyStorageManager,
+    metadata: dict[str, Any],
+    sync_tasks: list[BlueskyTask],
+    *,
+    config: dict[str, Any],
+    config_path: Path,
+) -> None:
+    _ = config, config_path
+    run_sync_tasks(
+        client,
+        ingestion_params,
+        output_dir,
+        storage,
+        metadata,
+        sync_tasks,
+        filename=storage.records_filename,
+    )
+
+
+def _summarize_bluesky_run(metadata: dict[str, Any], output_dir: Path) -> None:
     print(
-        f"sync_records: wrote {total_rows} rows to {output_dir} (status={metadata['sync_status']})"
+        f"sync_records: wrote {metadata['row_count']} rows to {output_dir} "
+        f"(status={metadata['sync_status']})"
     )
-    return output_dir
+
+
+BLUESKY_SYNC_SPEC = SyncPlatformSpec(
+    platform="bluesky",
+    storage_cls=BlueskyStorageManager,
+    entity_label="keywords",
+    init_client=lambda: init_bluesky_client(),
+    build_sync_tasks=build_sync_tasks,
+    task_progress_builder=_initial_task_progress,
+    validate_config=_validate_bluesky_config,
+    run_sync_tasks=_bluesky_run_sync_tasks,
+    summarize_run=_summarize_bluesky_run,
+)
+
+
+def sync_records(
+    config_path: Path,
+    *,
+    run_dir_name: str | None = None,
+) -> Path:
+    """Load config, prepare or resume a raw run, and sync all keyword tasks to posts.csv."""
+    return sync_with_spec(
+        config_path,
+        run_dir_name=run_dir_name,
+        spec=BLUESKY_SYNC_SPEC,
+        config_loader=load_yaml_config,
+    )
 
 
 def main() -> None:
     """CLI entrypoint for sync_bluesky.py (--config, --resume, --run-dir)."""
-    run_sync_cli(
-        sync_records_fn=sync_records,
+    make_sync_cli(
+        BLUESKY_SYNC_SPEC,
         config_help=(
             "Ingestion YAML path relative to the repo root "
             "(e.g. data_platform/ingestion/configs/bluesky/mirrorview.yaml)"
         ),
-    )
+    )()
 
 
 if __name__ == "__main__":

--- a/data_platform/ingestion/sync_reddit.py
+++ b/data_platform/ingestion/sync_reddit.py
@@ -30,7 +30,7 @@ import prawcore.exceptions
 from praw.models.comment_forest import CommentForest
 
 from data_platform.ingestion.retry import retry_reddit_request
-from data_platform.ingestion.runner import SyncPlatformSpec, make_sync_cli, sync_with_spec
+from data_platform.ingestion.runner import SyncPlatformSpec, sync_with_spec
 from data_platform.ingestion.sync_checkpoint import (
     COMMENTS_DEDUPE_POLICY_KEY,
     DEDUPE_POLICY_KEY,
@@ -45,6 +45,7 @@ from data_platform.ingestion.sync_checkpoint import (
     resolve_dedupe_policy,
     resolve_limit_per_task,
     run_checkpointed_sync,
+    run_sync_cli,
 )
 from data_platform.ingestion.sync_clients import init_reddit_client
 from data_platform.utils.config_paths import load_yaml_config
@@ -642,7 +643,6 @@ REDDIT_SYNC_SPEC = SyncPlatformSpec(
     validate_config=_validate_reddit_config,
     run_sync_tasks=_reddit_run_sync_tasks,
     summarize_run=_summarize_reddit_run,
-    parse_record_cap=parse_max_comments,
     metadata_extra_fields={"post_row_count": 0},
 )
 
@@ -662,13 +662,13 @@ def sync_records(
 
 
 def main() -> None:
-    make_sync_cli(
-        REDDIT_SYNC_SPEC,
+    run_sync_cli(
+        sync_records_fn=sync_records,
         config_help=(
             "Ingestion YAML path relative to the repo root "
             "(e.g. data_platform/ingestion/configs/reddit/mirrorview.yaml)"
         ),
-    )()
+    )
 
 
 if __name__ == "__main__":

--- a/data_platform/ingestion/sync_reddit.py
+++ b/data_platform/ingestion/sync_reddit.py
@@ -30,25 +30,21 @@ import prawcore.exceptions
 from praw.models.comment_forest import CommentForest
 
 from data_platform.ingestion.retry import retry_reddit_request
+from data_platform.ingestion.runner import SyncPlatformSpec, make_sync_cli, sync_with_spec
 from data_platform.ingestion.sync_checkpoint import (
     COMMENTS_DEDUPE_POLICY_KEY,
     DEDUPE_POLICY_KEY,
     POSTS_DEDUPE_POLICY_KEY,
     TaskStatus,
     build_base_sync_metadata,
-    ensure_dataset_manifest,
-    finalize_local_disk_sync,
     increment_duplicate_skip_counters,
     mark_task_completed,
     mark_task_failed,
     mark_task_in_progress,
     parse_max_comments,
-    prepare_sync_run,
-    require_dataset_id,
     resolve_dedupe_policy,
     resolve_limit_per_task,
     run_checkpointed_sync,
-    run_sync_cli,
 )
 from data_platform.ingestion.sync_clients import init_reddit_client
 from data_platform.utils.config_paths import load_yaml_config
@@ -57,7 +53,7 @@ from data_platform.utils.deduplication import (
     DedupeSession,
     policy_includes_prior_runs,
 )
-from data_platform.utils.storage import RedditStorageManager, StorageStage
+from data_platform.utils.storage import RedditStorageManager
 
 COMMENTS_RECORD_TYPE = "reddit.comment"
 POSTS_RECORD_TYPE = "reddit.post"
@@ -591,46 +587,30 @@ def run_sync_tasks(
 load_config = load_yaml_config
 
 
-def sync_records(
-    config_path: Path,
-    *,
-    run_dir_name: str | None = None,
-) -> Path:
-    """Fetch Reddit records per config and write raw records plus metadata.
-
-    Creates the dataset manifest first so storage can read the declared format.
-    """
-    config = load_config(config_path)
-    dataset_id = require_dataset_id(config, platform="reddit")
-    ensure_dataset_manifest(
-        RedditStorageManager(StorageStage.RAW, dataset_id),
-        "reddit",
-        dataset_id,
-        config,
-        config_path,
-    )
-    comment_storage = RedditStorageManager(StorageStage.RAW, dataset_id)
-    post_storage = comment_storage.post_storage()
-
-    ingestion_params = config["ingestion_params"]
-    sync_tasks = build_sync_tasks(ingestion_params)
+def _validate_reddit_config(config: dict[str, Any]) -> None:
     record_types: list[str] = config["record_types"]
     include_comments = COMMENTS_RECORD_TYPE in record_types
     include_posts = POSTS_RECORD_TYPE in record_types
-
     if not include_comments and not include_posts:
         raise ValueError(f"Unsupported record types for checkpoint sync: {record_types}")
 
-    reddit = init_reddit_client()
 
-    output_dir, metadata = prepare_sync_run(
-        comment_storage,
-        sync_tasks,
-        run_dir_name=run_dir_name,
-        init_metadata_fn=lambda ts: init_sync_metadata(config, config_path, ts, sync_tasks),
-        entity_label="subreddits",
-    )
-
+def _reddit_run_sync_tasks(
+    reddit: praw.Reddit,
+    ingestion_params: dict[str, Any],
+    output_dir: Path,
+    comment_storage: RedditStorageManager,
+    metadata: dict[str, Any],
+    sync_tasks: list[RedditTask],
+    *,
+    config: dict[str, Any],
+    config_path: Path,
+) -> None:
+    _ = config_path
+    post_storage = comment_storage.post_storage()
+    record_types: list[str] = config["record_types"]
+    include_comments = COMMENTS_RECORD_TYPE in record_types
+    include_posts = POSTS_RECORD_TYPE in record_types
     run_sync_tasks(
         reddit,
         ingestion_params,
@@ -642,24 +622,53 @@ def sync_records(
         include_comments=include_comments,
         include_posts=include_posts,
     )
-    finalize_local_disk_sync(comment_storage, output_dir, metadata)
 
+
+def _summarize_reddit_run(metadata: dict[str, Any], output_dir: Path) -> None:
     print(
         f"sync_records: wrote {metadata['row_count']} comments and "
         f"{metadata['post_row_count']} posts to {output_dir} "
         f"(status={metadata['sync_status']})"
     )
-    return output_dir
+
+
+REDDIT_SYNC_SPEC = SyncPlatformSpec(
+    platform="reddit",
+    storage_cls=RedditStorageManager,
+    entity_label="subreddits",
+    init_client=lambda: init_reddit_client(),
+    build_sync_tasks=build_sync_tasks,
+    task_progress_builder=_initial_task_progress,
+    validate_config=_validate_reddit_config,
+    run_sync_tasks=_reddit_run_sync_tasks,
+    summarize_run=_summarize_reddit_run,
+    parse_record_cap=parse_max_comments,
+    metadata_extra_fields={"post_row_count": 0},
+)
+
+
+def sync_records(
+    config_path: Path,
+    *,
+    run_dir_name: str | None = None,
+) -> Path:
+    """Fetch Reddit records per config and write raw records plus metadata."""
+    return sync_with_spec(
+        config_path,
+        run_dir_name=run_dir_name,
+        spec=REDDIT_SYNC_SPEC,
+        config_loader=load_config,
+    )
 
 
 def main() -> None:
-    run_sync_cli(
-        sync_records_fn=sync_records,
+    make_sync_cli(
+        REDDIT_SYNC_SPEC,
         config_help=(
             "Ingestion YAML path relative to the repo root "
             "(e.g. data_platform/ingestion/configs/reddit/mirrorview.yaml)"
         ),
-    )
+    )()
 
 
 if __name__ == "__main__":

--- a/data_platform/ingestion/sync_twitter.py
+++ b/data_platform/ingestion/sync_twitter.py
@@ -21,32 +21,23 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from data_platform.ingestion.runner import (
+    KeywordSyncParams,
+    SyncPlatformSpec,
+    effective_limit_per_keyword,
+    make_sync_cli,
+    remaining_record_budget,
+    run_keyword_sync_tasks,
+    sync_with_spec,
+)
 from data_platform.ingestion.sync_checkpoint import (
     TaskStatus,
     build_base_sync_metadata,
-    ensure_dataset_manifest,
-    finalize_local_disk_sync,
-    increment_duplicate_skip_counters,
-    mark_task_completed,
-    mark_task_failed,
-    mark_task_in_progress,
-    parse_max_posts,
-    prepare_sync_run,
-    require_dataset_id,
-    resolve_dedupe_policy,
-    resolve_limit_per_task,
-    run_checkpointed_sync,
-    run_sync_cli,
 )
 from data_platform.ingestion.sync_clients import init_twitter_client
 from data_platform.ingestion.twitter_client import fetch_posts_for_keyword
 from data_platform.utils.config_paths import load_yaml_config
-from data_platform.utils.deduplication import (
-    DedupeConfig,
-    DedupeSession,
-    policy_includes_prior_runs,
-)
-from data_platform.utils.storage import StorageStage, TwitterStorageManager
+from data_platform.utils.storage import TwitterStorageManager
 
 TWEETS_RECORD_TYPE = "twitter.tweet"
 
@@ -99,16 +90,17 @@ def init_sync_metadata(
 
 
 def _effective_limit_per_keyword(ingestion_params: dict[str, Any], remaining: int | None) -> int:
-    per_keyword = resolve_limit_per_task(ingestion_params)
-    if remaining is None:
-        return per_keyword
-    return max(0, min(per_keyword, remaining))
+    return effective_limit_per_keyword(ingestion_params, remaining)
 
 
 def _remaining_post_budget(metadata: dict[str, Any], max_posts_int: int | None) -> int | None:
-    if max_posts_int is None:
-        return None
-    return max_posts_int - metadata["row_count"]
+    return remaining_record_budget(metadata, max_posts_int)
+
+
+def _validate_twitter_config(config: dict[str, Any]) -> None:
+    record_types = config["record_types"]
+    if not isinstance(record_types, list) or TWEETS_RECORD_TYPE not in record_types:
+        raise ValueError(f"Unsupported record types for checkpoint sync: {record_types}")
 
 
 def run_sync_tasks(
@@ -122,87 +114,84 @@ def run_sync_tasks(
     sync_timestamp: str,
     filename: str,
 ) -> None:
-    """Run the checkpointed keyword loop: fetch, dedupe-append, and flush metadata per task.
-
-    Skips completed tasks on resume, stops early when max_posts is reached, and records failures
-    without aborting the full run.
-
-    Parameters
-    ----------
-    filename
-        Records file name from ``storage.records_filename``, including the dataset format suffix.
-    """
-    max_posts_int = parse_max_posts(ingestion_params)
+    """Run the checkpointed keyword loop: fetch, dedupe-append, and flush metadata per task."""
     lang = str(ingestion_params.get("lang", "en"))
     exclude = list(ingestion_params.get("exclude", ["reply", "retweet", "quote"]))
-    dedupe_session = DedupeSession(
-        DedupeConfig(
-            id_column="tweet_id",
-            filename=filename,
-            include_prior_runs=policy_includes_prior_runs(
-                resolve_dedupe_policy(ingestion_params)
-            ),
-        )
-    )
-    dedupe_session.warm(storage, output_dir)
 
-    def process_task(task: TwitterTask, entry: dict[str, Any]) -> None:
-        mark_task_in_progress(entry, storage, output_dir, metadata)
-
-        limit = _effective_limit_per_keyword(
-            ingestion_params,
-            _remaining_post_budget(metadata, max_posts_int),
-        )
-        try:
-            rows, stats = fetch_posts_for_keyword(
-                client,
-                task.keyword,
-                limit=limit,
-                lang=lang,
-                exclude=exclude,
-                sync_timestamp=sync_timestamp,
-            )
-        except Exception as exc:  # noqa: BLE001 — record and continue
-            mark_task_failed(entry, exc, task.task_id, storage, output_dir, metadata)
-            return
-
-        result = storage.append_deduped_records(
-            rows,
-            output_dir,
-            dedupe_session=dedupe_session,
-            filename=filename,
-        )
-        increment_duplicate_skip_counters(
-            metadata,
-            record_type=TWEETS_RECORD_TYPE,
-            skipped=result.skipped,
-        )
-        metadata["row_count"] = len(dedupe_session.seen_ids)
-        mark_task_completed(
-            entry,
-            storage,
-            output_dir,
-            metadata,
-            entry_updates={
-                "pages_fetched": stats["pages_fetched"],
-                "rows_collected": stats["rows_collected"],
-            },
+    def fetch_for_task(
+        fetch_client: Any,
+        task: TwitterTask,
+        _sync_timestamp: str,
+        remaining: int | None,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        limit = _effective_limit_per_keyword(ingestion_params, remaining)
+        return fetch_posts_for_keyword(
+            fetch_client,
+            task.keyword,
+            limit=limit,
+            lang=lang,
+            exclude=exclude,
+            sync_timestamp=sync_timestamp,
         )
 
-        print(
-            f"sync_records: {task.task_id} -> {stats['rows_collected']} rows "
-            f"(appended {result.kept}, pages={stats['pages_fetched']})"
-        )
-
-    run_checkpointed_sync(
-        sync_tasks,
-        metadata,
-        storage,
+    run_keyword_sync_tasks(
+        client,
+        ingestion_params,
         output_dir,
-        record_cap=max_posts_int,
-        tqdm_desc="Syncing keywords",
-        process_task=process_task,
+        storage,
+        metadata,
+        sync_tasks,
+        filename=filename,
+        params=KeywordSyncParams(
+            id_column="tweet_id",
+            record_type=TWEETS_RECORD_TYPE,
+        ),
+        fetch_for_task=fetch_for_task,
     )
+
+
+def _twitter_run_sync_tasks(
+    client: Any,
+    ingestion_params: dict[str, Any],
+    output_dir: Path,
+    storage: TwitterStorageManager,
+    metadata: dict[str, Any],
+    sync_tasks: list[TwitterTask],
+    *,
+    config: dict[str, Any],
+    config_path: Path,
+) -> None:
+    _ = config, config_path
+    run_sync_tasks(
+        client,
+        ingestion_params,
+        output_dir,
+        storage,
+        metadata,
+        sync_tasks,
+        sync_timestamp=str(metadata["sync_timestamp"]),
+        filename=storage.records_filename,
+    )
+
+
+def _summarize_twitter_run(metadata: dict[str, Any], output_dir: Path) -> None:
+    print(
+        f"sync_records: wrote {metadata['row_count']} rows to {output_dir} "
+        f"(status={metadata['sync_status']})"
+    )
+
+
+TWITTER_SYNC_SPEC = SyncPlatformSpec(
+    platform="twitter",
+    storage_cls=TwitterStorageManager,
+    entity_label="keywords",
+    init_client=lambda: init_twitter_client(),
+    build_sync_tasks=build_sync_tasks,
+    task_progress_builder=_initial_task_progress,
+    validate_config=_validate_twitter_config,
+    run_sync_tasks=_twitter_run_sync_tasks,
+    summarize_run=_summarize_twitter_run,
+)
 
 
 load_config = load_yaml_config
@@ -213,75 +202,23 @@ def sync_records(
     *,
     run_dir_name: str | None = None,
 ) -> Path:
-    """Fetch Twitter records per config and write raw records plus metadata.
-
-    Creates the dataset manifest first so storage can read the declared format.
-    Stops before creating the Twitter client when ``record_types`` is missing
-    or does not include ``TWEETS_RECORD_TYPE``.
-
-    Raises
-    ------
-    KeyError
-        When the config has no ``record_types`` key.
-    ValueError
-        When ``record_types`` is empty or does not include
-        ``TWEETS_RECORD_TYPE``.
-    """
-    config = load_config(config_path)
-    dataset_id = require_dataset_id(config, platform="twitter")
-    ensure_dataset_manifest(
-        TwitterStorageManager(StorageStage.RAW, dataset_id),
-        "twitter",
-        dataset_id,
-        config,
+    """Fetch Twitter records per config and write raw records plus metadata."""
+    return sync_with_spec(
         config_path,
-    )
-    storage = TwitterStorageManager(StorageStage.RAW, dataset_id)
-
-    ingestion_params = config["ingestion_params"]
-    sync_tasks = build_sync_tasks(ingestion_params)
-    record_types = config["record_types"]
-    if not isinstance(record_types, list) or TWEETS_RECORD_TYPE not in record_types:
-        raise ValueError(f"Unsupported record types for checkpoint sync: {record_types}")
-    client = init_twitter_client()
-
-    output_dir, metadata = prepare_sync_run(
-        storage,
-        sync_tasks,
         run_dir_name=run_dir_name,
-        init_metadata_fn=lambda ts: init_sync_metadata(config, config_path, ts, sync_tasks),
-        entity_label="keywords",
+        spec=TWITTER_SYNC_SPEC,
+        config_loader=load_config,
     )
-    sync_timestamp = str(metadata["sync_timestamp"])
-    filename = storage.records_filename
-
-    run_sync_tasks(
-        client,
-        ingestion_params,
-        output_dir,
-        storage,
-        metadata,
-        sync_tasks,
-        sync_timestamp=sync_timestamp,
-        filename=filename,
-    )
-    finalize_local_disk_sync(storage, output_dir, metadata)
-
-    total_rows = metadata["row_count"]
-    print(
-        f"sync_records: wrote {total_rows} rows to {output_dir} (status={metadata['sync_status']})"
-    )
-    return output_dir
 
 
 def main() -> None:
-    run_sync_cli(
-        sync_records_fn=sync_records,
+    make_sync_cli(
+        TWITTER_SYNC_SPEC,
         config_help=(
             "Ingestion YAML path relative to the repo root "
             "(e.g. data_platform/ingestion/configs/twitter/mirrorview.yaml)"
         ),
-    )
+    )()
 
 
 if __name__ == "__main__":

--- a/data_platform/ingestion/sync_twitter.py
+++ b/data_platform/ingestion/sync_twitter.py
@@ -25,7 +25,6 @@ from data_platform.ingestion.runner import (
     KeywordSyncParams,
     SyncPlatformSpec,
     effective_limit_per_keyword,
-    make_sync_cli,
     remaining_record_budget,
     run_keyword_sync_tasks,
     sync_with_spec,
@@ -33,6 +32,7 @@ from data_platform.ingestion.runner import (
 from data_platform.ingestion.sync_checkpoint import (
     TaskStatus,
     build_base_sync_metadata,
+    run_sync_cli,
 )
 from data_platform.ingestion.sync_clients import init_twitter_client
 from data_platform.ingestion.twitter_client import fetch_posts_for_keyword
@@ -212,13 +212,13 @@ def sync_records(
 
 
 def main() -> None:
-    make_sync_cli(
-        TWITTER_SYNC_SPEC,
+    run_sync_cli(
+        sync_records_fn=sync_records,
         config_help=(
             "Ingestion YAML path relative to the repo root "
             "(e.g. data_platform/ingestion/configs/twitter/mirrorview.yaml)"
         ),
-    )()
+    )
 
 
 if __name__ == "__main__":

--- a/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
+++ b/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
@@ -91,7 +91,7 @@ Common operations include:
 
 ### Checkpoint and resume during sync
 
-Ingestion scripts in `data_platform/ingestion/` share helpers from `sync_checkpoint.py`. A sync run stores per-task progress in `raw/<timestamp>/metadata.json`. Each task (keyword, subreddit, or similar) has a status: `pending`, `in_progress`, `completed`, `failed`, or `skipped`.
+Ingestion scripts in `data_platform/ingestion/` share orchestration in `runner.py` (`SyncPlatformSpec`, `sync_with_spec`) and checkpoint helpers from `sync_checkpoint.py`. A sync run stores per-task progress in `raw/<timestamp>/metadata.json`. Each task (keyword, subreddit, or similar) has a status: `pending`, `in_progress`, `completed`, `failed`, or `skipped`.
 
 On startup, `find_resume_run_dir` looks for the newest raw run whose `sync_status` is not `completed`. Pass `--run-dir <timestamp>` to pin a specific run. `run_checkpointed_sync` skips tasks already marked `completed` or `skipped`.
 
@@ -120,7 +120,7 @@ Entrypoints:
 - `data_platform/ingestion/sync_twitter.py`
 - `data_platform/ingestion/sync_reddit.py`
 
-Each script loads a YAML config from `data_platform/ingestion/configs/<platform>/`, validates `dataset_id`, and writes raw records under `raw/<timestamp>/`. Bluesky uses `init_bluesky_client` from `sync_clients.py`. Twitter and Reddit use their own clients and retry helpers.
+Each script loads a YAML config from `data_platform/ingestion/configs/<platform>/`, validates `dataset_id`, and writes raw records under `raw/<timestamp>/`. Bluesky and Twitter share the keyword task loop in `runner.py`; Reddit keeps its own dual-output loop. Bluesky uses `init_bluesky_client` from `sync_clients.py`. Twitter and Reddit use their own clients and retry helpers.
 
 ### 2. Preprocess
 

--- a/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
+++ b/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
@@ -91,7 +91,7 @@ Common operations include:
 
 ### Checkpoint and resume during sync
 
-Ingestion scripts in `data_platform/ingestion/` share orchestration in `runner.py` (`SyncPlatformSpec`, `sync_with_spec`) and checkpoint helpers from `sync_checkpoint.py`. A sync run stores per-task progress in `raw/<timestamp>/metadata.json`. Each task (keyword, subreddit, or similar) has a status: `pending`, `in_progress`, `completed`, `failed`, or `skipped`.
+Bluesky, Twitter, and Reddit sync scripts start and finish a raw run through `sync_with_spec` in `runner.py`. They still use the checkpoint helpers in `sync_checkpoint.py`. A sync run stores per-task progress in `raw/<timestamp>/metadata.json`. Each task (keyword, subreddit, or similar) has a status: `pending`, `in_progress`, `completed`, `failed`, or `skipped`.
 
 On startup, `find_resume_run_dir` looks for the newest raw run whose `sync_status` is not `completed`. Pass `--run-dir <timestamp>` to pin a specific run. `run_checkpointed_sync` skips tasks already marked `completed` or `skipped`.
 
@@ -120,7 +120,7 @@ Entrypoints:
 - `data_platform/ingestion/sync_twitter.py`
 - `data_platform/ingestion/sync_reddit.py`
 
-Each script loads a YAML config from `data_platform/ingestion/configs/<platform>/`, validates `dataset_id`, and writes raw records under `raw/<timestamp>/`. Bluesky and Twitter share the keyword task loop in `runner.py`; Reddit keeps its own dual-output loop. Bluesky uses `init_bluesky_client` from `sync_clients.py`. Twitter and Reddit use their own clients and retry helpers.
+Each script loads a YAML config from `data_platform/ingestion/configs/<platform>/`, validates `dataset_id`, and writes raw records under `raw/<timestamp>/`. Bluesky and Twitter fetch one keyword task at a time through `run_keyword_sync_tasks` in `runner.py`. Reddit still writes posts and comments in its own loop in `sync_reddit.py`. Bluesky uses `init_bluesky_client` from `sync_clients.py`. Twitter and Reddit use their own clients and retry helpers.
 
 ### 2. Preprocess
 

--- a/tests/data_platform/ingestion/test_sync_twitter_checkpoint.py
+++ b/tests/data_platform/ingestion/test_sync_twitter_checkpoint.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from data_platform.ingestion import sync_twitter
+from data_platform.ingestion import runner as ingestion_runner
 from data_platform.ingestion.sync_checkpoint import parse_max_posts
 from data_platform.utils.dataset import ValidDataFormats, write_dataset_manifest
 from data_platform.utils.deduplication import PRIOR_RUN_POLICY
@@ -475,7 +476,7 @@ class TestSyncRecords:
     ) -> tuple[MagicMock, MagicMock]:
         monkeypatch.setattr(sync_twitter, "load_config", lambda path: config)
         monkeypatch.setattr(
-            sync_twitter, "ensure_dataset_manifest", lambda *args, **kwargs: None
+            ingestion_runner, "ensure_dataset_manifest", lambda *args, **kwargs: None
         )
         init_client = MagicMock(name="init_twitter_client")
         run_tasks = MagicMock(name="run_sync_tasks")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Bluesky, Twitter, and Reddit each repeated the same sync shell: load YAML, validate `dataset_id`, write the dataset manifest, prepare or resume a run, then finalize. Bluesky and Twitter also repeated the same per-keyword checkpoint loop. Later ingest changes were easy to apply on one platform and miss on another.

## Solution

Platform scripts now declare a `SyncPlatformSpec` and call `sync_with_spec`. Bluesky and Twitter share `run_keyword_sync_tasks`. Reddit uses the shared start and finish path only and still writes posts and comments in `sync_reddit.py`. CLI flags and YAML stay the same. Operator commands still call `sync_records`.

## Purpose

Give ingest the same spec plus runner shape as preprocess and curate, without a fetch plugin layer or a unified runner that branches on Reddit posts and comments. Checkpoint semantics and metadata shape are unchanged.

Closes #139.

## How to run

```bash
PYTHONPATH=. uv run pytest tests/data_platform/ingestion/
```

Expect 138 passing tests. Operator commands are still `sync_bluesky.py`, `sync_twitter.py`, and `sync_reddit.py` with `--config` and optional `--run-dir`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5597410-1834-4db4-89a6-ac5c33b42f15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5597410-1834-4db4-89a6-ac5c33b42f15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a shared ingestion workflow that supports checkpointed keyword syncing, deduplication, failure tracking, progress metadata, and record limits.
  - Standardized synchronization setup, validation, execution, storage finalization, and run summaries across Bluesky, Reddit, and Twitter.
  - Added platform-specific synchronization configurations and validation for supported record types.

- **Tests**
  - Updated Twitter checkpoint tests to reflect the shared ingestion workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->