### PR TITLE
refactor(ingestion): move Bluesky client logic into BlueskyClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-03
 
-1. Bluesky ingest now delegates all API client work to `BlueskyClient` in `data_platform/ingestion/integrations/bluesky.py`, so `sync_bluesky.py` focuses on orchestration and the client can be tested independently. [PR #143](https://github.com/METResearchGroup/mirrorView-task/pull/143)
+1. Bluesky ingestion now delegates all API client work to `BlueskyClient` in `data_platform/ingestion/integrations/bluesky.py`. `sync_bluesky.py` now handles sync logic only, and the client can be tested on its own. [PR #143](https://github.com/METResearchGroup/mirrorView-task/pull/143)
 
 ## 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2026-09-03
+
+1. Bluesky ingest now delegates all API client work to `BlueskyClient` in `data_platform/ingestion/integrations/bluesky.py`, so `sync_bluesky.py` focuses on orchestration and the client can be tested independently. [PR #143](https://github.com/METResearchGroup/mirrorView-task/pull/143)
+
 ## 2026-09-02
 
 1. Preprocess now owns length and English gates for stimuli-ready text. Reddit comments also need at least 30 characters. Ingest fetch filters are unchanged. [PR #132](https://github.com/METResearchGroup/mirrorView-task/pull/132)

--- a/data_platform/ingestion/integrations/bluesky.py
+++ b/data_platform/ingestion/integrations/bluesky.py
@@ -20,27 +20,27 @@ BLUESKY_PUBLIC_APPVIEW = "https://api.bsky.app"
 
 @dataclass(frozen=True)
 class BlueskyFetchResult:
-    """Rows collected for a keyword and the per-task stats produced by the fetch."""
+    """Holds the rows collected for a keyword and the per-task stats produced by the fetch."""
 
     rows: list[dict[str, Any]]
     stats: dict[str, Any]
 
 
 class BlueskyClient:
-    """Thin wrapper around atproto Client for Bluesky keyword search ingestion."""
+    """Wraps the atproto Client for Bluesky keyword search ingestion."""
 
     def __init__(self, client: Client | None = None) -> None:
         """Initialize from an optional existing Client, otherwise from environment vars.
 
-        When ``BLUESKY_HANDLE`` and ``BLUESKY_PASSWORD`` are both set, log in on the
-        default PDS. When both are unset, use the public AppView host, which serves
-        ``searchPosts`` without an account.
+        If ``BLUESKY_HANDLE`` and ``BLUESKY_PASSWORD`` are both set, log in to the
+        default personal data server (PDS). If both are unset, use the public AppView
+        host, which lets you call ``searchPosts`` without an account.
         """
         self._client = client if client is not None else _init_bluesky_client()
 
     @staticmethod
     def _resolve_search_author(ingestion_params: dict[str, Any]) -> str | None:
-        """Return ingestion_params author_filter when non-empty, else None."""
+        """Return the author_filter value from ingestion_params when it is non-empty, otherwise return None."""
         author = ingestion_params.get("author_filter")
         if author:
             return author
@@ -55,7 +55,7 @@ class BlueskyClient:
         page_limit: int,
         cursor: str | None = None,
     ) -> Any:
-        """Fetch one page of searchPosts results, optionally scoped to one author."""
+        """Fetch one page of searchPosts results, scoped to one author when author_filter is set."""
         base_params = {
             "q": query,
             "limit": page_limit,
@@ -71,7 +71,7 @@ class BlueskyClient:
         return self._client.app.bsky.feed.search_posts(params=base_params)  # type: ignore[arg-type]
 
     def _posts_to_rows(self, response: Any, sync_timestamp: str) -> list[dict[str, Any]]:
-        """Map a searchPosts API response to flat dict rows for CSV storage."""
+        """Convert a searchPosts API response to dictionary rows for CSV storage."""
         rows: list[dict[str, Any]] = []
         for post in response.posts:
             rkey = post.uri.split("/")[-1]
@@ -100,7 +100,7 @@ class BlueskyClient:
         sync_timestamp: str,
         remaining_posts: int | None = None,
     ) -> BlueskyFetchResult:
-        """Paginate searchPosts until limit rows are collected or results are exhausted."""
+        """Call searchPosts repeatedly until the configured row limit is reached or the results are exhausted."""
         from data_platform.ingestion.sync_checkpoint import resolve_limit_per_task
 
         target = resolve_limit_per_task(ingestion_params)
@@ -156,9 +156,9 @@ class BlueskyClient:
 def _init_bluesky_client() -> Client:
     """Return an atproto Client for Bluesky keyword search.
 
-    When ``BLUESKY_HANDLE`` and ``BLUESKY_PASSWORD`` are both set, log in on the
-    default PDS. When they are missing, use the public AppView host, which serves
-    ``searchPosts`` without an account.
+    When ``BLUESKY_HANDLE`` and ``BLUESKY_PASSWORD`` are both set, log in to the default
+    personal data server (PDS). If both are unset, use the public AppView host, which
+    lets you call ``searchPosts`` without an account.
     """
     from atproto import Client
 

--- a/data_platform/ingestion/integrations/bluesky.py
+++ b/data_platform/ingestion/integrations/bluesky.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from data_platform.ingestion.query_terms import quote_query_term
 from data_platform.ingestion.retry import retry_bluesky_request
 from lib.load_env_vars import EnvVarsContainer
 
@@ -152,11 +151,6 @@ class BlueskyClient:
             "hits_total": hits_total,
         }
         return BlueskyFetchResult(rows=rows, stats=stats)
-
-    @staticmethod
-    def quote_keyword(keyword: str) -> str:
-        """Return the quoted keyword for Bluesky search syntax."""
-        return quote_query_term(keyword)
 
 
 def _init_bluesky_client() -> Client:

--- a/data_platform/ingestion/integrations/bluesky.py
+++ b/data_platform/ingestion/integrations/bluesky.py
@@ -1,0 +1,183 @@
+"""Bluesky API client wrapper for data ingestion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from data_platform.ingestion.query_terms import quote_query_term
+from data_platform.ingestion.retry import retry_bluesky_request
+from lib.load_env_vars import EnvVarsContainer
+
+if TYPE_CHECKING:
+    from atproto import Client
+
+API_MAX_LIMIT = 100
+
+POSTS_RECORD_TYPE = "app.bsky.feed.post"
+
+BLUESKY_PUBLIC_APPVIEW = "https://api.bsky.app"
+
+
+@dataclass(frozen=True)
+class BlueskyFetchResult:
+    """Rows collected for a keyword and the per-task stats produced by the fetch."""
+
+    rows: list[dict[str, Any]]
+    stats: dict[str, Any]
+
+
+class BlueskyClient:
+    """Thin wrapper around atproto Client for Bluesky keyword search ingestion."""
+
+    def __init__(self, client: Client | None = None) -> None:
+        """Initialize from an optional existing Client, otherwise from environment vars.
+
+        When ``BLUESKY_HANDLE`` and ``BLUESKY_PASSWORD`` are both set, log in on the
+        default PDS. When both are unset, use the public AppView host, which serves
+        ``searchPosts`` without an account.
+        """
+        self._client = client if client is not None else _init_bluesky_client()
+
+    @staticmethod
+    def _resolve_search_author(ingestion_params: dict[str, Any]) -> str | None:
+        """Return ingestion_params author_filter when non-empty, else None."""
+        author = ingestion_params.get("author_filter")
+        if author:
+            return author
+        return None
+
+    @retry_bluesky_request()
+    def _search_posts_page(
+        self,
+        ingestion_params: dict[str, Any],
+        query: str,
+        *,
+        page_limit: int,
+        cursor: str | None = None,
+    ) -> Any:
+        """Fetch one page of searchPosts results, optionally scoped to one author."""
+        base_params = {
+            "q": query,
+            "limit": page_limit,
+            "sort": ingestion_params.get("sort", "latest"),
+        }
+        if cursor:
+            base_params["cursor"] = cursor
+        author = self._resolve_search_author(ingestion_params)
+        if author:
+            return self._client.app.bsky.feed.search_posts(
+                params={**base_params, "author": author},  # type: ignore[arg-type]
+            )
+        return self._client.app.bsky.feed.search_posts(params=base_params)  # type: ignore[arg-type]
+
+    def _posts_to_rows(self, response: Any, sync_timestamp: str) -> list[dict[str, Any]]:
+        """Map a searchPosts API response to flat dict rows for CSV storage."""
+        rows: list[dict[str, Any]] = []
+        for post in response.posts:
+            rkey = post.uri.split("/")[-1]
+            rows.append(
+                {
+                    "uri": post.uri,
+                    "url": f"https://bsky.app/profile/{post.author.handle}/post/{rkey}",
+                    "author_handle": post.author.handle,
+                    "text": post.record.text,  # type: ignore[union-attr]
+                    "created_at": post.record.created_at,  # type: ignore[union-attr]
+                    "like_count": post.like_count,
+                    "repost_count": post.repost_count,
+                    "reply_count": post.reply_count,
+                    "quote_count": post.quote_count,
+                    "sync_timestamp": sync_timestamp,
+                }
+            )
+        return rows
+
+    def fetch_posts_for_keyword(
+        self,
+        ingestion_params: dict[str, Any],
+        query: str,
+        *,
+        task_id: str,
+        sync_timestamp: str,
+        remaining_posts: int | None = None,
+    ) -> BlueskyFetchResult:
+        """Paginate searchPosts until limit rows are collected or results are exhausted."""
+        from data_platform.ingestion.sync_checkpoint import resolve_limit_per_task
+
+        target = resolve_limit_per_task(ingestion_params)
+        if remaining_posts is not None:
+            target = min(target, remaining_posts)
+        if target <= 0:
+            stats = {
+                "task_id": task_id,
+                "query_len": len(query),
+                "per_query_limit": target,
+                "pages_fetched": 0,
+                "rows_collected": 0,
+                "hits_total": None,
+            }
+            return BlueskyFetchResult(rows=[], stats=stats)
+
+        rows: list[dict[str, Any]] = []
+        cursor: str | None = None
+        pages_fetched = 0
+        hits_total: int | None = None
+
+        while len(rows) < target:
+            page_limit = min(target - len(rows), API_MAX_LIMIT)
+            response = self._search_posts_page(
+                ingestion_params,
+                query,
+                page_limit=page_limit,
+                cursor=cursor,
+            )
+            if pages_fetched == 0:
+                hits_total = response.hits_total
+            page_rows = self._posts_to_rows(response, sync_timestamp)
+            if not page_rows:
+                break
+            rows.extend(page_rows)
+            pages_fetched += 1
+            cursor = response.cursor
+            if not cursor:
+                break
+
+        rows = rows[:target]
+        stats = {
+            "task_id": task_id,
+            "query_len": len(query),
+            "per_query_limit": target,
+            "pages_fetched": pages_fetched,
+            "rows_collected": len(rows),
+            "hits_total": hits_total,
+        }
+        return BlueskyFetchResult(rows=rows, stats=stats)
+
+    @staticmethod
+    def quote_keyword(keyword: str) -> str:
+        """Return the quoted keyword for Bluesky search syntax."""
+        return quote_query_term(keyword)
+
+
+def _init_bluesky_client() -> Client:
+    """Return an atproto Client for Bluesky keyword search.
+
+    When ``BLUESKY_HANDLE`` and ``BLUESKY_PASSWORD`` are both set, log in on the
+    default PDS. When they are missing, use the public AppView host, which serves
+    ``searchPosts`` without an account.
+    """
+    from atproto import Client
+
+    handle = EnvVarsContainer.get_env_var("BLUESKY_HANDLE", required=False).strip()
+    password = EnvVarsContainer.get_env_var("BLUESKY_PASSWORD", required=False).strip()
+    if bool(handle) != bool(password):
+        raise ValueError(
+            "BLUESKY_HANDLE and BLUESKY_PASSWORD must both be set, or both be unset. "
+            "When both are unset, keyword search uses the public Bluesky API at "
+            f"{BLUESKY_PUBLIC_APPVIEW}."
+        )
+    if handle and password:
+        client = Client()
+        client.login(handle, password)
+        return client
+    return Client(BLUESKY_PUBLIC_APPVIEW)

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -1,28 +1,23 @@
-"""Sync Bluesky posts from YAML config to raw CSV storage.
+"""Sync Bluesky posts from YAML config to storage.
 
 Run from the repo root:
 
     PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py \\
         --config data_platform/ingestion/configs/bluesky/mirrorview.yaml
 
-Automatically resumes the most recent in-progress run for the dataset, or starts a new one.
-Pin a specific run to resume with --run-dir:
-
-    PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py \\
-        --config data_platform/ingestion/configs/bluesky/mirrorview_scale.yaml \\
-        --run-dir 2026_05_30-12:00:00
-
-Ingestion YAML must include `dataset_id` (e.g. bluesky_<uuid>).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+from data_platform.ingestion.integrations.bluesky import (
+    POSTS_RECORD_TYPE,
+    BlueskyClient,
+)
 from data_platform.ingestion.query_terms import quote_query_term
-from data_platform.ingestion.retry import retry_bluesky_request
 from data_platform.ingestion.sync_checkpoint import (
     TaskStatus,
     build_base_sync_metadata,
@@ -36,11 +31,9 @@ from data_platform.ingestion.sync_checkpoint import (
     prepare_sync_run,
     require_dataset_id,
     resolve_dedupe_policy,
-    resolve_limit_per_task,
     run_checkpointed_sync,
     run_sync_cli,
 )
-from data_platform.ingestion.sync_clients import init_bluesky_client
 from data_platform.utils.config_paths import load_yaml_config
 from data_platform.utils.deduplication import (
     DedupeConfig,
@@ -48,13 +41,6 @@ from data_platform.utils.deduplication import (
     policy_includes_prior_runs,
 )
 from data_platform.utils.storage import BlueskyStorageManager, StorageStage
-
-if TYPE_CHECKING:
-    from atproto import Client
-
-API_MAX_LIMIT = 100
-
-POSTS_RECORD_TYPE = "app.bsky.feed.post"
 
 
 @dataclass(frozen=True)
@@ -78,136 +64,6 @@ def build_sync_tasks(ingestion_params: dict[str, Any]) -> list[BlueskyTask]:
         keyword = raw.strip()
         items.append(BlueskyTask(task_id=keyword, query=quote_query_term(keyword)))
     return items
-
-
-def _posts_to_rows(response: Any, sync_timestamp: str) -> list[dict[str, Any]]:
-    """Map a searchPosts API response to flat dict rows for CSV storage.
-
-    Parameters
-    ----------
-    response
-        Bluesky searchPosts API response.
-    sync_timestamp
-        Run timestamp written onto each raw row.
-    """
-    rows: list[dict[str, Any]] = []
-    for post in response.posts:
-        rkey = post.uri.split("/")[-1]
-        rows.append(
-            {
-                "uri": post.uri,
-                "url": f"https://bsky.app/profile/{post.author.handle}/post/{rkey}",
-                "author_handle": post.author.handle,
-                "text": post.record.text,  # type: ignore[union-attr]
-                "created_at": post.record.created_at,  # type: ignore[union-attr]
-                "like_count": post.like_count,
-                "repost_count": post.repost_count,
-                "reply_count": post.reply_count,
-                "quote_count": post.quote_count,
-                "sync_timestamp": sync_timestamp,
-            }
-        )
-    return rows
-
-
-def _resolve_search_author(ingestion_params: dict[str, Any]) -> str | None:
-    """Return ingestion_params author_filter when non-empty, else None."""
-    author = ingestion_params.get("author_filter")
-    if author:
-        return author
-    return None
-
-
-@retry_bluesky_request()
-def _search_posts_page(
-    client: Client,
-    ingestion_params: dict[str, Any],
-    query: str,
-    *,
-    page_limit: int,
-    cursor: str | None = None,
-) -> Any:
-    """Fetch one page of searchPosts results, optionally scoped to one author."""
-    base_params = {
-        "q": query,
-        "limit": page_limit,
-        "sort": ingestion_params.get("sort", "latest"),
-    }
-    if cursor:
-        base_params["cursor"] = cursor
-    author = _resolve_search_author(ingestion_params)
-    if author:
-        return client.app.bsky.feed.search_posts(
-            params={**base_params, "author": author},  # type: ignore[arg-type]
-        )
-    return client.app.bsky.feed.search_posts(params=base_params)  # type: ignore[arg-type]
-
-
-def fetch_posts_for_keyword(
-    client: Client,
-    ingestion_params: dict[str, Any],
-    query: str,
-    *,
-    task_id: str,
-    sync_timestamp: str,
-    remaining_posts: int | None = None,
-) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    """Paginate searchPosts until limit rows are collected or results are exhausted.
-
-    Parameters
-    ----------
-    sync_timestamp
-        Run timestamp written onto each raw row.
-
-    Returns
-    -------
-    tuple[list[dict[str, Any]], dict[str, Any]]
-        Rows and per-task stats (pages fetched, hits_total from the first page, etc.).
-    """
-    target = resolve_limit_per_task(ingestion_params)
-    if remaining_posts is not None:
-        target = min(target, remaining_posts)
-    if target <= 0:
-        stats = {
-            "task_id": task_id,
-            "query_len": len(query),
-            "per_query_limit": target,
-            "pages_fetched": 0,
-            "rows_collected": 0,
-            "hits_total": None,
-        }
-        return [], stats
-    rows: list[dict[str, Any]] = []
-    cursor: str | None = None
-    pages_fetched = 0
-    hits_total: int | None = None
-
-    while len(rows) < target:
-        page_limit = min(target - len(rows), API_MAX_LIMIT)
-        response = _search_posts_page(
-            client, ingestion_params, query, page_limit=page_limit, cursor=cursor
-        )
-        if pages_fetched == 0:
-            hits_total = response.hits_total
-        page_rows = _posts_to_rows(response, sync_timestamp)
-        if not page_rows:
-            break
-        rows.extend(page_rows)
-        pages_fetched += 1
-        cursor = response.cursor
-        if not cursor:
-            break
-
-    rows = rows[:target]
-    stats = {
-        "task_id": task_id,
-        "query_len": len(query),
-        "per_query_limit": target,
-        "pages_fetched": pages_fetched,
-        "rows_collected": len(rows),
-        "hits_total": hits_total,
-    }
-    return rows, stats
 
 
 def _initial_task_progress(task: BlueskyTask) -> dict[str, Any]:
@@ -240,7 +96,7 @@ def init_sync_metadata(
 
 
 def run_sync_tasks(
-    client: Client,
+    client: BlueskyClient,
     ingestion_params: dict[str, Any],
     output_dir: Path,
     storage: BlueskyStorageManager,
@@ -277,8 +133,7 @@ def run_sync_tasks(
                 return
 
         try:
-            rows, stats = fetch_posts_for_keyword(
-                client,
+            result = client.fetch_posts_for_keyword(
                 ingestion_params,
                 task.query,
                 task_id=task.task_id,
@@ -289,8 +144,8 @@ def run_sync_tasks(
             mark_task_failed(entry, exc, task.task_id, storage, output_dir, metadata)
             return
 
-        result = storage.append_deduped_records(
-            rows,
+        storage_result = storage.append_deduped_records(
+            result.rows,
             output_dir,
             dedupe_session=dedupe_session,
             filename=filename,
@@ -298,7 +153,7 @@ def run_sync_tasks(
         increment_duplicate_skip_counters(
             metadata,
             record_type=POSTS_RECORD_TYPE,
-            skipped=result.skipped,
+            skipped=storage_result.skipped,
         )
         metadata["row_count"] = len(dedupe_session.seen_ids)
         mark_task_completed(
@@ -307,15 +162,15 @@ def run_sync_tasks(
             output_dir,
             metadata,
             entry_updates={
-                "pages_fetched": stats["pages_fetched"],
-                "rows_collected": stats["rows_collected"],
-                "hits_total": stats["hits_total"],
+                "pages_fetched": result.stats["pages_fetched"],
+                "rows_collected": result.stats["rows_collected"],
+                "hits_total": result.stats["hits_total"],
             },
         )
 
         print(
-            f"sync_records: {task.task_id} -> {stats['rows_collected']} rows "
-            f"(appended {result.kept}, pages={stats['pages_fetched']})"
+            f"sync_records: {task.task_id} -> {result.stats['rows_collected']} rows "
+            f"(appended {storage_result.kept}, pages={result.stats['pages_fetched']})"
         )
 
     run_checkpointed_sync(
@@ -361,7 +216,7 @@ def sync_records(
         raise ValueError(f"Unsupported record types for checkpoint sync: {record_types}")
 
     filename = storage.records_filename
-    client = init_bluesky_client()
+    client = BlueskyClient()
 
     output_dir, metadata = prepare_sync_run(
         storage,

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -1,4 +1,4 @@
-"""Sync Bluesky posts from YAML config to storage.
+"""Sync Bluesky posts from a YAML config to storage.
 
 Run from the repo root:
 
@@ -45,14 +45,17 @@ from data_platform.utils.storage import BlueskyStorageManager, StorageStage
 
 @dataclass(frozen=True)
 class BlueskyTask:
-    """One checkpointed search unit: a stable task ID and the API query string."""
+    """One keyword search task tracked by the checkpoint system.
+
+    It stores a stable task ID and the API query string.
+    """
 
     task_id: str
     query: str
 
 
 def build_sync_tasks(ingestion_params: dict[str, Any]) -> list[BlueskyTask]:
-    """Build one checkpoint task per entry in ingestion_params.keywords."""
+    """Build one sync task for each entry in ingestion_params.keywords."""
     keywords = ingestion_params.get("keywords")
     if not isinstance(keywords, list) or not keywords:
         raise ValueError("ingestion_params must include 'keywords' as a non-empty list of strings")
@@ -67,7 +70,7 @@ def build_sync_tasks(ingestion_params: dict[str, Any]) -> list[BlueskyTask]:
 
 
 def _initial_task_progress(task: BlueskyTask) -> dict[str, Any]:
-    """Return the pending task-ledger entry written into run metadata at sync start."""
+    """Return the pending entry for the task ledger that is written into run metadata at sync start."""
     return {
         "status": TaskStatus.PENDING.value,
         "kind": "bluesky",
@@ -85,7 +88,7 @@ def init_sync_metadata(
     sync_timestamp: str,
     sync_tasks: list[BlueskyTask],
 ) -> dict[str, Any]:
-    """Build the initial metadata.json payload for a new raw run directory."""
+    """Return the initial metadata.json payload for a new raw run directory."""
     return build_base_sync_metadata(
         config,
         config_path,
@@ -105,10 +108,11 @@ def run_sync_tasks(
     *,
     filename: str,
 ) -> None:
-    """Run the checkpointed keyword loop: fetch, dedupe-append, and flush metadata per task.
+    """Run the keyword loop for each checkpointed task.
 
-    Skips completed tasks on resume, stops early when max_posts is reached, and records failures
-    without aborting the full run.
+    For each task, fetch rows for the keyword. Append the deduped rows, and flush the metadata.
+    On resume, skip tasks that are already completed. Stop early when max_posts is reached.
+    Record failures for each task without aborting the whole run.
     """
     max_posts_int = parse_max_posts(ingestion_params)
     dedupe_session = DedupeSession(
@@ -123,7 +127,7 @@ def run_sync_tasks(
     dedupe_session.warm(storage, output_dir)
 
     def process_task(task: BlueskyTask, entry: dict[str, Any]) -> None:
-        """Fetch one keyword, persist deduped rows, and update the task ledger entry."""
+        """Fetch rows for one keyword. Persist the deduped rows, and update the task ledger entry."""
         mark_task_in_progress(entry, storage, output_dir, metadata)
 
         remaining: int | None = None
@@ -140,7 +144,7 @@ def run_sync_tasks(
                 sync_timestamp=str(metadata["sync_timestamp"]),
                 remaining_posts=remaining,
             )
-        except Exception as exc:  # noqa: BLE001 — record and continue
+        except Exception as exc:  # noqa: BLE001  # record and continue
             mark_task_failed(entry, exc, task.task_id, storage, output_dir, metadata)
             return
 
@@ -189,16 +193,17 @@ def sync_records(
     *,
     run_dir_name: str | None = None,
 ) -> Path:
-    """Load config, prepare or resume a raw run, and sync all keyword tasks to posts.csv.
+    """Load the config and prepare or resume a raw run.
 
-    Creates the dataset manifest on first run and returns the output run directory path.
+    Then sync all keyword tasks to posts.csv. Creates the dataset manifest on first run
+    and returns the output run directory path.
     """
     config = load_yaml_config(config_path)
     dataset_id = require_dataset_id(config, platform="bluesky")
 
-    # Create a temporary storage just to locate the dataset root for the manifest.
-    # The manifest must exist before we create the real storage so that format is
-    # read correctly (new datasets have no dataset.json yet).
+    # Create a temporary storage manager just to locate the dataset root for the manifest.
+    # The manifest must exist before we create the real storage manager.
+    # New datasets have no dataset.json yet, so the manager cannot read the format without it.
     ensure_dataset_manifest(
         BlueskyStorageManager(StorageStage.RAW, dataset_id),
         "bluesky",
@@ -246,12 +251,12 @@ def sync_records(
 
 
 def main() -> None:
-    """CLI entrypoint for sync_bluesky.py (--config, --resume, --run-dir)."""
+    """CLI entrypoint for sync_bluesky.py. Supports --config, --resume, and --run-dir."""
     run_sync_cli(
         sync_records_fn=sync_records,
         config_help=(
-            "Ingestion YAML path relative to the repo root "
-            "(e.g. data_platform/ingestion/configs/bluesky/mirrorview.yaml)"
+            "Ingestion YAML path relative to the repo root. "
+            "For example, data_platform/ingestion/configs/bluesky/mirrorview.yaml."
         ),
     )
 

--- a/data_platform/ingestion/sync_clients.py
+++ b/data_platform/ingestion/sync_clients.py
@@ -9,7 +9,6 @@ from lib.load_env_vars import EnvVarsContainer
 if TYPE_CHECKING:
     import praw
     import tweepy
-    from atproto import Client
 
 
 def init_reddit_client() -> praw.Reddit:
@@ -28,33 +27,6 @@ def init_reddit_client() -> praw.Reddit:
         password=password,
         user_agent=user_agent,
     )
-
-
-BLUESKY_PUBLIC_APPVIEW = "https://api.bsky.app"
-
-
-def init_bluesky_client() -> Client:
-    """Return an atproto Client for Bluesky keyword search.
-
-    When BLUESKY_HANDLE and BLUESKY_PASSWORD are both set, log in on the
-    default PDS. When they are missing, use the public AppView host, which
-    serves searchPosts without an account.
-    """
-    from atproto import Client
-
-    handle = EnvVarsContainer.get_env_var("BLUESKY_HANDLE", required=False).strip()
-    password = EnvVarsContainer.get_env_var("BLUESKY_PASSWORD", required=False).strip()
-    if bool(handle) != bool(password):
-        raise ValueError(
-            "BLUESKY_HANDLE and BLUESKY_PASSWORD must both be set, or both be unset. "
-            "When both are unset, keyword search uses the public Bluesky API at "
-            f"{BLUESKY_PUBLIC_APPVIEW}."
-        )
-    if handle and password:
-        client = Client()
-        client.login(handle, password)
-        return client
-    return Client(BLUESKY_PUBLIC_APPVIEW)
 
 
 def init_twitter_client() -> tweepy.Client:

--- a/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
+++ b/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
@@ -120,7 +120,7 @@ Entrypoints:
 - `data_platform/ingestion/sync_twitter.py`
 - `data_platform/ingestion/sync_reddit.py`
 
-Each script loads a YAML config from `data_platform/ingestion/configs/<platform>/`, validates `dataset_id`, and writes raw records under `raw/<timestamp>/`. Bluesky uses `BlueskyClient` from `data_platform/ingestion/integrations/bluesky.py`. Twitter and Reddit use their own clients and retry helpers.
+Each script loads a YAML config from `data_platform/ingestion/configs/<platform>/`, validates `dataset_id`, and writes raw records under `raw/<timestamp>/`. Bluesky uses `BlueskyClient` from `data_platform/ingestion/integrations/bluesky.py`. Twitter and Reddit use their own client helpers in `data_platform/ingestion/sync_clients.py`.
 
 ### 2. Preprocess
 

--- a/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
+++ b/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
@@ -120,7 +120,7 @@ Entrypoints:
 - `data_platform/ingestion/sync_twitter.py`
 - `data_platform/ingestion/sync_reddit.py`
 
-Each script loads a YAML config from `data_platform/ingestion/configs/<platform>/`, validates `dataset_id`, and writes raw records under `raw/<timestamp>/`. Bluesky uses `init_bluesky_client` from `sync_clients.py`. Twitter and Reddit use their own clients and retry helpers.
+Each script loads a YAML config from `data_platform/ingestion/configs/<platform>/`, validates `dataset_id`, and writes raw records under `raw/<timestamp>/`. Bluesky uses `BlueskyClient` from `data_platform/ingestion/integrations/bluesky.py`. Twitter and Reddit use their own clients and retry helpers.
 
 ### 2. Preprocess
 

--- a/tests/data_platform/ingestion/conftest.py
+++ b/tests/data_platform/ingestion/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
-from data_platform.ingestion import sync_bluesky
+from data_platform.ingestion.integrations.bluesky import POSTS_RECORD_TYPE
 from data_platform.utils.deduplication import PRIOR_RUN_POLICY
 from tests.data_platform.constants import VALID_DATASET_ID
 
@@ -34,7 +34,7 @@ def minimal_sync_config() -> dict[str, Any]:
         "name": "test",
         "description": "test",
         "date": "2026-05-30",
-        "record_types": [sync_bluesky.POSTS_RECORD_TYPE],
+        "record_types": [POSTS_RECORD_TYPE],
         "ingestion_params": {
             "dedupe_policy": ["current_run", PRIOR_RUN_POLICY],
             "limit_per_task": 2,

--- a/tests/data_platform/ingestion/test_raw_row_timestamps.py
+++ b/tests/data_platform/ingestion/test_raw_row_timestamps.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from data_platform.ingestion.sync_bluesky import fetch_posts_for_keyword
+from data_platform.ingestion.integrations.bluesky import BlueskyClient
 from data_platform.ingestion.sync_reddit import comment_to_row, submission_to_row
 from data_platform.ingestion.twitter_client import tweet_to_row
 from data_platform.models.sync import (
@@ -76,7 +76,7 @@ def _tweet(*, created_at: datetime | None) -> SimpleNamespace:
 
 
 class TestFetchPostsForKeyword:
-    """Tests for fetch_posts_for_keyword()."""
+    """Tests for BlueskyClient.fetch_posts_for_keyword()."""
 
     def test_writes_created_at_and_sync_timestamp(
         self, monkeypatch: pytest.MonkeyPatch
@@ -85,12 +85,13 @@ class TestFetchPostsForKeyword:
         ingestion_params = {"limit_per_task": 1, "sort": "latest"}
         response = mock_search_response([mock_post("at://did:plc:ex/app.bsky.feed.post/a1")])
         monkeypatch.setattr(
-            "data_platform.ingestion.sync_bluesky._search_posts_page",
+            BlueskyClient,
+            "_search_posts_page",
             lambda *_args, **_kwargs: response,
         )
 
-        rows, _stats = fetch_posts_for_keyword(
-            MagicMock(),
+        client = BlueskyClient(client=MagicMock())
+        result = client.fetch_posts_for_keyword(
             ingestion_params,
             "alpha",
             task_id="alpha",
@@ -98,9 +99,9 @@ class TestFetchPostsForKeyword:
         )
 
         expected_created_at = "2026-05-30T00:00:00.000Z"
-        assert rows[0]["created_at"] == expected_created_at
-        assert rows[0]["sync_timestamp"] == SYNC_TIMESTAMP
-        SyncBlueskyPostModel.model_validate(rows[0])
+        assert result.rows[0]["created_at"] == expected_created_at
+        assert result.rows[0]["sync_timestamp"] == SYNC_TIMESTAMP
+        SyncBlueskyPostModel.model_validate(result.rows[0])
 
 
 class TestSubmissionToRow:

--- a/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py
+++ b/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from data_platform.ingestion import sync_bluesky
+from data_platform.ingestion.integrations.bluesky import BlueskyClient
 from data_platform.ingestion.sync_checkpoint import validate_tasks_for_resume
 from data_platform.utils.storage import BlueskyStorageManager, StorageStage
 from tests.data_platform.conftest import make_ingestion_row
@@ -15,6 +16,11 @@ from tests.data_platform.ingestion.conftest import (
     mock_post,
     mock_search_response,
 )
+
+
+def make_bluesky_client() -> BlueskyClient:
+    """Return a BlueskyClient with a no-op internal atproto Client."""
+    return BlueskyClient(client=MagicMock())
 
 
 def test_build_sync_tasks_requires_keywords_list() -> None:
@@ -68,8 +74,8 @@ def test_run_sync_tasks_appends_per_keyword(
     }
 
     def fake_search(
-        client: Any,
-        fetch_cfg: dict[str, Any],
+        _self: Any,
+        _fetch_cfg: dict[str, Any],
         query: str,
         *,
         page_limit: int,
@@ -77,10 +83,10 @@ def test_run_sync_tasks_appends_per_keyword(
     ):
         return mock_search_response(posts_by_query[query])
 
-    monkeypatch.setattr(sync_bluesky, "_search_posts_page", fake_search)
+    monkeypatch.setattr(BlueskyClient, "_search_posts_page", fake_search)
 
     sync_bluesky.run_sync_tasks(
-        MagicMock(),
+        make_bluesky_client(),
         ingestion_params,
         run_dir,
         storage,
@@ -127,8 +133,8 @@ def test_run_sync_tasks_skips_ids_from_other_dataset(
     )
 
     def fake_search(
-        client: Any,
-        fetch_cfg: dict[str, Any],
+        _self: Any,
+        _fetch_cfg: dict[str, Any],
         query: str,
         *,
         page_limit: int,
@@ -141,10 +147,10 @@ def test_run_sync_tasks_skips_ids_from_other_dataset(
             ]
         )
 
-    monkeypatch.setattr(sync_bluesky, "_search_posts_page", fake_search)
+    monkeypatch.setattr(BlueskyClient, "_search_posts_page", fake_search)
 
     sync_bluesky.run_sync_tasks(
-        MagicMock(),
+        make_bluesky_client(),
         ingestion_params,
         run_dir,
         storage,
@@ -195,8 +201,8 @@ def test_run_sync_tasks_respects_current_run_only_policy(
     )
 
     def fake_search(
-        client: Any,
-        fetch_cfg: dict[str, Any],
+        _self: Any,
+        _fetch_cfg: dict[str, Any],
         query: str,
         *,
         page_limit: int,
@@ -204,10 +210,10 @@ def test_run_sync_tasks_respects_current_run_only_policy(
     ):
         return mock_search_response([mock_post("at://did:plc:ex/app.bsky.feed.post/old")])
 
-    monkeypatch.setattr(sync_bluesky, "_search_posts_page", fake_search)
+    monkeypatch.setattr(BlueskyClient, "_search_posts_page", fake_search)
 
     sync_bluesky.run_sync_tasks(
-        MagicMock(),
+        make_bluesky_client(),
         ingestion_params,
         run_dir,
         storage,
@@ -239,8 +245,8 @@ def test_run_sync_tasks_dedupes_within_run(
     duplicate_uri = "at://did:plc:ex/app.bsky.feed.post/dup"
 
     def fake_search(
-        client: Any,
-        fetch_cfg: dict[str, Any],
+        _self: Any,
+        _fetch_cfg: dict[str, Any],
         query: str,
         *,
         page_limit: int,
@@ -248,10 +254,10 @@ def test_run_sync_tasks_dedupes_within_run(
     ):
         return mock_search_response([mock_post(duplicate_uri)])
 
-    monkeypatch.setattr(sync_bluesky, "_search_posts_page", fake_search)
+    monkeypatch.setattr(BlueskyClient, "_search_posts_page", fake_search)
 
     sync_bluesky.run_sync_tasks(
-        MagicMock(),
+        make_bluesky_client(),
         ingestion_params,
         run_dir,
         storage,
@@ -298,8 +304,8 @@ def test_resume_skips_completed_tasks(
     calls: list[str] = []
 
     def fake_search(
-        client: Any,
-        fetch_cfg: dict[str, Any],
+        _self: Any,
+        _fetch_cfg: dict[str, Any],
         query: str,
         *,
         page_limit: int,
@@ -308,11 +314,11 @@ def test_resume_skips_completed_tasks(
         calls.append(query)
         return mock_search_response([mock_post("at://did:plc:ex/app.bsky.feed.post/b1")])
 
-    monkeypatch.setattr(sync_bluesky, "_search_posts_page", fake_search)
+    monkeypatch.setattr(BlueskyClient, "_search_posts_page", fake_search)
 
     resumed_metadata = storage.load_run_metadata(run_dir)
     sync_bluesky.run_sync_tasks(
-        MagicMock(),
+        make_bluesky_client(),
         ingestion_params,
         run_dir,
         storage,
@@ -360,8 +366,8 @@ def test_resume_dedupes_against_records_from_completed_tasks(
     storage.write_run_metadata_atomic(run_dir, metadata)
 
     def fake_search(
-        client: Any,
-        fetch_cfg: dict[str, Any],
+        _self: Any,
+        _fetch_cfg: dict[str, Any],
         query: str,
         *,
         page_limit: int,
@@ -374,11 +380,11 @@ def test_resume_dedupes_against_records_from_completed_tasks(
             ]
         )
 
-    monkeypatch.setattr(sync_bluesky, "_search_posts_page", fake_search)
+    monkeypatch.setattr(BlueskyClient, "_search_posts_page", fake_search)
 
     resumed_metadata = storage.load_run_metadata(run_dir)
     sync_bluesky.run_sync_tasks(
-        MagicMock(),
+        make_bluesky_client(),
         ingestion_params,
         run_dir,
         storage,
@@ -427,8 +433,8 @@ def test_run_sync_tasks_caps_fetch_by_remaining_max_posts(
     )
 
     def fake_search(
-        client: Any,
-        fetch_cfg: dict[str, Any],
+        _self: Any,
+        _fetch_cfg: dict[str, Any],
         query: str,
         *,
         page_limit: int,
@@ -442,10 +448,10 @@ def test_run_sync_tasks_caps_fetch_by_remaining_max_posts(
             ]
         )
 
-    monkeypatch.setattr(sync_bluesky, "_search_posts_page", fake_search)
+    monkeypatch.setattr(BlueskyClient, "_search_posts_page", fake_search)
 
     sync_bluesky.run_sync_tasks(
-        MagicMock(),
+        make_bluesky_client(),
         ingestion_params,
         run_dir,
         storage,
@@ -460,13 +466,13 @@ def test_run_sync_tasks_caps_fetch_by_remaining_max_posts(
 
 
 class TestResolveSearchAuthor:
-    """Tests for _resolve_search_author."""
+    """Tests for BlueskyClient._resolve_search_author."""
 
     def test_returns_author_filter(self) -> None:
         ingestion_params = {"author_filter": "alice.bsky.social"}
         expected = "alice.bsky.social"
 
-        result = sync_bluesky._resolve_search_author(ingestion_params)
+        result = BlueskyClient._resolve_search_author(ingestion_params)
 
         assert result == expected
 
@@ -482,18 +488,18 @@ class TestResolveSearchAuthor:
         self,
         ingestion_params: dict[str, Any],
     ) -> None:
-        result = sync_bluesky._resolve_search_author(ingestion_params)
+        result = BlueskyClient._resolve_search_author(ingestion_params)
 
         expected = None
         assert result == expected
 
 
 class TestSearchPostsPage:
-    """Tests for _search_posts_page."""
+    """Tests for BlueskyClient._search_posts_page."""
 
-    def _client_with_empty_search(self) -> MagicMock:
-        client = MagicMock()
-        client.app.bsky.feed.search_posts.return_value = mock_search_response([])
+    def _client_with_empty_search(self) -> BlueskyClient:
+        client = make_bluesky_client()
+        client._client.app.bsky.feed.search_posts.return_value = mock_search_response([])
         return client
 
     def test_passes_author_filter_as_search_author(self) -> None:
@@ -501,11 +507,11 @@ class TestSearchPostsPage:
         ingestion_params = {"sort": "latest", "author_filter": "alice.bsky.social"}
         expected_author = "alice.bsky.social"
 
-        sync_bluesky._search_posts_page(
-            client, ingestion_params, "alpha", page_limit=10
+        client._search_posts_page(
+            ingestion_params, "alpha", page_limit=10
         )
 
-        params = client.app.bsky.feed.search_posts.call_args.kwargs["params"]
+        params = client._client.app.bsky.feed.search_posts.call_args.kwargs["params"]
         result = params.get("author")
         assert result == expected_author
         assert params["q"] == "alpha"
@@ -515,18 +521,18 @@ class TestSearchPostsPage:
         client = self._client_with_empty_search()
         ingestion_params = {"sort": "latest"}
 
-        sync_bluesky._search_posts_page(
-            client, ingestion_params, "alpha", page_limit=10
+        client._search_posts_page(
+            ingestion_params, "alpha", page_limit=10
         )
 
-        params = client.app.bsky.feed.search_posts.call_args.kwargs["params"]
+        params = client._client.app.bsky.feed.search_posts.call_args.kwargs["params"]
         result = "author" in params
         expected = False
         assert result == expected
 
 
 class TestFetchPostsForKeywordLimitPerTask:
-    """Tests that fetch_posts_for_keyword reads limit_per_task."""
+    """Tests that BlueskyClient.fetch_posts_for_keyword reads limit_per_task."""
 
     def test_uses_limit_per_task(
         self,
@@ -536,8 +542,8 @@ class TestFetchPostsForKeywordLimitPerTask:
         expected = 1
 
         def fake_search(
-            client: Any,
-            fetch_cfg: dict[str, Any],
+            _self: Any,
+            _fetch_cfg: dict[str, Any],
             query: str,
             *,
             page_limit: int,
@@ -550,15 +556,13 @@ class TestFetchPostsForKeywordLimitPerTask:
                 ]
             )
 
-        monkeypatch.setattr(sync_bluesky, "_search_posts_page", fake_search)
+        monkeypatch.setattr(BlueskyClient, "_search_posts_page", fake_search)
 
-        rows, _stats = sync_bluesky.fetch_posts_for_keyword(
-            MagicMock(),
+        result = make_bluesky_client().fetch_posts_for_keyword(
             ingestion_params,
             "alpha",
             task_id="alpha",
             sync_timestamp="2026_05_30-10:00:00",
         )
-        result = len(rows)
 
-        assert result == expected
+        assert len(result.rows) == expected


### PR DESCRIPTION
## Problem

Bluesky client code for authentication, search, pagination, and row mapping was mixed with sync logic in `sync_bluesky.py` and `sync_clients.py`. The client could not be tested on its own because it depended on checkpoint logic.

## Solution

Add `BlueskyClient` in `data_platform/ingestion/integrations/bluesky.py` and move all Bluesky API operations into it:

- `init_bluesky_client` now lives inside the client as `_init_bluesky_client`.
- `_search_posts_page`, `_resolve_search_author`, `_posts_to_rows`, and `fetch_posts_for_keyword` are now methods on `BlueskyClient`.
- `fetch_posts_for_keyword` returns a `BlueskyFetchResult` dataclass.
- `sync_bluesky.py` now handles sync logic only and delegates fetching to `BlueskyClient`.
- `sync_clients.py` no longer contains Bluesky-specific initialization.

## Purpose

Separate platform-specific API details from sync logic so the Bluesky client can be tested and reused on its own. Twitter and Reddit clients stay unchanged in `sync_clients.py`.

## How to run

```bash
PYTHONPATH=. uv run pytest tests/data_platform -q
```

Expected: 368 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Bluesky post ingestion with support for authenticated and public access.
  - Added keyword search with author filtering, pagination, retry handling, and configurable post limits.
  - Added ingestion statistics for collected results.
- **Bug Fixes**
  - Improved validation of Bluesky configuration by rejecting incomplete credential settings.
  - Improved reliability when retrieving results across multiple API pages.
- **Tests**
  - Expanded coverage for author filtering, pagination, task limits, timestamps, and checkpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->