### PR TITLE
feat(ingestion): explicit Bluesky new-run and resume commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## 2026-09-03
 
-1. Raw ingest now writes a stable `record_id` on every row using the same `{integration}_{id}` keys as study stimuli (`bluesky_{sha256(uri)}`, `twitter_{tweet_id}`, `reddit_{post_reddit_id}_{comment_id}`). [PR #138](https://github.com/METResearchGroup/mirrorView-task/pull/138)
-2. Ingest, preprocess, and feature unlabeled skip now share one skip set session. The warmup names are gone. Callers load known ids for this run or for all runs before they drop, persist, or collapse. [PR #144](https://github.com/METResearchGroup/mirrorView-task/pull/144)
-3. Bluesky ingestion now delegates all API client work to `BlueskyClient` in `data_platform/ingestion/integrations/bluesky.py`. `sync_bluesky.py` now handles sync logic only, and the client can be tested on its own. [PR #143](https://github.com/METResearchGroup/mirrorView-task/pull/143)
+1. Bluesky ingest now requires an explicit `new-run` or `resume` command. `new-run` refuses to start when an unfinished raw run exists; `resume` accepts a named timestamp or `--latest` and fails fast when the run is missing or already completed. Twitter and Reddit keep the combined start-or-resume behavior. [PR #145](https://github.com/METResearchGroup/mirrorView-task/pull/145)
+2. Raw ingest now writes a stable `record_id` on every row using the same `{integration}_{id}` keys as study stimuli (`bluesky_{sha256(uri)}`, `twitter_{tweet_id}`, `reddit_{post_reddit_id}_{comment_id}`). [PR #138](https://github.com/METResearchGroup/mirrorView-task/pull/138)
+3. Ingest, preprocess, and feature unlabeled skip now share one skip set session. The warmup names are gone. Callers load known ids for this run or for all runs before they drop, persist, or collapse. [PR #144](https://github.com/METResearchGroup/mirrorView-task/pull/144)
+4. Bluesky ingestion now delegates all API client work to `BlueskyClient` in `data_platform/ingestion/integrations/bluesky.py`. `sync_bluesky.py` now handles sync logic only, and the client can be tested on its own. [PR #143](https://github.com/METResearchGroup/mirrorView-task/pull/143)
 
 ## 2026-09-02
 

--- a/data_platform/README.md
+++ b/data_platform/README.md
@@ -34,7 +34,7 @@ See the operator runbook at [docs/runbooks/HOW_TO_RUN_DATA_INGESTION.md](../docs
 The ingestion CLI reads `dataset_id` from the ingestion config. Pass config paths relative to the repo root. The `smoke.yaml` config collects about 100 Bluesky posts for a local dry run.
 
 ```bash
-PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py \
+PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py new-run \
   --config data_platform/ingestion/configs/bluesky/smoke.yaml
 
 PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py new-run \

--- a/data_platform/README.md
+++ b/data_platform/README.md
@@ -37,7 +37,7 @@ The ingestion CLI reads `dataset_id` from the ingestion config. Pass config path
 PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py \
   --config data_platform/ingestion/configs/bluesky/smoke.yaml
 
-PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py \
+PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py new-run \
   --config data_platform/ingestion/configs/bluesky/mirrorview.yaml
 
 PYTHONPATH=. uv run python data_platform/ingestion/sync_twitter.py \
@@ -47,12 +47,20 @@ PYTHONPATH=. uv run python data_platform/ingestion/sync_reddit.py \
   --config data_platform/ingestion/configs/reddit/mirrorview.yaml
 ```
 
-Large syncs checkpoint per keyword/subreddit in `raw/{timestamp}/metadata.json`. Resume after interrupt:
+Large syncs checkpoint per keyword/subreddit in `raw/{timestamp}/metadata.json`. Resume a named Bluesky run after interrupt:
 
 ```bash
-PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py \
+PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py resume \
   --config data_platform/ingestion/configs/bluesky/mirrorview.yaml \
   --run-dir <timestamp>
+```
+
+Resume the latest unfinished Bluesky run instead:
+
+```bash
+PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py resume \
+  --config data_platform/ingestion/configs/bluesky/mirrorview.yaml \
+  --latest
 ```
 
 Preprocess, features, and curate require the same `--dataset-id` as in ingestion YAML:

--- a/data_platform/README.md
+++ b/data_platform/README.md
@@ -47,7 +47,7 @@ PYTHONPATH=. uv run python data_platform/ingestion/sync_reddit.py \
   --config data_platform/ingestion/configs/reddit/mirrorview.yaml
 ```
 
-Large syncs checkpoint per keyword/subreddit in `raw/{timestamp}/metadata.json`. Resume a named Bluesky run after interrupt:
+Large syncs write a checkpoint per keyword or subreddit to `raw/{timestamp}/metadata.json`. Resume a named Bluesky run after interrupt:
 
 ```bash
 PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py resume \

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -201,11 +201,9 @@ def run_sync_tasks(
 
 
 @dataclass(frozen=True)
-class BlueskySyncContext:
-    """Shared Bluesky ingest setup used by new-run and resume."""
+class BlueskyRuntime:
+    """Execution-time state shared by Bluesky new-run and resume."""
 
-    config: dict[str, Any]
-    config_path: Path
     storage: BlueskyStorageManager
     ingestion_params: dict[str, Any]
     sync_tasks: list[BlueskyTask]
@@ -213,8 +211,8 @@ class BlueskySyncContext:
     filename: str
 
 
-def load_bluesky_sync_context(config_path: Path) -> BlueskySyncContext:
-    """Load config, storage, tasks, and the Bluesky client for one sync.
+def load_bluesky_runtime(config_path: Path) -> tuple[dict[str, Any], BlueskyRuntime]:
+    """Load config and return execution-time runtime for one sync.
 
     Parameters
     ----------
@@ -223,8 +221,8 @@ def load_bluesky_sync_context(config_path: Path) -> BlueskySyncContext:
 
     Returns
     -------
-    BlueskySyncContext
-        Shared setup for new-run and resume.
+    tuple[dict[str, Any], BlueskyRuntime]
+        The loaded config and the shared runtime.
 
     Raises
     ------
@@ -247,19 +245,20 @@ def load_bluesky_sync_context(config_path: Path) -> BlueskySyncContext:
     record_types: list[str] = config["record_types"]
     if POSTS_RECORD_TYPE not in record_types:
         raise ValueError(f"Unsupported record types for checkpoint sync: {record_types}")
-    return BlueskySyncContext(
-        config=config,
-        config_path=config_path,
-        storage=storage,
-        ingestion_params=ingestion_params,
-        sync_tasks=sync_tasks,
-        client=BlueskyClient(),
-        filename=storage.records_filename,
+    return (
+        config,
+        BlueskyRuntime(
+            storage=storage,
+            ingestion_params=ingestion_params,
+            sync_tasks=sync_tasks,
+            client=BlueskyClient(),
+            filename=storage.records_filename,
+        ),
     )
 
 
 def execute_bluesky_sync(
-    context: BlueskySyncContext,
+    runtime: BlueskyRuntime,
     output_dir: Path,
     metadata: dict[str, Any],
 ) -> Path:
@@ -267,8 +266,8 @@ def execute_bluesky_sync(
 
     Parameters
     ----------
-    context
-        Shared Bluesky ingest setup.
+    runtime
+        Shared execution-time state.
     output_dir
         Opened raw run directory.
     metadata
@@ -280,15 +279,15 @@ def execute_bluesky_sync(
         The same ``output_dir`` after tasks are synced and metadata is flushed.
     """
     run_sync_tasks(
-        context.client,
-        context.ingestion_params,
+        runtime.client,
+        runtime.ingestion_params,
         output_dir,
-        context.storage,
+        runtime.storage,
         metadata,
-        context.sync_tasks,
-        filename=context.filename,
+        runtime.sync_tasks,
+        filename=runtime.filename,
     )
-    finalize_local_disk_sync(context.storage, output_dir, metadata)
+    finalize_local_disk_sync(runtime.storage, output_dir, metadata)
     total_rows = metadata["row_count"]
     print(
         f"sync_records: wrote {total_rows} rows to {output_dir} "
@@ -315,31 +314,26 @@ def sync_records_new_run(config_path: Path) -> Path:
     ValueError
         When an unfinished raw run already exists for this dataset.
     """
-    context = load_bluesky_sync_context(config_path)
+    config, runtime = load_bluesky_runtime(config_path)
     output_dir, metadata = start_new_sync_run(
-        context.storage,
-        lambda ts: init_sync_metadata(
-            context.config, context.config_path, ts, context.sync_tasks
-        ),
+        runtime.storage,
+        lambda ts: init_sync_metadata(config, config_path, ts, runtime.sync_tasks),
     )
-    return execute_bluesky_sync(context, output_dir, metadata)
+    return execute_bluesky_sync(runtime, output_dir, metadata)
 
 
 def sync_records_from_checkpoint(
     config_path: Path,
-    run_dir_name: str | None,
-    latest: bool,
+    run_dir_name: str,
 ) -> Path:
-    """Resume an unfinished raw run by name or by latest unfinished timestamp.
+    """Resume an unfinished raw run by name.
 
     Parameters
     ----------
     config_path
         Ingestion YAML path.
     run_dir_name
-        Raw run timestamp directory name, or None when ``latest`` is True.
-    latest
-        When True, resume the newest unfinished raw run.
+        Raw run timestamp directory name.
 
     Returns
     -------
@@ -348,29 +342,19 @@ def sync_records_from_checkpoint(
 
     Raises
     ------
-    ValueError
-        When both ``run_dir_name`` and ``latest`` are set, when neither is set,
-        or when the named run is already completed.
     FileNotFoundError
-        When the named run is missing, or when ``latest`` is True and no
-        unfinished run exists.
+        When the named run is missing.
+    ValueError
+        When the run is already completed.
     """
-    named = run_dir_name is not None
-    if latest == named:
-        raise ValueError(
-            "Resume requires exactly one of a named run directory or latest"
-        )
-    context = load_bluesky_sync_context(config_path)
-    resolved_run_dir_name = run_dir_name
-    if latest:
-        resolved_run_dir_name = require_latest_in_progress_run_dir(context.storage).name
+    config, runtime = load_bluesky_runtime(config_path)
     output_dir, metadata = load_checkpoint_run(
-        context.storage,
-        context.sync_tasks,
-        resolved_run_dir_name,
+        runtime.storage,
+        runtime.sync_tasks,
+        run_dir_name,
         "keywords",
     )
-    return execute_bluesky_sync(context, output_dir, metadata)
+    return execute_bluesky_sync(runtime, output_dir, metadata)
 
 
 CONFIG_HELP = (
@@ -390,6 +374,21 @@ def new_run_command(
     sync_records_new_run(config_path)
 
 
+def _resolve_resume_run_dir(
+    storage: BlueskyStorageManager,
+    run_dir: str | None,
+    latest: bool,
+) -> str:
+    """Return the run directory name to resume, or raise for invalid options."""
+    if (run_dir is not None and latest) or (run_dir is None and not latest):
+        raise ValueError(
+            "Resume requires exactly one of --run-dir or --latest"
+        )
+    if run_dir is not None:
+        return run_dir
+    return require_latest_in_progress_run_dir(storage).name
+
+
 @app.command("resume")
 def resume_command(
     config: Path = typer.Option(..., "--config", help=CONFIG_HELP),
@@ -406,7 +405,9 @@ def resume_command(
 ) -> None:
     """Resume an unfinished Bluesky raw run. Requires --run-dir or --latest."""
     config_path = resolve_config_path(config, REPO_ROOT)
-    sync_records_from_checkpoint(config_path, run_dir, latest)
+    config, runtime = load_bluesky_runtime(config_path)
+    resolved_run_dir = _resolve_resume_run_dir(runtime.storage, run_dir, latest)
+    sync_records_from_checkpoint(config_path, resolved_run_dir)
 
 
 def main() -> None:

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -2,8 +2,16 @@
 
 Run from the repo root:
 
-    PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py \\
+    PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py new-run \\
         --config data_platform/ingestion/configs/bluesky/mirrorview.yaml
+
+    PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py resume \\
+        --config data_platform/ingestion/configs/bluesky/mirrorview.yaml \\
+        --run-dir 2026_05_30-12:00:00
+
+    PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py resume \\
+        --config data_platform/ingestion/configs/bluesky/mirrorview.yaml \\
+        --latest
 
 """
 
@@ -12,6 +20,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+import typer
 
 from data_platform.ingestion.integrations.bluesky import (
     POSTS_RECORD_TYPE,
@@ -24,23 +34,25 @@ from data_platform.ingestion.sync_checkpoint import (
     ensure_dataset_manifest,
     finalize_local_disk_sync,
     increment_duplicate_skip_counters,
+    load_checkpoint_run,
     mark_task_completed,
     mark_task_failed,
     mark_task_in_progress,
     parse_max_posts,
-    prepare_sync_run,
     require_dataset_id,
+    require_latest_in_progress_run_dir,
     resolve_dedupe_policy,
     run_checkpointed_sync,
-    run_sync_cli,
+    start_new_sync_run,
 )
-from data_platform.utils.config_paths import load_yaml_config
+from data_platform.utils.config_paths import load_yaml_config, resolve_config_path
 from data_platform.utils.deduplication import (
     DedupeConfig,
     DedupeSession,
     policy_includes_prior_runs,
 )
 from data_platform.utils.storage import BlueskyStorageManager, StorageStage
+from lib.constants import REPO_ROOT
 
 
 @dataclass(frozen=True)
@@ -188,77 +200,86 @@ def run_sync_tasks(
     )
 
 
-def sync_records(
-    config_path: Path,
-    *,
-    run_dir_name: str | None = None,
+@dataclass(frozen=True)
+class BlueskySyncContext:
+    """Shared Bluesky ingest setup used by new-run and resume."""
+
+    config: dict[str, Any]
+    config_path: Path
+    storage: BlueskyStorageManager
+    ingestion_params: dict[str, Any]
+    sync_tasks: list[BlueskyTask]
+    client: BlueskyClient
+    filename: str
+
+
+def load_bluesky_sync_context(config_path: Path) -> BlueskySyncContext:
+    """Load config, storage, tasks, and the Bluesky client for one sync."""
+    raise NotImplementedError
+
+
+def execute_bluesky_sync(
+    context: BlueskySyncContext,
+    output_dir: Path,
+    metadata: dict[str, Any],
 ) -> Path:
-    """Load the config and prepare or resume a raw run.
+    """Run keyword tasks and finalize metadata for an opened raw run."""
+    raise NotImplementedError
 
-    Then sync all keyword tasks to posts.csv. Creates the dataset manifest on first run
-    and returns the output run directory path.
-    """
-    config = load_yaml_config(config_path)
-    dataset_id = require_dataset_id(config, platform="bluesky")
 
-    # Create a temporary storage manager just to locate the dataset root for the manifest.
-    # The manifest must exist before we create the real storage manager.
-    # New datasets have no dataset.json yet, so the manager cannot read the format without it.
-    ensure_dataset_manifest(
-        BlueskyStorageManager(StorageStage.RAW, dataset_id),
-        "bluesky",
-        dataset_id,
-        config,
-        config_path,
-    )
-    storage = BlueskyStorageManager(StorageStage.RAW, dataset_id)
+def sync_records_new_run(config_path: Path) -> Path:
+    """Create a new raw run and sync keyword tasks into it."""
+    raise NotImplementedError
 
-    ingestion_params = config["ingestion_params"]
-    sync_tasks = build_sync_tasks(ingestion_params)
-    record_types: list[str] = config["record_types"]
 
-    if POSTS_RECORD_TYPE not in record_types:
-        raise ValueError(f"Unsupported record types for checkpoint sync: {record_types}")
+def sync_records_from_checkpoint(
+    config_path: Path,
+    run_dir_name: str | None,
+    latest: bool,
+) -> Path:
+    """Resume an unfinished raw run by name or by latest unfinished timestamp."""
+    raise NotImplementedError
 
-    filename = storage.records_filename
-    client = BlueskyClient()
 
-    output_dir, metadata = prepare_sync_run(
-        storage,
-        sync_tasks,
-        run_dir_name=run_dir_name,
-        init_metadata_fn=lambda ts: init_sync_metadata(config, config_path, ts, sync_tasks),
-        entity_label="keywords",
-    )
+CONFIG_HELP = (
+    "Ingestion YAML path relative to the repo root. "
+    "For example, data_platform/ingestion/configs/bluesky/mirrorview.yaml."
+)
 
-    run_sync_tasks(
-        client,
-        ingestion_params,
-        output_dir,
-        storage,
-        metadata,
-        sync_tasks,
-        filename=filename,
-    )
+app = typer.Typer(no_args_is_help=True)
 
-    finalize_local_disk_sync(storage, output_dir, metadata)
 
-    total_rows = metadata["row_count"]
-    print(
-        f"sync_records: wrote {total_rows} rows to {output_dir} (status={metadata['sync_status']})"
-    )
-    return output_dir
+@app.command("new-run")
+def new_run_command(
+    config: Path = typer.Option(..., "--config", help=CONFIG_HELP),
+) -> None:
+    """Start a new Bluesky raw run. Fails if an unfinished run already exists."""
+    config_path = resolve_config_path(config, REPO_ROOT)
+    sync_records_new_run(config_path)
+
+
+@app.command("resume")
+def resume_command(
+    config: Path = typer.Option(..., "--config", help=CONFIG_HELP),
+    run_dir: str | None = typer.Option(
+        None,
+        "--run-dir",
+        help="Raw run timestamp directory name to resume (e.g. 2026_05_30-12:00:00)",
+    ),
+    latest: bool = typer.Option(
+        False,
+        "--latest",
+        help="Resume the newest unfinished raw run for this dataset.",
+    ),
+) -> None:
+    """Resume an unfinished Bluesky raw run. Requires --run-dir or --latest."""
+    config_path = resolve_config_path(config, REPO_ROOT)
+    sync_records_from_checkpoint(config_path, run_dir, latest)
 
 
 def main() -> None:
-    """CLI entrypoint for sync_bluesky.py. Supports --config, --resume, and --run-dir."""
-    run_sync_cli(
-        sync_records_fn=sync_records,
-        config_help=(
-            "Ingestion YAML path relative to the repo root. "
-            "For example, data_platform/ingestion/configs/bluesky/mirrorview.yaml."
-        ),
-    )
+    """CLI entrypoint for sync_bluesky.py. Requires new-run or resume."""
+    app()
 
 
 if __name__ == "__main__":

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -381,9 +381,7 @@ def _resolve_resume_run_dir(
 ) -> str:
     """Return the run directory name to resume, or raise for invalid options."""
     if (run_dir is not None and latest) or (run_dir is None and not latest):
-        raise ValueError(
-            "Resume requires exactly one of --run-dir or --latest"
-        )
+        raise ValueError("Pass --run-dir or --latest, but not both")
     if run_dir is not None:
         return run_dir
     return require_latest_in_progress_run_dir(storage).name

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -214,8 +214,48 @@ class BlueskySyncContext:
 
 
 def load_bluesky_sync_context(config_path: Path) -> BlueskySyncContext:
-    """Load config, storage, tasks, and the Bluesky client for one sync."""
-    raise NotImplementedError
+    """Load config, storage, tasks, and the Bluesky client for one sync.
+
+    Parameters
+    ----------
+    config_path
+        Ingestion YAML path. The dataset manifest is created on first use.
+
+    Returns
+    -------
+    BlueskySyncContext
+        Shared setup for new-run and resume.
+
+    Raises
+    ------
+    ValueError
+        When ``dataset_id`` is missing, or when ``record_types`` does not
+        include Bluesky posts.
+    """
+    config = load_yaml_config(config_path)
+    dataset_id = require_dataset_id(config, platform="bluesky")
+    ensure_dataset_manifest(
+        BlueskyStorageManager(StorageStage.RAW, dataset_id),
+        "bluesky",
+        dataset_id,
+        config,
+        config_path,
+    )
+    storage = BlueskyStorageManager(StorageStage.RAW, dataset_id)
+    ingestion_params = config["ingestion_params"]
+    sync_tasks = build_sync_tasks(ingestion_params)
+    record_types: list[str] = config["record_types"]
+    if POSTS_RECORD_TYPE not in record_types:
+        raise ValueError(f"Unsupported record types for checkpoint sync: {record_types}")
+    return BlueskySyncContext(
+        config=config,
+        config_path=config_path,
+        storage=storage,
+        ingestion_params=ingestion_params,
+        sync_tasks=sync_tasks,
+        client=BlueskyClient(),
+        filename=storage.records_filename,
+    )
 
 
 def execute_bluesky_sync(
@@ -223,8 +263,38 @@ def execute_bluesky_sync(
     output_dir: Path,
     metadata: dict[str, Any],
 ) -> Path:
-    """Run keyword tasks and finalize metadata for an opened raw run."""
-    raise NotImplementedError
+    """Run keyword tasks and finalize metadata for an opened raw run.
+
+    Parameters
+    ----------
+    context
+        Shared Bluesky ingest setup.
+    output_dir
+        Opened raw run directory.
+    metadata
+        Run metadata to update in place.
+
+    Returns
+    -------
+    Path
+        The same ``output_dir`` after tasks are synced and metadata is flushed.
+    """
+    run_sync_tasks(
+        context.client,
+        context.ingestion_params,
+        output_dir,
+        context.storage,
+        metadata,
+        context.sync_tasks,
+        filename=context.filename,
+    )
+    finalize_local_disk_sync(context.storage, output_dir, metadata)
+    total_rows = metadata["row_count"]
+    print(
+        f"sync_records: wrote {total_rows} rows to {output_dir} "
+        f"(status={metadata['sync_status']})"
+    )
+    return output_dir
 
 
 def sync_records_new_run(config_path: Path) -> Path:

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -298,8 +298,31 @@ def execute_bluesky_sync(
 
 
 def sync_records_new_run(config_path: Path) -> Path:
-    """Create a new raw run and sync keyword tasks into it."""
-    raise NotImplementedError
+    """Create a new raw run and sync keyword tasks into it.
+
+    Parameters
+    ----------
+    config_path
+        Ingestion YAML path.
+
+    Returns
+    -------
+    Path
+        New raw run directory.
+
+    Raises
+    ------
+    ValueError
+        When an unfinished raw run already exists for this dataset.
+    """
+    context = load_bluesky_sync_context(config_path)
+    output_dir, metadata = start_new_sync_run(
+        context.storage,
+        lambda ts: init_sync_metadata(
+            context.config, context.config_path, ts, context.sync_tasks
+        ),
+    )
+    return execute_bluesky_sync(context, output_dir, metadata)
 
 
 def sync_records_from_checkpoint(

--- a/data_platform/ingestion/sync_bluesky.py
+++ b/data_platform/ingestion/sync_bluesky.py
@@ -307,8 +307,47 @@ def sync_records_from_checkpoint(
     run_dir_name: str | None,
     latest: bool,
 ) -> Path:
-    """Resume an unfinished raw run by name or by latest unfinished timestamp."""
-    raise NotImplementedError
+    """Resume an unfinished raw run by name or by latest unfinished timestamp.
+
+    Parameters
+    ----------
+    config_path
+        Ingestion YAML path.
+    run_dir_name
+        Raw run timestamp directory name, or None when ``latest`` is True.
+    latest
+        When True, resume the newest unfinished raw run.
+
+    Returns
+    -------
+    Path
+        Resumed raw run directory.
+
+    Raises
+    ------
+    ValueError
+        When both ``run_dir_name`` and ``latest`` are set, when neither is set,
+        or when the named run is already completed.
+    FileNotFoundError
+        When the named run is missing, or when ``latest`` is True and no
+        unfinished run exists.
+    """
+    named = run_dir_name is not None
+    if latest == named:
+        raise ValueError(
+            "Resume requires exactly one of a named run directory or latest"
+        )
+    context = load_bluesky_sync_context(config_path)
+    resolved_run_dir_name = run_dir_name
+    if latest:
+        resolved_run_dir_name = require_latest_in_progress_run_dir(context.storage).name
+    output_dir, metadata = load_checkpoint_run(
+        context.storage,
+        context.sync_tasks,
+        resolved_run_dir_name,
+        "keywords",
+    )
+    return execute_bluesky_sync(context, output_dir, metadata)
 
 
 CONFIG_HELP = (

--- a/data_platform/ingestion/sync_checkpoint.py
+++ b/data_platform/ingestion/sync_checkpoint.py
@@ -406,7 +406,16 @@ def start_new_sync_run(
     ValueError
         When an unfinished raw run already exists for this dataset.
     """
-    raise NotImplementedError
+    unfinished_dir = find_resume_run_dir(storage, run_dir_name=None)
+    if unfinished_dir is not None:
+        raise ValueError(
+            f"An unfinished raw run exists at {unfinished_dir}; resume it instead of starting a new run"
+        )
+    sync_timestamp = get_current_timestamp()
+    output_dir = storage.create_new_run_dir(sync_timestamp)
+    metadata = init_metadata_fn(sync_timestamp)
+    flush_run_metadata(storage, output_dir, metadata)
+    return output_dir, metadata
 
 
 def load_checkpoint_run(

--- a/data_platform/ingestion/sync_checkpoint.py
+++ b/data_platform/ingestion/sync_checkpoint.py
@@ -462,7 +462,12 @@ def require_latest_in_progress_run_dir(storage: StorageManager) -> Path:
     FileNotFoundError
         When no unfinished raw run exists.
     """
-    raise NotImplementedError
+    resume_dir = find_resume_run_dir(storage, run_dir_name=None)
+    if resume_dir is None:
+        raise FileNotFoundError(
+            f"No unfinished raw run exists under {storage.root_dir}"
+        )
+    return resume_dir
 
 
 def prepare_sync_run(

--- a/data_platform/ingestion/sync_checkpoint.py
+++ b/data_platform/ingestion/sync_checkpoint.py
@@ -383,6 +383,88 @@ def ensure_dataset_manifest(
         )
 
 
+def start_new_sync_run(
+    storage: StorageManager,
+    init_metadata_fn: Callable[[str], dict[str, Any]],
+) -> tuple[Path, dict[str, Any]]:
+    """Create a new raw run directory and write initial metadata.
+
+    Parameters
+    ----------
+    storage
+        Raw-stage storage manager for the dataset.
+    init_metadata_fn
+        Builds the initial ``metadata.json`` payload from the new run timestamp.
+
+    Returns
+    -------
+    tuple[Path, dict[str, Any]]
+        New run directory and the flushed metadata payload.
+
+    Raises
+    ------
+    ValueError
+        When an unfinished raw run already exists for this dataset.
+    """
+    raise NotImplementedError
+
+
+def load_checkpoint_run(
+    storage: StorageManager,
+    sync_tasks: Sequence[HasTaskId],
+    run_dir_name: str,
+    entity_label: str,
+) -> tuple[Path, dict[str, Any]]:
+    """Load an unfinished named raw run and validate its task ledger.
+
+    Parameters
+    ----------
+    storage
+        Raw-stage storage manager for the dataset.
+    sync_tasks
+        Config tasks that must match the checkpoint ledger.
+    run_dir_name
+        Raw run timestamp directory name, for example ``2026_05_30-12:00:00``.
+    entity_label
+        Noun used in the task-mismatch error, for example ``keywords``.
+
+    Returns
+    -------
+    tuple[Path, dict[str, Any]]
+        Existing run directory and its metadata.
+
+    Raises
+    ------
+    FileNotFoundError
+        When the named run directory does not exist.
+    ValueError
+        When the run is already completed, or when config tasks do not match
+        the checkpoint ledger.
+    """
+    raise NotImplementedError
+
+
+def require_latest_in_progress_run_dir(storage: StorageManager) -> Path:
+    """Return the newest unfinished raw run directory for this dataset.
+
+    Parameters
+    ----------
+    storage
+        Raw-stage storage manager for the dataset.
+
+    Returns
+    -------
+    Path
+        Newest raw run directory whose ``sync_status`` is not completed.
+
+    Raises
+    ------
+    FileNotFoundError
+        When no unfinished raw run exists.
+    """
+    raise NotImplementedError
+
+
 def prepare_sync_run(
     storage: StorageManager,
     sync_tasks: Sequence[HasTaskId],

--- a/data_platform/ingestion/sync_checkpoint.py
+++ b/data_platform/ingestion/sync_checkpoint.py
@@ -441,7 +441,17 @@ def load_checkpoint_run(
         When the run is already completed, or when config tasks do not match
         the checkpoint ledger.
     """
-    raise NotImplementedError
+    run_dir = storage.root_dir / run_dir_name
+    if not run_dir.is_dir():
+        raise FileNotFoundError(f"Run directory not found: {run_dir}")
+    metadata = storage.load_run_metadata(run_dir)
+    if metadata.get("sync_status") == SyncStatus.COMPLETED.value:
+        raise ValueError(f"Run is already completed: {run_dir}")
+    validate_tasks_for_resume(sync_tasks, metadata, entity_label=entity_label)
+    if metadata.get("sync_status") != SyncStatus.IN_PROGRESS.value:
+        metadata["sync_status"] = SyncStatus.IN_PROGRESS.value
+        flush_run_metadata(storage, run_dir, metadata)
+    return run_dir, metadata
 
 
 def require_latest_in_progress_run_dir(storage: StorageManager) -> Path:

--- a/docs/plans/2026-09-03_explicit_ingest_run_modes_7b2e91/plan.md
+++ b/docs/plans/2026-09-03_explicit_ingest_run_modes_7b2e91/plan.md
@@ -1,0 +1,84 @@
+# Split Bluesky raw ingest into exclusive new-run and resume commands
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Bluesky ingest currently guesses whether to start a new raw run or attach to an unfinished one. A plain config invocation resumes the latest incomplete timestamp when one exists, and a named run directory can be reopened even after it is marked complete. This work makes new-run and resume separate, required choices on Bluesky only. Each path fails immediately when the dataset is in the other path's state. Resume may name a timestamp or ask for the latest unfinished run. Completed runs stay closed. Twitter and Reddit keep today's combined opener.
+
+## Happy flow
+
+An operator who wants a fresh timestamp runs the Bluesky new-run command with only a config path. An operator who wants to continue an interrupted run runs the resume command with that config path and either the existing raw timestamp or the latest-unfinished flag. The fetch loop, skip-set policy, and per-task ledger stay as they are.
+
+```mermaid
+flowchart TD
+  subgraph before [Before]
+    B1[Config-only Bluesky ingest]
+    B2{Unfinished raw run exists?}
+    B3[Resume latest unfinished]
+    B4[Create new timestamp]
+    B5[Named run dir, even if complete]
+    B1 --> B2
+    B2 -->|yes| B3
+    B2 -->|no| B4
+    B5 --> B3
+  end
+  subgraph after [After]
+    A1{Bluesky command}
+    A2[New-run]
+    A3[Resume]
+    A4{Unfinished run exists?}
+    A5[Create new timestamp]
+    A6[Fail: resume the unfinished run]
+    A7{How is the run chosen?}
+    A8[Named unfinished timestamp]
+    A9[Latest unfinished]
+    A10[Fail: missing, complete, both flags, or neither flag]
+    A1 --> A2
+    A1 --> A3
+    A2 --> A4
+    A4 -->|no| A5
+    A4 -->|yes| A6
+    A3 --> A7
+    A7 -->|run-dir and unfinished| A8
+    A7 -->|latest and one unfinished exists| A9
+    A7 -->|otherwise| A10
+  end
+```
+
+## Approach
+
+Add two openers next to the existing combined opener. Bluesky calls only the new openers. Twitter and Reddit keep calling the combined opener, so their CLI and tests stay as they are. Resume on Bluesky requires exactly one of a named timestamp or the latest-unfinished flag. Do not add a force-reopen flag.
+
+## Decisions
+
+1. New-run fails if the dataset already has an unfinished raw run.
+2. Resume fails if the named timestamp is missing, and it fails if that run is already complete.
+3. Resume `--latest` opens the newest unfinished raw run and fails if none exists.
+4. Resume requires exactly one of `--run-dir` or `--latest`. Both or neither is an error.
+5. The CLI requires the new-run command or the resume command. Config-only with no command is an error.
+6. Twitter, Reddit, the per-task fetch loop, skip-set policy, dataset manifest creation, and feature-generation resume stay as they are.
+
+## Steps
+
+### Step 1: Add fail-fast new-run and resume helpers beside the combined opener
+
+Add tests first for new-run on a clean dataset, new-run blocked by an unfinished run, resume of an unfinished named run, resume of the latest unfinished run, and resume rejected for a missing run, a completed run, or no unfinished run when latest is requested. Keep the combined opener in place for Twitter and Reddit.
+
+### Step 2: Require an explicit mode on Bluesky ingest only
+
+Replace the Bluesky config-only entrypoint with new-run and resume commands. Resume accepts a named timestamp or `--latest`. Update Bluesky module docs, `data_platform/README.md`, and the Bluesky sections of the ingest runbook. Leave Twitter and Reddit CLIs unchanged.
+
+## What "done" looks like
+
+1. Bluesky config-only ingest no longer creates or resumes a raw run. The operator must choose new-run or resume.
+2. Bluesky new-run always creates a new timestamp and refuses to run when an unfinished raw run already exists for that dataset.
+3. Bluesky resume opens an unfinished named timestamp, or the latest unfinished run when `--latest` is set. A missing directory, a completed run, both flags, neither flag, and `--latest` with no unfinished run all fail before any fetch.
+4. Twitter and Reddit still use the combined opener and the existing config-only CLI.
+5. `PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_sync_checkpoint.py tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py -q` exits 0.
+6. `PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q` exits 0 with no new failures.
+7. No reopen of completed runs. Feature-generation `--run-dir` is unchanged.

--- a/docs/plans/2026-09-03_explicit_ingest_run_modes_7b2e91/steps/step1.md
+++ b/docs/plans/2026-09-03_explicit_ingest_run_modes_7b2e91/steps/step1.md
@@ -1,0 +1,159 @@
+# Step 1: Add fail-fast new-run and resume helpers beside the combined opener
+
+## Goal
+
+Add two openers in the shared checkpoint module that cannot take the other branch: one that only creates a new raw run, and one that only loads an unfinished named run. Add a helper that requires a latest unfinished run and fails when none exists. Leave `prepare_sync_run` and `find_resume_run_dir` unchanged so Twitter and Reddit keep today's combined behavior.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/ingestion/sync_checkpoint.py` `start_new_sync_run`, `load_checkpoint_run`, and `require_latest_in_progress_run_dir`.
+
+**Task:** prove the four fail-fast outcomes and the `--latest` locator against storage and metadata, without wiring Bluesky yet.
+
+**Out of scope:** Bluesky CLI and `sync_records` split (Step 2). Twitter and Reddit scripts. Changing `prepare_sync_run` or `find_resume_run_dir`. Feature-generation `--run-dir`. Force-reopen of completed runs. `CHANGELOG.md`.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorView-task/data_platform/ingestion/sync_checkpoint.py` | `find_resume_run_dir`, `prepare_sync_run`, `validate_tasks_for_resume`, `flush_run_metadata`, `SyncStatus` |
+| `/Users/mark/src/work/mirrorView-task/tests/data_platform/ingestion/test_sync_checkpoint.py` | Existing `test_find_resume_run_dir_*` and metadata helpers. Pattern for storage fixtures |
+| `/Users/mark/src/work/mirrorView-task/tests/data_platform/constants.py` | `VALID_DATASET_ID` |
+| `/Users/mark/src/work/mirrorView-task/data_platform/utils/storage.py` | `create_new_run_dir`, `load_run_metadata`, `write_run_metadata_atomic` |
+
+## Files allowed to change
+
+- `/Users/mark/src/work/mirrorView-task/data_platform/ingestion/sync_checkpoint.py`
+- `/Users/mark/src/work/mirrorView-task/tests/data_platform/ingestion/test_sync_checkpoint.py`
+
+Plan package files under `/Users/mark/src/work/mirrorView-task/docs/plans/2026-09-03_explicit_ingest_run_modes_7b2e91/` may already be on the branch. Do not edit them during implementation.
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorView-task/data_platform/ingestion/sync_bluesky.py`
+- `/Users/mark/src/work/mirrorView-task/data_platform/ingestion/sync_twitter.py`
+- `/Users/mark/src/work/mirrorView-task/data_platform/ingestion/sync_reddit.py`
+- `/Users/mark/src/work/mirrorView-task/data_platform/README.md`
+- `/Users/mark/src/work/mirrorView-task/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md`
+- `/Users/mark/src/work/mirrorView-task/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py`
+- `/Users/mark/src/work/mirrorView-task/tests/data_platform/ingestion/test_sync_twitter_checkpoint.py`
+- `/Users/mark/src/work/mirrorView-task/tests/data_platform/ingestion/test_sync_reddit_checkpoint.py`
+- `/Users/mark/src/work/mirrorView-task/CHANGELOG.md`
+- Any file outside the allowed list, except git commits of this work
+
+## Contracts to lock
+
+Add these public helpers in `sync_checkpoint.py`. Do not change `prepare_sync_run` or `find_resume_run_dir`.
+
+```text
+def start_new_sync_run(
+    storage: StorageManager,
+    init_metadata_fn: Callable[[str], dict[str, Any]],
+) -> tuple[Path, dict[str, Any]]:
+
+def load_checkpoint_run(
+    storage: StorageManager,
+    sync_tasks: Sequence[HasTaskId],
+    run_dir_name: str,
+    entity_label: str,
+) -> tuple[Path, dict[str, Any]]:
+
+def require_latest_in_progress_run_dir(storage: StorageManager) -> Path:
+```
+
+Behavior:
+
+- `start_new_sync_run`: if `find_resume_run_dir(storage, run_dir_name=None)` is not None, raise `ValueError` whose message says an unfinished run exists and the operator must resume it. Otherwise call `get_current_timestamp()`, `storage.create_new_run_dir(sync_timestamp)`, `init_metadata_fn(sync_timestamp)`, `flush_run_metadata`, and return `(output_dir, metadata)`. Do not load existing metadata.
+- `load_checkpoint_run`: resolve `storage.root_dir / run_dir_name`. Raise `FileNotFoundError` if that path is not a directory. Load metadata. If `sync_status` is `completed`, raise `ValueError` whose message says the run is already completed. Call `validate_tasks_for_resume`. If `sync_status` is not `in_progress`, set it to `in_progress` and flush. Return `(run_dir, metadata)`. Never create a directory.
+- `require_latest_in_progress_run_dir`: call `find_resume_run_dir(storage, run_dir_name=None)`. If the result is None, raise `FileNotFoundError` whose message says no unfinished run exists. Otherwise return that path.
+- Numpy docstrings on all three.
+- Keep `prepare_sync_run` as the Twitter/Reddit combined opener. Keep `find_resume_run_dir` returning None when nothing is unfinished, including when `run_dir_name` is None.
+
+Do not add a `--force` flag or a reopen path for completed runs.
+
+## Test design
+
+One test class per new function. Use `BlueskyStorageManager` or `TwitterStorageManager` with the existing `data_root` fixture, matching `test_find_resume_run_dir_*`. Use `_StubTask` already in the file. Monkeypatch `get_current_timestamp` for new-run tests.
+
+```text
+given no raw runs
+when start_new_sync_run(storage, init_metadata_fn)
+then a new run directory named with the patched timestamp exists
+and metadata is the init payload flushed to disk
+
+given an in_progress raw run
+when start_new_sync_run(storage, init_metadata_fn)
+then raise ValueError matching "unfinished"
+and no additional run directory is created
+
+given only completed raw runs
+when start_new_sync_run(storage, init_metadata_fn)
+then a new run directory is created
+
+given an in_progress run whose tasks match the stub tasks
+when load_checkpoint_run(storage, tasks, that run dir name, "keywords")
+then return that directory and its metadata
+
+given no such directory
+when load_checkpoint_run(...)
+then raise FileNotFoundError
+
+given a completed run
+when load_checkpoint_run(...)
+then raise ValueError matching "completed"
+and metadata on disk stays completed
+
+given an in_progress run whose tasks do not match
+when load_checkpoint_run(...)
+then raise ValueError from validate_tasks_for_resume
+
+given a newer in_progress run and an older completed run
+when require_latest_in_progress_run_dir(storage)
+then return the newer in_progress directory
+
+given only completed runs, or no runs
+when require_latest_in_progress_run_dir(storage)
+then raise FileNotFoundError matching "unfinished"
+```
+
+Keep `test_find_resume_run_dir_specific_run` and `test_find_resume_run_dir_latest_in_progress` passing unchanged.
+
+## Implementation notes (implement-from-spec)
+
+Files already exist. Scaffold means adding the three helpers as `raise NotImplementedError` in `sync_checkpoint.py`. Do not put the real fail-fast logic in until Phase 5.
+
+Phase order, one Git commit per phase that changes the repo, and one commit per Phase 5 unit:
+
+1. Phase 1 scope. Confirm caller, file tree, and out-of-scope. No product-code commit if nothing on disk changes.
+2. Phase 2 scaffold. Add the three helpers with `raise NotImplementedError` and numpy docstrings. Commit.
+3. Phase 3 contracts. Confirm signatures match the freeze. Bodies stay stubs. Full auto. Commit only if signatures change.
+4. Phase 4 test design. Add the tests from the pseudocode. They must fail for `NotImplementedError`. Commit.
+5. Phase 5 units, in this order, one commit each:
+   1. Implement `require_latest_in_progress_run_dir`. Its tests pass.
+   2. Implement `load_checkpoint_run`. Its tests pass. `require_latest` tests stay green.
+   3. Implement `start_new_sync_run`. All new tests pass. Existing `find_resume_run_dir` and `prepare_sync_run` callers stay green.
+6. Phase 6. Run the must-pass commands. Confirm `prepare_sync_run` body is unchanged.
+
+## Must pass
+
+```bash
+cd /Users/mark/src/work/mirrorView-task
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_sync_checkpoint.py -q
+```
+
+Expected: exit 0.
+
+```bash
+cd /Users/mark/src/work/mirrorView-task
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
+```
+
+Expected: exit 0. Twitter and Reddit checkpoint tests still pass through `prepare_sync_run`.
+
+## Must fail / not happen
+
+- `prepare_sync_run` rewritten or deleted.
+- `find_resume_run_dir` now raising instead of returning None.
+- Bluesky, Twitter, or Reddit CLI changed.
+- Completed runs reopened as in_progress by the new helpers.
+- `CHANGELOG.md` edited.

--- a/docs/plans/2026-09-03_explicit_ingest_run_modes_7b2e91/steps/step2.md
+++ b/docs/plans/2026-09-03_explicit_ingest_run_modes_7b2e91/steps/step2.md
@@ -1,0 +1,200 @@
+# Step 2: Require an explicit mode on Bluesky ingest only
+
+## Goal
+
+Replace Bluesky's combined `sync_records` plus shared `run_sync_cli` with two public functions and two CLI commands: `new-run` and `resume`. Resume takes exactly one of `--run-dir` or `--latest`. Twitter and Reddit keep `sync_records` and `run_sync_cli`.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/ingestion/sync_bluesky.py` `main`, which dispatches to `sync_records_new_run` or `sync_records_from_checkpoint`.
+
+**Task:** load config and storage once, open the run with the Step 1 helpers, then run the existing keyword loop and finalize.
+
+**Out of scope:** Twitter and Reddit CLIs. Changing `prepare_sync_run` or `run_sync_cli`. Feature-generation `--run-dir`. Force-reopen. Dedup policy. `CHANGELOG.md`.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/Users/mark/src/work/mirrorView-task/data_platform/ingestion/sync_bluesky.py` | Current `sync_records`, stub functions, `main` via `run_sync_cli` |
+| `/Users/mark/src/work/mirrorView-task/data_platform/ingestion/sync_checkpoint.py` | Step 1 helpers, `run_sync_cli` (leave as-is), `ensure_dataset_manifest` |
+| `/Users/mark/src/work/mirrorView-task/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py` | `minimal_sync_config`, `make_bluesky_client`, `test_resume_skips_completed_tasks` |
+| `/Users/mark/src/work/mirrorView-task/tests/data_platform/ingestion/conftest.py` | Bluesky fixtures |
+| `/Users/mark/src/work/mirrorView-task/tests/data_platform/constants.py` | `TEST_INGEST_CONFIG_PATH`, `VALID_DATASET_ID` |
+| `/Users/mark/src/work/mirrorView-task/data_platform/README.md` | Bluesky ingest commands |
+| `/Users/mark/src/work/mirrorView-task/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md` | Bluesky sync sequence and checkpoint resume flow |
+
+## Files allowed to change
+
+- `/Users/mark/src/work/mirrorView-task/data_platform/ingestion/sync_bluesky.py`
+- `/Users/mark/src/work/mirrorView-task/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py`
+- `/Users/mark/src/work/mirrorView-task/data_platform/README.md`
+- `/Users/mark/src/work/mirrorView-task/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md`
+
+Do not edit the plan package during implementation.
+
+## Files forbidden to change
+
+- `/Users/mark/src/work/mirrorView-task/data_platform/ingestion/sync_checkpoint.py`
+- `/Users/mark/src/work/mirrorView-task/data_platform/ingestion/sync_twitter.py`
+- `/Users/mark/src/work/mirrorView-task/data_platform/ingestion/sync_reddit.py`
+- `/Users/mark/src/work/mirrorView-task/tests/data_platform/ingestion/test_sync_checkpoint.py`
+- `/Users/mark/src/work/mirrorView-task/tests/data_platform/ingestion/test_sync_twitter_checkpoint.py`
+- `/Users/mark/src/work/mirrorView-task/tests/data_platform/ingestion/test_sync_reddit_checkpoint.py`
+- `/Users/mark/src/work/mirrorView-task/CHANGELOG.md`
+- Any file outside the allowed list, except git commits of this work
+
+## Contracts to lock
+
+In `sync_bluesky.py`:
+
+Delete the `pass` stubs named `sync_records_from_start` and `sync_records_from_checkpoint` if they are still present. Do not keep a public `sync_records` that guesses new vs resume.
+
+```text
+def load_bluesky_sync_context(config_path: Path) -> BlueskySyncContext:
+
+def sync_records_new_run(config_path: Path) -> Path:
+
+def sync_records_from_checkpoint(
+    config_path: Path,
+    run_dir_name: str | None,
+    latest: bool,
+) -> Path:
+
+def execute_bluesky_sync(
+    context: BlueskySyncContext,
+    output_dir: Path,
+    metadata: dict[str, Any],
+) -> Path:
+```
+
+`BlueskySyncContext` is a frozen dataclass holding config, config_path, storage, ingestion_params, sync_tasks, client, and filename. `load_bluesky_sync_context` contains today's config load, `require_dataset_id`, `ensure_dataset_manifest`, storage construction, `build_sync_tasks`, record-type check, and `BlueskyClient()` construction.
+
+`sync_records_new_run`:
+
+- Load context.
+- `output_dir, metadata = start_new_sync_run(storage, init_metadata_fn=...)`.
+- Return `execute_bluesky_sync(...)`.
+
+`sync_records_from_checkpoint`:
+
+- Raise `ValueError` if `latest` is True and `run_dir_name` is not None.
+- Raise `ValueError` if `latest` is False and `run_dir_name` is None. Message must say resume requires exactly one of a named run directory or latest.
+- Load context.
+- If `latest`, `run_dir_name = require_latest_in_progress_run_dir(storage).name`.
+- `output_dir, metadata = load_checkpoint_run(storage, sync_tasks, run_dir_name, "keywords")`.
+- Return `execute_bluesky_sync(...)`.
+
+`execute_bluesky_sync` is today's `run_sync_tasks` plus `finalize_local_disk_sync` plus the existing print and return of `output_dir`.
+
+CLI: replace `run_sync_cli` with a Typer app that has two subcommands and `no_args_is_help=True`.
+
+```text
+PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py new-run \
+  --config data_platform/ingestion/configs/bluesky/mirrorview.yaml
+
+PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py resume \
+  --config data_platform/ingestion/configs/bluesky/mirrorview.yaml \
+  --run-dir 2026_05_30-12:00:00
+
+PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py resume \
+  --config data_platform/ingestion/configs/bluesky/mirrorview.yaml \
+  --latest
+```
+
+Both subcommands take `--config`. Resume takes `--run-dir` as optional str and `--latest` as a flag defaulting to False at the CLI layer only. The resume subcommand passes those two values into `sync_records_from_checkpoint` with no extra defaulting in the Python function.
+
+Module docstring, `data_platform/README.md` Bluesky ingest example, and the Bluesky sync / checkpoint sections of `docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md` must show `new-run` and `resume`, not config-only Bluesky ingest. The runbook sequence diagram must not say Bluesky calls `prepare_sync_run`. Leave Twitter and Reddit command examples as they are.
+
+Do not import or call `prepare_sync_run` or `run_sync_cli` from `sync_bluesky.py`.
+
+## Test design
+
+Add classes in `test_sync_bluesky_checkpoint.py`. Mock `BlueskyClient._search_posts_page` the same way as `test_run_sync_tasks_appends_per_keyword`. Write a real YAML file in the test tmp dir that matches `minimal_sync_config()`, or patch `load_yaml_config` / write YAML via the existing `TEST_INGEST_CONFIG_PATH` only if that file already matches. Prefer writing a temp YAML from `minimal_sync_config()` so tests do not depend on committed mirrorview YAML.
+
+Monkeypatch `get_current_timestamp` for new-run tests. Patch `BlueskyClient.__init__` or pass through the existing `make_bluesky_client` by monkeypatching `sync_bluesky.BlueskyClient` to a factory that returns `make_bluesky_client()`.
+
+```text
+given a temp config and no raw runs
+when sync_records_new_run(config_path)
+then a new run directory is created
+and both keyword tasks complete
+
+given an in_progress raw run for that dataset
+when sync_records_new_run(config_path)
+then raise ValueError matching "unfinished"
+
+given an in_progress run with alpha completed and beta pending
+when sync_records_from_checkpoint(config_path, run_dir_name=that_name, latest=False)
+then beta is fetched
+and alpha is not refetched
+
+given the same in_progress run
+when sync_records_from_checkpoint(config_path, run_dir_name=None, latest=True)
+then the same run directory is returned
+
+given no unfinished run
+when sync_records_from_checkpoint(config_path, run_dir_name=None, latest=True)
+then raise FileNotFoundError
+
+given a completed run
+when sync_records_from_checkpoint(config_path, run_dir_name=that_name, latest=False)
+then raise ValueError matching "completed"
+
+when sync_records_from_checkpoint(config_path, run_dir_name="x", latest=True)
+then raise ValueError matching "exactly one"
+
+when sync_records_from_checkpoint(config_path, run_dir_name=None, latest=False)
+then raise ValueError matching "exactly one"
+```
+
+Keep existing `run_sync_tasks` resume tests. They still prove the loop skips completed tasks.
+
+Optional: one `typer.testing.CliRunner` test that invoking the module with no subcommand exits non-zero or prints help. Skip if wiring the Typer app for import is awkward; the Python-level exclusivity tests are required.
+
+## Implementation notes (implement-from-spec)
+
+Phase order, one Git commit per phase that changes the repo, and one commit per Phase 5 unit:
+
+1. Phase 1 scope. Confirm caller and out-of-scope. No product-code commit if nothing on disk changes.
+2. Phase 2 scaffold. Add `BlueskySyncContext`, `load_bluesky_sync_context`, `sync_records_new_run`, `sync_records_from_checkpoint`, and `execute_bluesky_sync` as stubs (`raise NotImplementedError`). Point `main` at a Typer app with `new-run` and `resume` subcommands that call those functions. Delete `sync_records` and the `pass` stubs. Commit.
+3. Phase 3 contracts. Signatures match the freeze. Full auto.
+4. Phase 4 test design. Add the tests. They fail for `NotImplementedError` or missing exclusivity. Commit.
+5. Phase 5 units, in this order, one commit each:
+   1. Implement `load_bluesky_sync_context` and `execute_bluesky_sync`.
+   2. Implement `sync_records_from_checkpoint` exclusivity plus named and latest resume.
+   3. Implement `sync_records_new_run`.
+   4. Update `data_platform/README.md` and the ingest runbook Bluesky sections.
+6. Phase 6. Run the must-pass commands. Confirm Twitter and Reddit still import `run_sync_cli` and `prepare_sync_run`. Confirm `sync_bluesky.py` does not import those two names.
+
+## Must pass
+
+```bash
+cd /Users/mark/src/work/mirrorView-task
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_sync_checkpoint.py tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py -q
+```
+
+Expected: exit 0.
+
+```bash
+cd /Users/mark/src/work/mirrorView-task
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
+```
+
+Expected: exit 0. Twitter and Reddit tests unchanged.
+
+```bash
+cd /Users/mark/src/work/mirrorView-task
+PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py --help
+```
+
+Expected: exit 0. Help lists `new-run` and `resume`, not a config-only default command.
+
+## Must fail / not happen
+
+- Twitter or Reddit CLI changed.
+- `prepare_sync_run` or `run_sync_cli` called from `sync_bluesky.py`.
+- A public Bluesky `sync_records` that auto-resumes.
+- Completed Bluesky runs reopened.
+- Feature-generation scripts edited.
+- `CHANGELOG.md` edited.

--- a/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
+++ b/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
@@ -181,7 +181,7 @@ Run each stage from the repository root with `PYTHONPATH=.`.
 ### Step 1: Sync
 
 ```bash
-PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py \
+PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py new-run \
   --config data_platform/ingestion/configs/bluesky/smoke.yaml
 ```
 

--- a/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
+++ b/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
@@ -308,7 +308,7 @@ PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py resume \
   --run-dir <timestamp>
 ```
 
-Or resume the latest unfinished run with `--latest`. The config keywords must match the tasks recorded in that run's metadata. `validate_tasks_for_resume` raises if they differ. Completed runs are not reopened.
+Or resume the latest unfinished run with `--latest`. The config keywords must match the tasks recorded in that run's metadata. If the keywords differ, `validate_tasks_for_resume` raises an error. Completed runs are not reopened.
 
 ## Environment variables
 

--- a/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
+++ b/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md
@@ -249,9 +249,9 @@ sequenceDiagram
   participant SM as BlueskyStorageManager
   participant API as Bluesky API
 
-  Op->>CLI: --config smoke.yaml
-  CLI->>CP: require_dataset_id, prepare_sync_run
-  CP->>SM: create or resume raw/<timestamp>/
+  Op->>CLI: new-run --config smoke.yaml
+  CLI->>CP: require_dataset_id, start_new_sync_run
+  CP->>SM: create raw/<timestamp>/
   CP->>SM: ensure_dataset_manifest
   loop Each keyword task
     CLI->>API: searchPosts (via retry_bluesky_request)
@@ -267,11 +267,10 @@ sequenceDiagram
 
 ```mermaid
 flowchart TD
-  start([Operator runs sync CLI])
-  runDir{--run-dir provided?}
-  pin[Open raw/run-dir/]
-  find[find_resume_run_dir: newest incomplete raw run]
-  newRun[create_new_run_dir with new timestamp]
+  start([Operator runs Bluesky resume CLI])
+  mode{Named run or latest?}
+  pin[load_checkpoint_run raw/run-dir/]
+  find[require_latest_in_progress_run_dir]
   loadMeta[Load metadata.json tasks]
   loop{Next task}
   skipDone{Status completed or skipped?}
@@ -282,13 +281,11 @@ flowchart TD
   finalize[finalize_local_disk_sync]
   done([sync_status completed])
 
-  start --> runDir
-  runDir -->|yes| pin
-  runDir -->|no| find
-  find -->|found| pin
-  find -->|not found| newRun
+  start --> mode
+  mode -->|named| pin
+  mode -->|latest| find
   pin --> loadMeta
-  newRun --> loadMeta
+  find --> loadMeta
   loadMeta --> loop
   loop --> skipDone
   skipDone -->|yes| loop
@@ -303,15 +300,15 @@ flowchart TD
   finalize --> done
 ```
 
-To resume a large Bluesky sync after interrupt:
+To resume a large Bluesky sync after interrupt, name the run directory:
 
 ```bash
-PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py \
+PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py resume \
   --config data_platform/ingestion/configs/bluesky/mirrorview.yaml \
   --run-dir <timestamp>
 ```
 
-The config keywords must match the tasks recorded in that run's metadata. `validate_tasks_for_resume` raises if they differ.
+Or resume the latest unfinished run with `--latest`. The config keywords must match the tasks recorded in that run's metadata. `validate_tasks_for_resume` raises if they differ. Completed runs are not reopened.
 
 ## Environment variables
 

--- a/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py
+++ b/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py
@@ -4,10 +4,15 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from typer.testing import CliRunner
 
 from data_platform.ingestion import sync_bluesky
 from data_platform.ingestion.integrations.bluesky import BlueskyClient
-from data_platform.ingestion.sync_checkpoint import validate_tasks_for_resume
+from data_platform.ingestion.sync_checkpoint import (
+    SyncStatus,
+    flush_run_metadata,
+    validate_tasks_for_resume,
+)
 from data_platform.utils.storage import BlueskyStorageManager, StorageStage
 from tests.data_platform.conftest import make_ingestion_row
 from tests.data_platform.constants import TEST_INGEST_CONFIG_PATH, VALID_DATASET_ID
@@ -566,3 +571,242 @@ class TestFetchPostsForKeywordLimitPerTask:
         )
 
         assert len(result.rows) == expected
+
+
+PATCHED_SYNC_TIMESTAMP = "2026_05_30-11:00:00"
+
+
+def _patch_load_yaml_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sync_bluesky,
+        "load_yaml_config",
+        lambda path: minimal_sync_config(),
+    )
+
+
+def _patch_bluesky_client(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_search,
+) -> None:
+    monkeypatch.setattr(BlueskyClient, "_search_posts_page", fake_search)
+    monkeypatch.setattr(sync_bluesky, "BlueskyClient", lambda: make_bluesky_client())
+
+
+def _posts_by_query_search(posts_by_query: dict[str, list[Any]]):
+    def fake_search(
+        _self: Any,
+        _fetch_cfg: dict[str, Any],
+        query: str,
+        *,
+        page_limit: int,
+        cursor: str | None = None,
+    ):
+        return mock_search_response(posts_by_query[query])
+
+    return fake_search
+
+
+class TestSyncRecordsNewRun:
+    """Tests for sync_records_new_run()."""
+
+    def test_creates_run_and_completes_keyword_tasks(
+        self,
+        data_root,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _patch_load_yaml_config(monkeypatch)
+        monkeypatch.setattr(
+            "data_platform.ingestion.sync_checkpoint.get_current_timestamp",
+            lambda: PATCHED_SYNC_TIMESTAMP,
+        )
+        _patch_bluesky_client(
+            monkeypatch,
+            _posts_by_query_search(
+                {
+                    "alpha": [mock_post("at://did:plc:ex/app.bsky.feed.post/a1")],
+                    "beta": [mock_post("at://did:plc:ex/app.bsky.feed.post/b1")],
+                }
+            ),
+        )
+
+        result = sync_bluesky.sync_records_new_run(TEST_INGEST_CONFIG_PATH)
+
+        expected = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID).root_dir / (
+            PATCHED_SYNC_TIMESTAMP
+        )
+        assert result == expected
+        metadata = BlueskyStorageManager(
+            StorageStage.RAW, VALID_DATASET_ID
+        ).load_run_metadata(result)
+        assert metadata["tasks"]["alpha"]["status"] == "completed"
+        assert metadata["tasks"]["beta"]["status"] == "completed"
+
+    def test_raises_when_unfinished_run_exists(
+        self,
+        data_root,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _patch_load_yaml_config(monkeypatch)
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+        existing = storage.create_new_run_dir("2026_05_30-10:00:00")
+        flush_run_metadata(
+            storage,
+            existing,
+            {"sync_status": SyncStatus.IN_PROGRESS.value, "tasks": {}},
+        )
+        _patch_bluesky_client(
+            monkeypatch,
+            _posts_by_query_search({}),
+        )
+
+        with pytest.raises(ValueError, match="unfinished"):
+            sync_bluesky.sync_records_new_run(TEST_INGEST_CONFIG_PATH)
+
+
+class TestSyncRecordsFromCheckpoint:
+    """Tests for sync_records_from_checkpoint()."""
+
+    def _seed_in_progress_run(self) -> tuple[BlueskyStorageManager, Any]:
+        config = minimal_sync_config()
+        sync_tasks = sync_bluesky.build_sync_tasks(config["ingestion_params"])
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+        run_dir = storage.create_new_run_dir("2026_05_30-10:00:00")
+        metadata = sync_bluesky.init_sync_metadata(
+            config,
+            TEST_INGEST_CONFIG_PATH,
+            "2026_05_30-10:00:00",
+            sync_tasks,
+        )
+        metadata["tasks"]["alpha"]["status"] = "completed"
+        metadata["tasks"]["alpha"]["rows_collected"] = 1
+        storage.append_records(
+            [
+                make_ingestion_row(
+                    uri="at://did:plc:ex/app.bsky.feed.post/a1",
+                    url="https://bsky.app/profile/user/post/a1",
+                    author_handle="user",
+                    text="x",
+                )
+            ],
+            run_dir,
+        )
+        metadata["row_count"] = 1
+        storage.write_run_metadata_atomic(run_dir, metadata)
+        return storage, run_dir
+
+    def test_resumes_named_unfinished_run(
+        self,
+        data_root,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _patch_load_yaml_config(monkeypatch)
+        storage, run_dir = self._seed_in_progress_run()
+        calls: list[str] = []
+
+        def fake_search(
+            _self: Any,
+            _fetch_cfg: dict[str, Any],
+            query: str,
+            *,
+            page_limit: int,
+            cursor: str | None = None,
+        ):
+            calls.append(query)
+            return mock_search_response(
+                [mock_post("at://did:plc:ex/app.bsky.feed.post/b1")]
+            )
+
+        _patch_bluesky_client(monkeypatch, fake_search)
+
+        result = sync_bluesky.sync_records_from_checkpoint(
+            TEST_INGEST_CONFIG_PATH,
+            "2026_05_30-10:00:00",
+            False,
+        )
+
+        assert result == run_dir
+        assert calls == ["beta"]
+        metadata = storage.load_run_metadata(run_dir)
+        assert metadata["tasks"]["beta"]["status"] == "completed"
+
+    def test_resumes_latest_unfinished_run(
+        self,
+        data_root,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _patch_load_yaml_config(monkeypatch)
+        storage, run_dir = self._seed_in_progress_run()
+        _patch_bluesky_client(
+            monkeypatch,
+            _posts_by_query_search(
+                {
+                    "beta": [mock_post("at://did:plc:ex/app.bsky.feed.post/b1")],
+                }
+            ),
+        )
+
+        result = sync_bluesky.sync_records_from_checkpoint(
+            TEST_INGEST_CONFIG_PATH, None, True
+        )
+
+        assert result == run_dir
+        metadata = storage.load_run_metadata(run_dir)
+        assert metadata["tasks"]["beta"]["status"] == "completed"
+
+    def test_latest_raises_when_no_unfinished_run(
+        self,
+        data_root,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _patch_load_yaml_config(monkeypatch)
+        _patch_bluesky_client(monkeypatch, _posts_by_query_search({}))
+
+        with pytest.raises(FileNotFoundError):
+            sync_bluesky.sync_records_from_checkpoint(
+                TEST_INGEST_CONFIG_PATH, None, True
+            )
+
+    def test_raises_when_named_run_is_completed(
+        self,
+        data_root,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _patch_load_yaml_config(monkeypatch)
+        storage, run_dir = self._seed_in_progress_run()
+        metadata = storage.load_run_metadata(run_dir)
+        metadata["sync_status"] = SyncStatus.COMPLETED.value
+        metadata["tasks"]["beta"]["status"] = "completed"
+        storage.write_run_metadata_atomic(run_dir, metadata)
+        _patch_bluesky_client(monkeypatch, _posts_by_query_search({}))
+
+        with pytest.raises(ValueError, match="completed"):
+            sync_bluesky.sync_records_from_checkpoint(
+                TEST_INGEST_CONFIG_PATH,
+                "2026_05_30-10:00:00",
+                False,
+            )
+
+    def test_raises_when_both_run_dir_and_latest_are_set(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            sync_bluesky.sync_records_from_checkpoint(
+                TEST_INGEST_CONFIG_PATH,
+                "2026_05_30-10:00:00",
+                True,
+            )
+
+    def test_raises_when_neither_run_dir_nor_latest_is_set(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            sync_bluesky.sync_records_from_checkpoint(
+                TEST_INGEST_CONFIG_PATH, None, False
+            )
+
+
+class TestBlueskySyncCli:
+    """Tests for the Bluesky ingest Typer app."""
+
+    def test_help_lists_new_run_and_resume(self) -> None:
+        result = CliRunner().invoke(sync_bluesky.app, ["--help"])
+
+        assert result.exit_code == 0
+        assert "new-run" in result.stdout
+        assert "resume" in result.stdout

--- a/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py
+++ b/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py
@@ -800,7 +800,7 @@ class TestSyncRecordsFromCheckpoint:
     ) -> None:
         storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
 
-        with pytest.raises(ValueError, match="exactly one"):
+        with pytest.raises(ValueError, match="--run-dir or --latest"):
             sync_bluesky._resolve_resume_run_dir(storage, run_dir, latest)
 
 
@@ -819,5 +819,5 @@ class TestBlueskySyncCli:
     ) -> None:
         storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
 
-        with pytest.raises(ValueError, match="exactly one"):
+        with pytest.raises(ValueError, match="--run-dir or --latest"):
             sync_bluesky._resolve_resume_run_dir(storage, None, False)

--- a/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py
+++ b/tests/data_platform/ingestion/test_sync_bluesky_checkpoint.py
@@ -576,7 +576,9 @@ class TestFetchPostsForKeywordLimitPerTask:
 PATCHED_SYNC_TIMESTAMP = "2026_05_30-11:00:00"
 
 
-def _patch_load_yaml_config(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture
+def patched_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch load_yaml_config so TEST_INGEST_CONFIG_PATH resolves to minimal config."""
     monkeypatch.setattr(
         sync_bluesky,
         "load_yaml_config",
@@ -584,11 +586,9 @@ def _patch_load_yaml_config(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def _patch_bluesky_client(
-    monkeypatch: pytest.MonkeyPatch,
-    fake_search,
-) -> None:
-    monkeypatch.setattr(BlueskyClient, "_search_posts_page", fake_search)
+@pytest.fixture
+def bluesky_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch BlueskyClient to a no-op MagicMock-backed client."""
     monkeypatch.setattr(sync_bluesky, "BlueskyClient", lambda: make_bluesky_client())
 
 
@@ -612,15 +612,17 @@ class TestSyncRecordsNewRun:
     def test_creates_run_and_completes_keyword_tasks(
         self,
         data_root,
+        patched_config,
+        bluesky_client,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _patch_load_yaml_config(monkeypatch)
         monkeypatch.setattr(
             "data_platform.ingestion.sync_checkpoint.get_current_timestamp",
             lambda: PATCHED_SYNC_TIMESTAMP,
         )
-        _patch_bluesky_client(
-            monkeypatch,
+        monkeypatch.setattr(
+            BlueskyClient,
+            "_search_posts_page",
             _posts_by_query_search(
                 {
                     "alpha": [mock_post("at://did:plc:ex/app.bsky.feed.post/a1")],
@@ -644,19 +646,15 @@ class TestSyncRecordsNewRun:
     def test_raises_when_unfinished_run_exists(
         self,
         data_root,
-        monkeypatch: pytest.MonkeyPatch,
+        patched_config,
+        bluesky_client,
     ) -> None:
-        _patch_load_yaml_config(monkeypatch)
         storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
         existing = storage.create_new_run_dir("2026_05_30-10:00:00")
         flush_run_metadata(
             storage,
             existing,
             {"sync_status": SyncStatus.IN_PROGRESS.value, "tasks": {}},
-        )
-        _patch_bluesky_client(
-            monkeypatch,
-            _posts_by_query_search({}),
         )
 
         with pytest.raises(ValueError, match="unfinished"):
@@ -697,9 +695,10 @@ class TestSyncRecordsFromCheckpoint:
     def test_resumes_named_unfinished_run(
         self,
         data_root,
+        patched_config,
+        bluesky_client,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _patch_load_yaml_config(monkeypatch)
         storage, run_dir = self._seed_in_progress_run()
         calls: list[str] = []
 
@@ -716,12 +715,11 @@ class TestSyncRecordsFromCheckpoint:
                 [mock_post("at://did:plc:ex/app.bsky.feed.post/b1")]
             )
 
-        _patch_bluesky_client(monkeypatch, fake_search)
+        monkeypatch.setattr(BlueskyClient, "_search_posts_page", fake_search)
 
         result = sync_bluesky.sync_records_from_checkpoint(
             TEST_INGEST_CONFIG_PATH,
             "2026_05_30-10:00:00",
-            False,
         )
 
         assert result == run_dir
@@ -732,12 +730,14 @@ class TestSyncRecordsFromCheckpoint:
     def test_resumes_latest_unfinished_run(
         self,
         data_root,
+        patched_config,
+        bluesky_client,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _patch_load_yaml_config(monkeypatch)
         storage, run_dir = self._seed_in_progress_run()
-        _patch_bluesky_client(
-            monkeypatch,
+        monkeypatch.setattr(
+            BlueskyClient,
+            "_search_posts_page",
             _posts_by_query_search(
                 {
                     "beta": [mock_post("at://did:plc:ex/app.bsky.feed.post/b1")],
@@ -745,8 +745,11 @@ class TestSyncRecordsFromCheckpoint:
             ),
         )
 
+        resolved = sync_bluesky._resolve_resume_run_dir(
+            storage, None, True
+        )
         result = sync_bluesky.sync_records_from_checkpoint(
-            TEST_INGEST_CONFIG_PATH, None, True
+            TEST_INGEST_CONFIG_PATH, resolved
         )
 
         assert result == run_dir
@@ -756,49 +759,49 @@ class TestSyncRecordsFromCheckpoint:
     def test_latest_raises_when_no_unfinished_run(
         self,
         data_root,
-        monkeypatch: pytest.MonkeyPatch,
+        patched_config,
+        bluesky_client,
     ) -> None:
-        _patch_load_yaml_config(monkeypatch)
-        _patch_bluesky_client(monkeypatch, _posts_by_query_search({}))
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
 
         with pytest.raises(FileNotFoundError):
-            sync_bluesky.sync_records_from_checkpoint(
-                TEST_INGEST_CONFIG_PATH, None, True
-            )
+            sync_bluesky._resolve_resume_run_dir(storage, None, True)
 
     def test_raises_when_named_run_is_completed(
         self,
         data_root,
-        monkeypatch: pytest.MonkeyPatch,
+        patched_config,
+        bluesky_client,
     ) -> None:
-        _patch_load_yaml_config(monkeypatch)
         storage, run_dir = self._seed_in_progress_run()
         metadata = storage.load_run_metadata(run_dir)
         metadata["sync_status"] = SyncStatus.COMPLETED.value
         metadata["tasks"]["beta"]["status"] = "completed"
         storage.write_run_metadata_atomic(run_dir, metadata)
-        _patch_bluesky_client(monkeypatch, _posts_by_query_search({}))
 
         with pytest.raises(ValueError, match="completed"):
             sync_bluesky.sync_records_from_checkpoint(
                 TEST_INGEST_CONFIG_PATH,
                 "2026_05_30-10:00:00",
-                False,
             )
 
-    def test_raises_when_both_run_dir_and_latest_are_set(self) -> None:
-        with pytest.raises(ValueError, match="exactly one"):
-            sync_bluesky.sync_records_from_checkpoint(
-                TEST_INGEST_CONFIG_PATH,
-                "2026_05_30-10:00:00",
-                True,
-            )
+    @pytest.mark.parametrize(
+        "run_dir, latest",
+        [
+            ("2026_05_30-10:00:00", True),
+            (None, False),
+        ],
+    )
+    def test_resume_requires_run_dir_or_latest(
+        self,
+        data_root,
+        run_dir: str | None,
+        latest: bool,
+    ) -> None:
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
 
-    def test_raises_when_neither_run_dir_nor_latest_is_set(self) -> None:
         with pytest.raises(ValueError, match="exactly one"):
-            sync_bluesky.sync_records_from_checkpoint(
-                TEST_INGEST_CONFIG_PATH, None, False
-            )
+            sync_bluesky._resolve_resume_run_dir(storage, run_dir, latest)
 
 
 class TestBlueskySyncCli:
@@ -810,3 +813,11 @@ class TestBlueskySyncCli:
         assert result.exit_code == 0
         assert "new-run" in result.stdout
         assert "resume" in result.stdout
+
+    def test_resume_without_run_dir_or_latest_exits_with_error(
+        self,
+    ) -> None:
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+
+        with pytest.raises(ValueError, match="exactly one"):
+            sync_bluesky._resolve_resume_run_dir(storage, None, False)

--- a/tests/data_platform/ingestion/test_sync_checkpoint.py
+++ b/tests/data_platform/ingestion/test_sync_checkpoint.py
@@ -18,14 +18,17 @@ from data_platform.ingestion.sync_checkpoint import (
     flush_run_metadata,
     get_task_progress,
     increment_duplicate_skip_counters,
+    load_checkpoint_run,
     mark_remaining_tasks_skipped,
     mark_task_completed,
     parse_max_comments,
     parse_max_posts,
     record_type_to_filename,
     require_dataset_id,
+    require_latest_in_progress_run_dir,
     resolve_dedupe_policy,
     resolve_limit_per_task,
+    start_new_sync_run,
     stop_at_record_cap,
     sync_status_from_tasks,
     validate_tasks_for_resume,
@@ -159,6 +162,203 @@ def test_find_resume_run_dir_latest_in_progress(data_root) -> None:
     flush_run_metadata(storage, older, {"sync_status": SyncStatus.COMPLETED.value, "tasks": {}})
     flush_run_metadata(storage, newer, {"sync_status": SyncStatus.IN_PROGRESS.value, "tasks": {}})
     assert find_resume_run_dir(storage, run_dir_name=None) == newer
+
+
+PATCHED_SYNC_TIMESTAMP = "2026_05_30-11:00:00"
+
+
+def _new_run_metadata(sync_timestamp: str) -> dict[str, Any]:
+    return {
+        "sync_status": SyncStatus.IN_PROGRESS.value,
+        "sync_timestamp": sync_timestamp,
+        "tasks": {"alpha": {"status": TaskStatus.PENDING.value}},
+    }
+
+
+def _matching_stub_tasks() -> list[_StubTask]:
+    return [_StubTask("alpha")]
+
+
+class TestStartNewSyncRun:
+    """Tests for start_new_sync_run()."""
+
+    def test_creates_run_when_dataset_has_no_raw_runs(
+        self,
+        data_root,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+        monkeypatch.setattr(
+            "data_platform.ingestion.sync_checkpoint.get_current_timestamp",
+            lambda: PATCHED_SYNC_TIMESTAMP,
+        )
+
+        result_dir, result_metadata = start_new_sync_run(storage, _new_run_metadata)
+
+        expected_dir = storage.root_dir / PATCHED_SYNC_TIMESTAMP
+        expected_metadata = _new_run_metadata(PATCHED_SYNC_TIMESTAMP)
+        assert result_dir == expected_dir
+        assert result_metadata == expected_metadata
+        assert storage.load_run_metadata(result_dir) == expected_metadata
+
+    def test_raises_when_unfinished_run_exists(self, data_root) -> None:
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+        existing = storage.create_new_run_dir("2026_05_30-10:00:00")
+        flush_run_metadata(
+            storage,
+            existing,
+            {"sync_status": SyncStatus.IN_PROGRESS.value, "tasks": {}},
+        )
+        before = {path.name for path in storage.root_dir.iterdir() if path.is_dir()}
+
+        with pytest.raises(ValueError, match="unfinished"):
+            start_new_sync_run(storage, _new_run_metadata)
+
+        after = {path.name for path in storage.root_dir.iterdir() if path.is_dir()}
+        assert after == before
+
+    def test_creates_run_when_only_completed_runs_exist(
+        self,
+        data_root,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+        completed = storage.create_new_run_dir("2026_05_30-10:00:00")
+        flush_run_metadata(
+            storage,
+            completed,
+            {"sync_status": SyncStatus.COMPLETED.value, "tasks": {}},
+        )
+        monkeypatch.setattr(
+            "data_platform.ingestion.sync_checkpoint.get_current_timestamp",
+            lambda: PATCHED_SYNC_TIMESTAMP,
+        )
+
+        result_dir, result_metadata = start_new_sync_run(storage, _new_run_metadata)
+
+        expected_dir = storage.root_dir / PATCHED_SYNC_TIMESTAMP
+        assert result_dir == expected_dir
+        assert result_metadata["sync_timestamp"] == PATCHED_SYNC_TIMESTAMP
+        assert completed.is_dir()
+
+
+class TestLoadCheckpointRun:
+    """Tests for load_checkpoint_run()."""
+
+    def test_returns_unfinished_named_run(self, data_root) -> None:
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+        run_dir = storage.create_new_run_dir("2026_05_30-10:00:00")
+        metadata = {
+            "sync_status": SyncStatus.IN_PROGRESS.value,
+            "tasks": {"alpha": {"status": TaskStatus.PENDING.value}},
+        }
+        flush_run_metadata(storage, run_dir, metadata)
+
+        result_dir, result_metadata = load_checkpoint_run(
+            storage,
+            _matching_stub_tasks(),
+            "2026_05_30-10:00:00",
+            "keywords",
+        )
+
+        assert result_dir == run_dir
+        assert result_metadata["sync_status"] == SyncStatus.IN_PROGRESS.value
+        assert result_metadata["tasks"]["alpha"]["status"] == TaskStatus.PENDING.value
+
+    def test_raises_when_directory_is_missing(self, data_root) -> None:
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+
+        with pytest.raises(FileNotFoundError):
+            load_checkpoint_run(
+                storage,
+                _matching_stub_tasks(),
+                "2026_05_30-10:00:00",
+                "keywords",
+            )
+
+    def test_raises_when_run_is_completed(self, data_root) -> None:
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+        run_dir = storage.create_new_run_dir("2026_05_30-10:00:00")
+        metadata = {
+            "sync_status": SyncStatus.COMPLETED.value,
+            "tasks": {"alpha": {"status": TaskStatus.COMPLETED.value}},
+        }
+        flush_run_metadata(storage, run_dir, metadata)
+
+        with pytest.raises(ValueError, match="completed"):
+            load_checkpoint_run(
+                storage,
+                _matching_stub_tasks(),
+                "2026_05_30-10:00:00",
+                "keywords",
+            )
+
+        assert storage.load_run_metadata(run_dir)["sync_status"] == SyncStatus.COMPLETED.value
+
+    def test_raises_when_tasks_do_not_match(self, data_root) -> None:
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+        run_dir = storage.create_new_run_dir("2026_05_30-10:00:00")
+        flush_run_metadata(
+            storage,
+            run_dir,
+            {
+                "sync_status": SyncStatus.IN_PROGRESS.value,
+                "tasks": {
+                    "alpha": {"status": TaskStatus.PENDING.value},
+                    "extra": {"status": TaskStatus.PENDING.value},
+                },
+            },
+        )
+
+        with pytest.raises(ValueError, match="missing in metadata"):
+            load_checkpoint_run(
+                storage,
+                _matching_stub_tasks(),
+                "2026_05_30-10:00:00",
+                "keywords",
+            )
+
+
+class TestRequireLatestInProgressRunDir:
+    """Tests for require_latest_in_progress_run_dir()."""
+
+    def test_returns_newest_unfinished_run(self, data_root) -> None:
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+        older = storage.create_new_run_dir("2026_05_30-09:00:00")
+        newer = storage.create_new_run_dir("2026_05_30-10:00:00")
+        flush_run_metadata(
+            storage,
+            older,
+            {"sync_status": SyncStatus.COMPLETED.value, "tasks": {}},
+        )
+        flush_run_metadata(
+            storage,
+            newer,
+            {"sync_status": SyncStatus.IN_PROGRESS.value, "tasks": {}},
+        )
+
+        result = require_latest_in_progress_run_dir(storage)
+
+        expected = newer
+        assert result == expected
+
+    def test_raises_when_only_completed_runs_exist(self, data_root) -> None:
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+        completed = storage.create_new_run_dir("2026_05_30-10:00:00")
+        flush_run_metadata(
+            storage,
+            completed,
+            {"sync_status": SyncStatus.COMPLETED.value, "tasks": {}},
+        )
+
+        with pytest.raises(FileNotFoundError, match="unfinished"):
+            require_latest_in_progress_run_dir(storage)
+
+    def test_raises_when_no_runs_exist(self, data_root) -> None:
+        storage = BlueskyStorageManager(StorageStage.RAW, VALID_DATASET_ID)
+
+        with pytest.raises(FileNotFoundError, match="unfinished"):
+            require_latest_in_progress_run_dir(storage)
 
 
 def test_mark_task_completed_updates_entry_and_metadata(data_root) -> None:


### PR DESCRIPTION
## Problem

Bluesky ingest's `sync_records` command silently decides whether to start a new raw run or attach to an unfinished one. A plain config-only run resumes the latest in-progress timestamp, and a named run directory can be reopened even after it is marked completed. Operators cannot tell which behavior happened until after the command starts writing.

## Solution

Split Bluesky ingest into two explicit subcommands. `new-run` creates a fresh timestamp and fails if an unfinished run already exists. `resume` opens an unfinished run by name or with `--latest`, and fails fast when the run is missing, already completed, or when both/neither selection flag is provided. Twitter and Reddit keep the existing combined behavior for now.

Shared checkpoint helpers support the split: `start_new_sync_run`, `load_checkpoint_run`, and `require_latest_in_progress_run_dir` live beside the unchanged `prepare_sync_run` so the other platforms are unaffected.

## Purpose

Explicit run modes remove the ambiguity in raw ingest state and prevent accidental reuse of the wrong checkpoint. Scoping the CLI change to Bluesky keeps the PR small and avoids disrupting Twitter and Reddit workflows until the same pattern is needed there.

## How to run

```bash
# help shows the two commands
PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py --help

# start a fresh run (fails if an unfinished run exists)
PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py new-run \
  --config data_platform/ingestion/configs/bluesky/mirrorview.yaml

# resume by timestamp
PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py resume \
  --config data_platform/ingestion/configs/bluesky/mirrorview.yaml \
  --run-dir 2026_05_30-12:00:00

# resume the latest unfinished run
PYTHONPATH=. uv run python data_platform/ingestion/sync_bluesky.py resume \
  --config data_platform/ingestion/configs/bluesky/mirrorview.yaml \
  --latest

# tests
PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
PYTHONPATH=. uv run pytest tests/data_platform -q
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate commands to start a new Bluesky sync or resume an existing one.
  * Resuming supports selecting a named run or automatically using the latest unfinished run.
  * Added validation for invalid, missing, completed, or incompatible checkpoint runs.

* **Bug Fixes**
  * Improved checkpoint handling and metadata persistence during sync operations.

* **Tests**
  * Expanded coverage for new-run, resume, checkpoint validation, failure scenarios, and command-line help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->