### PR TITLE
Finish making ingest, preprocess, and feature unlabeled skip share one skip set session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2026-09-03
 
 1. Raw ingest now writes a stable `record_id` on every row using the same `{integration}_{id}` keys as study stimuli (`bluesky_{sha256(uri)}`, `twitter_{tweet_id}`, `reddit_{post_reddit_id}_{comment_id}`). [PR #138](https://github.com/METResearchGroup/mirrorView-task/pull/138)
-2. Ingest, preprocess, and feature unlabeled skip now share one skip-set session. Warmup names are gone, and known ids load as this-run or all-runs before drop, persist, or collapse. [PR #144](https://github.com/METResearchGroup/mirrorView-task/pull/144)
+2. Ingest, preprocess, and feature unlabeled skip now share one skip set session. The warmup names are gone. Callers load known ids for this run or for all runs before they drop, persist, or collapse. [PR #144](https://github.com/METResearchGroup/mirrorView-task/pull/144)
 
 ## 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-09-03
 
 1. Raw ingest now writes a stable `record_id` on every row using the same `{integration}_{id}` keys as study stimuli (`bluesky_{sha256(uri)}`, `twitter_{tweet_id}`, `reddit_{post_reddit_id}_{comment_id}`). [PR #138](https://github.com/METResearchGroup/mirrorView-task/pull/138)
+2. Ingest, preprocess, and feature unlabeled skip now share one skip-set session. Warmup names are gone, and known ids load as this-run or all-runs before drop, persist, or collapse. [PR #144](https://github.com/METResearchGroup/mirrorView-task/pull/144)
 
 ## 2026-09-02
 

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -259,12 +259,12 @@ def run_sync_tasks(
         DedupeConfig(
             id_column="uri",
             filename=filename,
-            include_prior_runs=policy_includes_prior_runs(
-                resolve_dedupe_policy(ingestion_params)
-            ),
         )
     )
-    dedupe_session.warm(storage, output_dir)
+    if policy_includes_prior_runs(resolve_dedupe_policy(ingestion_params)):
+        dedupe_session.load_seen_ids_from_all_runs(storage)
+    else:
+        dedupe_session.load_seen_ids(storage, output_dir)
 
     def process_task(task: BlueskyTask, entry: dict[str, Any]) -> None:
         """Fetch one keyword, persist deduped rows, and update the task ledger entry."""

--- a/data_platform/ingestion/sync_reddit.py
+++ b/data_platform/ingestion/sync_reddit.py
@@ -410,27 +410,31 @@ def _open_reddit_dedupe_sessions(
             DedupeConfig(
                 id_column="comment_fullname",
                 filename=comments_filename,
-                include_prior_runs=policy_includes_prior_runs(
-                    _resolve_reddit_dedupe_policy(
-                        ingestion_params, COMMENTS_DEDUPE_POLICY_KEY
-                    )
-                ),
             )
         )
-        comment_dedupe_session.warm(comment_storage, output_dir)
+        if policy_includes_prior_runs(
+            _resolve_reddit_dedupe_policy(
+                ingestion_params, COMMENTS_DEDUPE_POLICY_KEY
+            )
+        ):
+            comment_dedupe_session.load_seen_ids_from_all_runs(comment_storage)
+        else:
+            comment_dedupe_session.load_seen_ids(comment_storage, output_dir)
     if include_posts:
         post_dedupe_session = DedupeSession(
             DedupeConfig(
                 id_column="reddit_fullname",
                 filename=posts_filename,
-                include_prior_runs=policy_includes_prior_runs(
-                    _resolve_reddit_dedupe_policy(
-                        ingestion_params, POSTS_DEDUPE_POLICY_KEY
-                    )
-                ),
             )
         )
-        post_dedupe_session.warm(post_storage, output_dir)
+        if policy_includes_prior_runs(
+            _resolve_reddit_dedupe_policy(
+                ingestion_params, POSTS_DEDUPE_POLICY_KEY
+            )
+        ):
+            post_dedupe_session.load_seen_ids_from_all_runs(post_storage)
+        else:
+            post_dedupe_session.load_seen_ids(post_storage, output_dir)
     return comment_dedupe_session, post_dedupe_session
 
 

--- a/data_platform/ingestion/sync_twitter.py
+++ b/data_platform/ingestion/sync_twitter.py
@@ -139,12 +139,12 @@ def run_sync_tasks(
         DedupeConfig(
             id_column="tweet_id",
             filename=filename,
-            include_prior_runs=policy_includes_prior_runs(
-                resolve_dedupe_policy(ingestion_params)
-            ),
         )
     )
-    dedupe_session.warm(storage, output_dir)
+    if policy_includes_prior_runs(resolve_dedupe_policy(ingestion_params)):
+        dedupe_session.load_seen_ids_from_all_runs(storage)
+    else:
+        dedupe_session.load_seen_ids(storage, output_dir)
 
     def process_task(task: TwitterTask, entry: dict[str, Any]) -> None:
         mark_task_in_progress(entry, storage, output_dir, metadata)

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -193,6 +193,28 @@ def save_preprocessed(
     return output_dir
 
 
+def collapse_candidates_by_id(
+    df: pd.DataFrame, id_col: str, keep: str = "last"
+) -> pd.DataFrame:
+    """Keep one row per id. Later rows win when keep is last.
+
+    Parameters
+    ----------
+    df
+        Candidate records after known ids have already been dropped.
+    id_col
+        Column that identifies a post or comment.
+    keep
+        Which duplicate to keep. ``last`` means the later raw row wins.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per id, index reset.
+    """
+    raise NotImplementedError
+
+
 def _drop_already_preprocessed(
     records: pd.DataFrame, id_col: str, seen_ids: set[str]
 ) -> tuple[pd.DataFrame, int]:

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -212,7 +212,7 @@ def collapse_candidates_by_id(
     pd.DataFrame
         One row per id, index reset.
     """
-    raise NotImplementedError
+    return df.drop_duplicates(subset=[id_col], keep=keep).reset_index(drop=True)
 
 
 def _drop_already_preprocessed(

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -196,7 +196,7 @@ def save_preprocessed(
 def collapse_candidates_by_id(
     df: pd.DataFrame, id_col: str, keep: str = "last"
 ) -> pd.DataFrame:
-    """Keep one row per id. Later rows win when keep is last.
+    """Keep one row per id, and keep the later row when keep is last.
 
     Parameters
     ----------
@@ -210,7 +210,7 @@ def collapse_candidates_by_id(
     Returns
     -------
     pd.DataFrame
-        One row per id, index reset.
+        The frame has one row per id, and the index is reset.
     """
     return df.drop_duplicates(subset=[id_col], keep=keep).reset_index(drop=True)
 

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -253,6 +253,6 @@ def preprocess_records(
     noun = spec.columns.records_file_key
     print(
         f"preprocess_records: kept {len(preprocessed)} of {len(records)} {noun}"
-        f" (skipped {skipped} already preprocessed) -> {output_dir}"
+        f" (skipped {skipped} already in a prior preprocessed run) -> {output_dir}"
     )
     return output_dir

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -242,17 +242,17 @@ def preprocess_records(
     raw_storage.require_all_runs_complete(dataset_id)
     preprocessed_storage = spec.storage_cls(StorageStage.PREPROCESSED, dataset_id)
     dedupe_session = DedupeSession(
-        DedupeConfig(
-            id_column=spec.columns.records_id_column,
-            include_prior_runs=True,
-        )
+        DedupeConfig(id_column=spec.columns.records_id_column)
     )
-    dedupe_session.warm(preprocessed_storage, preprocessed_storage.root_dir)
+    dedupe_session.load_seen_ids_from_all_runs(preprocessed_storage)
 
     records, source_raw_run_dirs = load_raw_records(spec, dataset_id)
-    records, skipped = _drop_already_preprocessed(
-        records, spec.columns.records_id_column, dedupe_session.seen_ids
-    )
+    id_col = spec.columns.records_id_column
+    id_series = cast(pd.Series, records[id_col])
+    is_new = ~id_series.isin(list(dedupe_session.seen_ids))
+    skipped = len(records) - int(is_new.sum())
+    records = records.loc[is_new].reset_index(drop=True)
+    records = collapse_candidates_by_id(records, id_col, keep="last")
 
     records = add_canonical_text_column(records, spec)
     records = add_canonical_author_columns(records, spec)

--- a/data_platform/preprocessing/runner.py
+++ b/data_platform/preprocessing/runner.py
@@ -215,22 +215,6 @@ def collapse_candidates_by_id(
     return df.drop_duplicates(subset=[id_col], keep=keep).reset_index(drop=True)
 
 
-def _drop_already_preprocessed(
-    records: pd.DataFrame, id_col: str, seen_ids: set[str]
-) -> tuple[pd.DataFrame, int]:
-    """Drop rows already preprocessed in a prior run, then dedupe by id within this batch.
-
-    Returns the surviving records and how many rows were dropped for being seen before.
-    """
-    id_series = cast(pd.Series, records[id_col])
-    is_new = ~id_series.isin(list(seen_ids))
-    skipped = len(records) - int(is_new.sum())
-    deduped = (
-        records.loc[is_new].drop_duplicates(subset=[id_col], keep="last").reset_index(drop=True)
-    )
-    return deduped, skipped
-
-
 def preprocess_records(
     dataset_id: str,
     spec: PreprocessPlatformSpec,

--- a/data_platform/utils/deduplication.py
+++ b/data_platform/utils/deduplication.py
@@ -42,7 +42,6 @@ def policy_includes_prior_runs(policy: object) -> bool:
 class DedupeConfig:
     id_column: str
     filename: str | None = None
-    include_prior_runs: bool = False
 
 
 @dataclass
@@ -56,23 +55,6 @@ class DedupeSession:
 
     config: DedupeConfig
     seen_ids: set[str] = field(default_factory=set)
-
-    def warm(self, storage: StorageManager, output_dir: Path) -> None:  # noqa: F821
-        """Load this-run ids, then all-run ids when ``include_prior_runs`` is true.
-
-        Compatibility path for existing ingest and preprocess callers.
-        """
-        self.load_seen_ids(storage, output_dir)
-        if self.config.include_prior_runs:
-            self.load_seen_ids_from_all_runs(storage)
-
-    def filter_rows(self, rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
-        """Return unseen rows and a skipped count. Delegates to ``exclude_seen_ids``."""
-        return self.exclude_seen_ids(rows)
-
-    def note_appended(self, rows: list[dict[str, Any]]) -> None:
-        """Record persisted row ids. Delegates to ``add_seen_ids``."""
-        self.add_seen_ids(rows)
 
     def load_seen_ids(self, storage: StorageManager, run_dir: Path) -> None:  # noqa: F821
         """Add ids from one run directory to ``seen_ids`` without replacing existing ids.

--- a/data_platform/utils/feature_labels.py
+++ b/data_platform/utils/feature_labels.py
@@ -13,7 +13,8 @@ from data_platform.utils.storage import StorageManager
 class FeatureLabelQuery:
     """Query labeled record ids from feature files across timestamped runs.
 
-    Unlabeled skip uses the same skip-set session type as ingest and preprocess.
+    Feature generation skips unlabeled records with the same skip set session
+    type that ingest and preprocess use.
     """
 
     feature_storage: StorageManager

--- a/data_platform/utils/feature_labels.py
+++ b/data_platform/utils/feature_labels.py
@@ -4,13 +4,17 @@ from dataclasses import dataclass
 
 import pandas as pd
 
+from data_platform.utils.deduplication import DedupeConfig, DedupeSession
 from data_platform.utils.platform_specific_columns import CANONICAL_SOURCE_RECORD_ID_COLUMN
 from data_platform.utils.storage import StorageManager
 
 
 @dataclass(frozen=True)
 class FeatureLabelQuery:
-    """Query labeled record ids from feature files across timestamped runs."""
+    """Query labeled record ids from feature files across timestamped runs.
+
+    Unlabeled skip uses the same skip-set session type as ingest and preprocess.
+    """
 
     feature_storage: StorageManager
     id_column: str = "uri"
@@ -18,11 +22,14 @@ class FeatureLabelQuery:
 
     def labeled_ids(self, feature_name: str) -> set[str]:
         """Return ids labeled for feature_name from timestamped feature run directories."""
-        filename = self.feature_storage.filename_for(feature_name)
-        return self.feature_storage.load_seen_ids_from_all_runs(
-            self.feature_file_id_column,
-            filename=filename,
+        skip_set = DedupeSession(
+            DedupeConfig(
+                id_column=self.feature_file_id_column,
+                filename=self.feature_storage.filename_for(feature_name),
+            )
         )
+        skip_set.load_seen_ids_from_all_runs(self.feature_storage)
+        return set(skip_set.seen_ids)
 
     def filter_unlabeled(
         self,

--- a/data_platform/utils/storage.py
+++ b/data_platform/utils/storage.py
@@ -256,11 +256,11 @@ class StorageManager:
         dedupe_session: DedupeSession,
         filename: str | None = None,
     ) -> AppendResult:
-        kept_rows, skipped = dedupe_session.filter_rows(rows)
+        kept_rows, skipped = dedupe_session.exclude_seen_ids(rows)
         resolved_filename = filename or dedupe_session.config.filename
         if kept_rows:
             self.append_records(kept_rows, run_dir, filename=resolved_filename)
-            dedupe_session.note_appended(kept_rows)
+            dedupe_session.add_seen_ids(kept_rows)
         return AppendResult(kept=len(kept_rows), skipped=skipped)
 
     def load_records(

--- a/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md
+++ b/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md
@@ -71,6 +71,15 @@ PYTHONPATH=. uv run python data_platform/preprocessing/preprocess_reddit.py \
   --dataset-id reddit_<uuid>
 ```
 
+### Extra details of note
+
+Skip-set load is not a preprocess stage. You load all prior preprocessed IDs before creating the new run directory. You drop known IDs with pandas. You collapse remaining IDs last-wins.
+
+```mermaid
+flowchart LR
+  cli["cli"] --> validate["validate"] --> gate["gate"] --> loadSkip["load skip set"] --> loadRaw["load raw"] --> drop["drop known IDs"] --> collapse["collapse candidates"] --> transform["transform"] --> filter["filter"] --> save["save"]
+```
+
 ...
 
 ## Stage 3: Feature generation

--- a/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md
+++ b/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md
@@ -71,9 +71,9 @@ PYTHONPATH=. uv run python data_platform/preprocessing/preprocess_reddit.py \
   --dataset-id reddit_<uuid>
 ```
 
-### Extra details of note
+### Extra details
 
-Skip-set load is not a preprocess stage. You load all prior preprocessed IDs before creating the new run directory. You drop known IDs with pandas. You collapse remaining IDs last-wins.
+Loading the skip set is work you do before preprocess writes a new run directory, not a named preprocess stage. You load all prior preprocessed IDs first. You then drop known IDs with pandas, and you keep the last remaining row when an id appears more than once.
 
 ```mermaid
 flowchart LR

--- a/tests/data_platform/ingestion/test_sync_checkpoint.py
+++ b/tests/data_platform/ingestion/test_sync_checkpoint.py
@@ -206,7 +206,7 @@ def test_append_deduped_records_skips_seen_ids(data_root) -> None:
     storage.append_records(existing, run_dir)
     config = DedupeConfig(id_column="tweet_id")
     dedupe_session = DedupeSession(config)
-    dedupe_session.warm(storage, run_dir)
+    dedupe_session.load_seen_ids(storage, run_dir)
     incoming = [mock_tweet_row("1"), mock_tweet_row("2")]
     result = storage.append_deduped_records(incoming, run_dir, dedupe_session=dedupe_session)
     assert result.skipped == 1

--- a/tests/data_platform/preprocessing/test_preprocess_twitter.py
+++ b/tests/data_platform/preprocessing/test_preprocess_twitter.py
@@ -269,7 +269,7 @@ def test_prior_run_skip_count_excludes_collapse_duplicates() -> None:
         ]
     )
     session = DedupeSession(DedupeConfig(id_column="tweet_id"))
-    session.seen_ids = {"a"}
+    session.seen_ids = {"a"}  # public skip-set seed for this helper-path test
     id_col = "tweet_id"
     is_new = ~records[id_col].isin(list(session.seen_ids))
     skipped = len(records) - int(is_new.sum())

--- a/tests/data_platform/preprocessing/test_preprocess_twitter.py
+++ b/tests/data_platform/preprocessing/test_preprocess_twitter.py
@@ -6,7 +6,9 @@ import pandas as pd
 import pytest
 
 from data_platform.preprocessing import preprocess_twitter
+from data_platform.preprocessing.runner import collapse_candidates_by_id
 from data_platform.preprocessing.validators import twitter_validators
+from data_platform.utils.deduplication import DedupeConfig, DedupeSession
 from data_platform.utils.storage import StorageStage, TwitterStorageManager
 from tests.data_platform.constants import VALID_TWITTER_DATASET_ID
 from tests.data_platform.ingestion.twitter_conftest import mock_tweet_row
@@ -239,3 +241,71 @@ def test_second_preprocess_run_skips_already_preprocessed_ids(data_root) -> None
     assert second_metadata["row_counts"]["input"] == 0
     assert second_metadata["row_counts"]["output"] == 0
     assert len(preprocessed_storage.load_records(second_output)) == 0
+
+
+def test_collapse_candidates_by_id_keeps_last_row() -> None:
+    """Verifies last-wins collapse keeps one row per id."""
+    records = pd.DataFrame(
+        [
+            {"tweet_id": "a", "text": "first"},
+            {"tweet_id": "a", "text": "second"},
+        ]
+    )
+    expected_text = "second"
+
+    result = collapse_candidates_by_id(records, "tweet_id", keep="last")
+
+    assert len(result) == 1
+    assert result.iloc[0]["text"] == expected_text
+
+
+def test_prior_run_skip_count_excludes_collapse_duplicates() -> None:
+    """Verifies pandas drop counts prior-run ids only, then collapse keeps one new id."""
+    records = pd.DataFrame(
+        [
+            {"tweet_id": "a", "text": "seen"},
+            {"tweet_id": "b", "text": "first-new"},
+            {"tweet_id": "b", "text": "last-new"},
+        ]
+    )
+    session = DedupeSession(DedupeConfig(id_column="tweet_id"))
+    session.seen_ids = {"a"}
+    id_col = "tweet_id"
+    is_new = ~records[id_col].isin(list(session.seen_ids))
+    skipped = len(records) - int(is_new.sum())
+    surviving = collapse_candidates_by_id(
+        records.loc[is_new].reset_index(drop=True), id_col, keep="last"
+    )
+    expected_skipped = 1
+    expected_ids = ["b"]
+    expected_text = "last-new"
+
+    assert skipped == expected_skipped
+    assert surviving["tweet_id"].tolist() == expected_ids
+    assert surviving.iloc[0]["text"] == expected_text
+
+
+def test_second_preprocess_run_print_names_prior_preprocessed_run(
+    data_root, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Verifies the skip print names prior preprocessed runs and counts one known id."""
+    dataset_id = VALID_TWITTER_DATASET_ID
+    raw_storage = TwitterStorageManager(StorageStage.RAW, dataset_id)
+    run_dir = raw_storage.create_new_run_dir("2026_05_31-13:00:00")
+    tweet_id = "1000000000000000001"
+    raw_storage.write_records([_tweet_row(tweet_id=tweet_id)], run_dir)
+    raw_storage.write_run_metadata(
+        run_dir,
+        {
+            "sync_status": "completed",
+            "row_count": 1,
+        },
+    )
+    preprocess_twitter.preprocess_records(dataset_id)
+    capsys.readouterr()
+
+    preprocess_twitter.preprocess_records(dataset_id)
+    printed = capsys.readouterr().out
+
+    assert "already in a prior preprocessed run" in printed
+    assert "skipped 1 already in a prior preprocessed run" in printed

--- a/tests/data_platform/utils/test_deduplication.py
+++ b/tests/data_platform/utils/test_deduplication.py
@@ -13,45 +13,6 @@ from data_platform.utils.deduplication import (
 )
 
 
-def test_session_warm_loads_current_run_only_by_default() -> None:
-    storage = MagicMock()
-    storage.load_seen_ids_from_disk.return_value = {"uri-a"}
-    config = DedupeConfig(id_column="uri", filename="posts.csv")
-    session = DedupeSession(config)
-    session.warm(storage, Path("/tmp/run"))
-
-    assert session.seen_ids == {"uri-a"}
-    storage.load_seen_ids_from_disk.assert_called_once_with(
-        Path("/tmp/run"), "uri", filename="posts.csv"
-    )
-    storage.load_seen_ids_from_all_runs.assert_not_called()
-
-
-def test_session_warm_unions_prior_runs_when_enabled() -> None:
-    storage = MagicMock()
-    storage.load_seen_ids_from_disk.return_value = {"uri-a"}
-    storage.load_seen_ids_from_all_runs.return_value = {"uri-b"}
-    config = DedupeConfig(
-        id_column="uri", filename="posts.csv", include_prior_runs=True
-    )
-    session = DedupeSession(config)
-    session.warm(storage, Path("/tmp/run"))
-
-    assert session.seen_ids == {"uri-a", "uri-b"}
-    storage.load_seen_ids_from_all_runs.assert_called_once_with(
-        "uri", filename="posts.csv"
-    )
-    storage = MagicMock()
-    storage.load_seen_ids_from_disk.return_value = {"uri-b"}
-    config = DedupeConfig(id_column="uri", filename="posts.csv")
-    session = DedupeSession(config)
-    session.seen_ids = {"uri-a"}
-    session.warm(storage, Path("/tmp/run"))
-
-    assert session.seen_ids == {"uri-a", "uri-b"}
-    storage.load_seen_ids_from_all_runs.assert_not_called()
-
-
 def test_dedupe_config_rejects_include_prior_runs() -> None:
     """Verifies DedupeConfig no longer accepts the prior-runs flag."""
     with pytest.raises(TypeError):
@@ -92,33 +53,7 @@ class TestPolicyIncludesPriorRuns:
         assert result is expected
 
 
-def test_session_filter_rows_skips_seen() -> None:
-    config = DedupeConfig(id_column="uri")
-    session = DedupeSession(config)
-    session.seen_ids = {"uri-a"}
-
-    kept, skipped = session.filter_rows(
-        [
-            {"uri": "uri-a", "text": "dup"},
-            {"uri": "uri-b", "text": "new"},
-        ]
-    )
-
-    assert kept == [{"uri": "uri-b", "text": "new"}]
-    assert skipped == 1
-
-
-def test_note_appended_updates_seen_ids() -> None:
-    config = DedupeConfig(id_column="uri")
-    session = DedupeSession(config)
-    session.seen_ids = {"uri-a"}
-
-    session.note_appended([{"uri": "uri-b"}, {"uri": "uri-c"}])
-
-    assert session.seen_ids == {"uri-a", "uri-b", "uri-c"}
-
-
-def test_load_seen_ids_unions_current_run_only() -> None:
+def test_load_seen_ids_loads_current_run_only() -> None:
     storage = MagicMock()
     storage.load_seen_ids_from_disk.return_value = {"uri-a"}
     config = DedupeConfig(id_column="uri", filename="posts.csv")

--- a/tests/data_platform/utils/test_deduplication.py
+++ b/tests/data_platform/utils/test_deduplication.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from data_platform.utils.deduplication import (
     DedupeConfig,
     DedupeSession,
@@ -48,6 +50,12 @@ def test_session_warm_unions_prior_runs_when_enabled() -> None:
 
     assert session.seen_ids == {"uri-a", "uri-b"}
     storage.load_seen_ids_from_all_runs.assert_not_called()
+
+
+def test_dedupe_config_rejects_include_prior_runs() -> None:
+    """Verifies DedupeConfig no longer accepts the prior-runs flag."""
+    with pytest.raises(TypeError):
+        DedupeConfig(id_column="uri", include_prior_runs=True)
 
 
 class TestPolicyIncludesPriorRuns:

--- a/tests/data_platform/utils/test_feature_labels.py
+++ b/tests/data_platform/utils/test_feature_labels.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pandas as pd
 from pydantic import BaseModel
 
+from data_platform.utils.deduplication import DedupeConfig, DedupeSession
 from data_platform.utils.feature_labels import FeatureLabelQuery
 from data_platform.utils.storage import StorageManager
 from tests.data_platform.conftest import make_political_feature_rows, write_feature_csv
@@ -70,3 +71,28 @@ def test_labeled_ids_unions_two_timestamped_run_dirs(data_root) -> None:
     query = FeatureLabelQuery(feature_storage=feature_storage)
     labeled = query.labeled_ids("is_political")
     assert labeled == {URI_POST_A, URI_POST_B}
+
+
+def test_labeled_ids_matches_skip_set_session_all_runs_load(data_root) -> None:
+    """Verifies unlabeled skip uses the same all-runs skip-set load as DedupeSession."""
+    feature_storage = StorageManager(
+        "bluesky", "features", BaseModel, FEATURES_DATASET_ID, records_filename="features"
+    )
+    write_feature_csv(
+        feature_storage.root_dir / LABEL_TIMESTAMP,
+        "is_political",
+        make_political_feature_rows(),
+    )
+    query = FeatureLabelQuery(feature_storage=feature_storage)
+    session = DedupeSession(
+        DedupeConfig(
+            id_column=query.feature_file_id_column,
+            filename=feature_storage.filename_for("is_political"),
+        )
+    )
+    session.load_seen_ids_from_all_runs(feature_storage)
+    expected = set(session.seen_ids)
+
+    result = query.labeled_ids("is_political")
+
+    assert result == expected

--- a/tests/data_platform/utils/test_storage.py
+++ b/tests/data_platform/utils/test_storage.py
@@ -63,7 +63,7 @@ def test_append_deduped_records_skips_current_run_duplicates(bluesky_storage) ->
     bluesky_storage.append_records(existing, run_dir)
     config = DedupeConfig(id_column="uri")
     dedupe_session = DedupeSession(config)
-    dedupe_session.warm(bluesky_storage, run_dir)
+    dedupe_session.load_seen_ids(bluesky_storage, run_dir)
 
     result = bluesky_storage.append_deduped_records(
         [
@@ -92,7 +92,7 @@ def test_append_deduped_records_skips_prior_run_duplicates(data_root) -> None:
     )
     config = DedupeConfig(id_column="comment_fullname", filename="comments.csv")
     dedupe_session = DedupeSession(config)
-    dedupe_session.warm(comment_storage, current_run)
+    dedupe_session.load_seen_ids(comment_storage, current_run)
 
     result = comment_storage.append_deduped_records(
         [
@@ -116,9 +116,9 @@ def test_append_deduped_records_skips_ids_from_prior_run_dirs(bluesky_storage) -
     current_run = bluesky_storage.create_new_run_dir("2026_05_30-10:00:00")
     prior_uri = "at://did:plc:ex/app.bsky.feed.post/prior"
     bluesky_storage.append_records([make_ingestion_row(uri=prior_uri)], prior_run)
-    config = DedupeConfig(id_column="uri", include_prior_runs=True)
+    config = DedupeConfig(id_column="uri")
     dedupe_session = DedupeSession(config)
-    dedupe_session.warm(bluesky_storage, current_run)
+    dedupe_session.load_seen_ids_from_all_runs(bluesky_storage)
 
     result = bluesky_storage.append_deduped_records(
         [
@@ -151,7 +151,7 @@ def test_append_deduped_records_does_not_dedupe_across_datasets(data_root) -> No
     )
     config = DedupeConfig(id_column="comment_fullname", filename="comments.csv")
     dedupe_session = DedupeSession(config)
-    dedupe_session.warm(storage_b, current_run_b)
+    dedupe_session.load_seen_ids(storage_b, current_run_b)
 
     result = storage_b.append_deduped_records(
         [
@@ -173,7 +173,7 @@ def test_append_deduped_records_returns_empty_when_all_duplicates(bluesky_storag
     bluesky_storage.append_records(existing, run_dir)
     config = DedupeConfig(id_column="uri")
     dedupe_session = DedupeSession(config)
-    dedupe_session.warm(bluesky_storage, run_dir)
+    dedupe_session.load_seen_ids(bluesky_storage, run_dir)
 
     result = bluesky_storage.append_deduped_records(
         [make_ingestion_row(uri="at://did:plc:ex/app.bsky.feed.post/a1")],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Callers of the skip set still used the old warmup names (`warm`, `filter_rows`, `note_appended`) and a prior-runs flag on session config, even after the load, exclude, and extend methods existed. Feature generation still skipped already labeled ids through its own `FeatureLabelQuery` path.

## Solution

The ingest step now loads ids for this run or for all runs, based on the YAML policy. After that, it excludes known ids and writes the remaining rows. It extends the skip set when remaining rows are not empty. The preprocess step loads all prior preprocessed ids before it creates the new run directory. It then drops known ids with pandas, and it keeps the last remaining row when an id appears more than once. Feature generation loads unlabeled skip ids through `DedupeSession`. The warmup methods are gone.

## Purpose

The PR finishes the skip set change. Earlier work added the new helpers and left the old names in place. Feature generation now skips unlabeled records with the same skip set type that ingest and preprocess use.

The remaining work comes from `docs/plans/2026-09-01_incremental_identity_skip_124df6/` (ingest, preprocess, warmup removal) and from putting `FeatureLabelQuery` on `DedupeSession` in #142.

YAML `dedupe_policy` token strings and `append_deduped_records` stay.

## How to run

```bash
PYTHONPATH=. uv run pytest tests/data_platform -q
rg -n "include_prior_runs|\\.warm\\(|filter_rows|note_appended|_drop_already_preprocessed" data_platform tests docs/runbooks
```

`pytest` exits 0 (385 passed). Grep matches only `include_prior_runs` in the TypeError test and in `policy_includes_prior_runs` test names. There is no `DedupeSession.warm`. The stimuli runbook names the steps load skip set, drop known IDs, and collapse candidates. It does not name warmup.

Fixes #142

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e445942-b3c3-49bb-9da7-6c4844170d3e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e445942-b3c3-49bb-9da7-6c4844170d3e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved duplicate detection across ingestion, preprocessing, storage, and feature-label workflows.
  - Records from previous runs are now consistently skipped when the configured policy includes historical data.
  - Current-run processing continues to avoid reprocessing records already present in the active output.
  - Preprocessing now keeps the selected candidate per ID and reports previously processed records more clearly.

- **Tests**
  - Added coverage for candidate selection, historical duplicate handling, feature-label consistency, and current-run deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->