### PR TITLE
Filter Reddit dump comments into sampled parquet files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+data_platform/ingestion/data_dumps/reddit/filtered/*.parquet filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,10 @@ experiments/fetch_reddit_pushshift_dump_2026_06_15/outputs/**
 !experiments/fetch_reddit_pushshift_dump_2026_06_15/outputs/*/high_toxic_comments.parquet
 !experiments/fetch_reddit_pushshift_dump_2026_06_15/outputs/*/metadata.json
 
+# Reddit monthly dump artifacts (keep filtered/.gitkeep)
+data_platform/ingestion/data_dumps/reddit/*.zst
+data_platform/ingestion/data_dumps/reddit/filtered/*.parquet
+
 __pycache__/
 **/__pycache__/
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -170,9 +170,8 @@ experiments/fetch_reddit_pushshift_dump_2026_06_15/outputs/**
 !experiments/fetch_reddit_pushshift_dump_2026_06_15/outputs/*/high_toxic_comments.parquet
 !experiments/fetch_reddit_pushshift_dump_2026_06_15/outputs/*/metadata.json
 
-# Reddit monthly dump artifacts (keep filtered/.gitkeep)
+# Reddit dump copies next to the spec. Source zst files live in the experiment.
 data_platform/ingestion/data_dumps/reddit/*.zst
-data_platform/ingestion/data_dumps/reddit/filtered/*.parquet
 
 __pycache__/
 **/__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-03
 
-1. Reddit monthly comment dumps can be filtered, sampled to 500,000 comments per month, and written as parquet using the same comment fields as live Reddit ingest. [PR #153](https://github.com/METResearchGroup/mirrorView-task/pull/153)
+1. Reddit monthly comment dumps from the Pushshift experiment can be filtered, sampled to 500,000 comments per month, and stored as git LFS parquet using the same comment fields as live Reddit ingest. [PR #153](https://github.com/METResearchGroup/mirrorView-task/pull/153)
 2. `data_platform` now uses "standardized" instead of "canonical" for shared column helpers and constants (`add_standardized_text_column`, `STANDARDIZED_TEXT_COLUMN`, and related names). Column values are unchanged. [PR #150](https://github.com/METResearchGroup/mirrorView-task/pull/150)
 3. New Reddit comment rows keep `comment_fullname`, `author`, `body`, `created_at`, and `sync_timestamp`. The writer still adds `record_id` from `comment_fullname`. Older comment files that still have extra columns will not load until you ingest the comments again. [PR #148](https://github.com/METResearchGroup/mirrorView-task/pull/148)
 4. Bluesky ingest now requires an explicit `new-run` or `resume` command. `new-run` refuses to start when an unfinished raw run exists; `resume` accepts a named timestamp or `--latest` and fails fast when the run is missing or already completed. Twitter and Reddit keep the combined start-or-resume behavior. [PR #145](https://github.com/METResearchGroup/mirrorView-task/pull/145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## 2026-09-03
 
-1. `data_platform` now uses "standardized" instead of "canonical" for shared column helpers and constants (`add_standardized_text_column`, `STANDARDIZED_TEXT_COLUMN`, and related names). Column values are unchanged. [PR #150](https://github.com/METResearchGroup/mirrorView-task/pull/150)
-2. New Reddit comment rows keep `comment_fullname`, `author`, `body`, `created_at`, and `sync_timestamp`. The writer still adds `record_id` from `comment_fullname`. Older comment files that still have extra columns will not load until you ingest the comments again. [PR #148](https://github.com/METResearchGroup/mirrorView-task/pull/148)
-3. Bluesky ingest now requires an explicit `new-run` or `resume` command. `new-run` refuses to start when an unfinished raw run exists; `resume` accepts a named timestamp or `--latest` and fails fast when the run is missing or already completed. Twitter and Reddit keep the combined start-or-resume behavior. [PR #145](https://github.com/METResearchGroup/mirrorView-task/pull/145)
-4. Raw ingest now writes a stable `record_id` on every row using the same `{integration}_{id}` keys as study stimuli (`bluesky_{sha256(uri)}`, `twitter_{tweet_id}`, `reddit_{post_reddit_id}_{comment_id}`). [PR #138](https://github.com/METResearchGroup/mirrorView-task/pull/138)
-5. Ingest, preprocess, and feature unlabeled skip now share one skip set session. The warmup names are gone. Callers load known ids for this run or for all runs before they drop, persist, or collapse. [PR #144](https://github.com/METResearchGroup/mirrorView-task/pull/144)
-6. Bluesky ingestion now delegates all API client work to `BlueskyClient` in `data_platform/ingestion/integrations/bluesky.py`. `sync_bluesky.py` now handles sync logic only, and the client can be tested on its own. [PR #143](https://github.com/METResearchGroup/mirrorView-task/pull/143)
+1. Reddit monthly comment dumps can be filtered, sampled to 500,000 comments per month, and written as parquet using the same comment fields as live Reddit ingest. [PR #153](https://github.com/METResearchGroup/mirrorView-task/pull/153)
+2. `data_platform` now uses "standardized" instead of "canonical" for shared column helpers and constants (`add_standardized_text_column`, `STANDARDIZED_TEXT_COLUMN`, and related names). Column values are unchanged. [PR #150](https://github.com/METResearchGroup/mirrorView-task/pull/150)
+3. New Reddit comment rows keep `comment_fullname`, `author`, `body`, `created_at`, and `sync_timestamp`. The writer still adds `record_id` from `comment_fullname`. Older comment files that still have extra columns will not load until you ingest the comments again. [PR #148](https://github.com/METResearchGroup/mirrorView-task/pull/148)
+4. Bluesky ingest now requires an explicit `new-run` or `resume` command. `new-run` refuses to start when an unfinished raw run exists; `resume` accepts a named timestamp or `--latest` and fails fast when the run is missing or already completed. Twitter and Reddit keep the combined start-or-resume behavior. [PR #145](https://github.com/METResearchGroup/mirrorView-task/pull/145)
+5. Raw ingest now writes a stable `record_id` on every row using the same `{integration}_{id}` keys as study stimuli (`bluesky_{sha256(uri)}`, `twitter_{tweet_id}`, `reddit_{post_reddit_id}_{comment_id}`). [PR #138](https://github.com/METResearchGroup/mirrorView-task/pull/138)
+6. Ingest, preprocess, and feature unlabeled skip now share one skip set session. The warmup names are gone. Callers load known ids for this run or for all runs before they drop, persist, or collapse. [PR #144](https://github.com/METResearchGroup/mirrorView-task/pull/144)
+7. Bluesky ingestion now delegates all API client work to `BlueskyClient` in `data_platform/ingestion/integrations/bluesky.py`. `sync_bluesky.py` now handles sync logic only, and the client can be tested on its own. [PR #143](https://github.com/METResearchGroup/mirrorView-task/pull/143)
 
 ## 2026-09-02
 

--- a/data_platform/ingestion/data_dumps/reddit/README.md
+++ b/data_platform/ingestion/data_dumps/reddit/README.md
@@ -1,9 +1,74 @@
 # Reddit data dump
 
+<-- NOTE TO AI AGENTS: do NOT touch this file. This file is READ-ONLY. If something here is incorrect or needs updating, inform the user and they will make the change themselves -->
+
 In `experiments/fetch_reddit_pushshift_dump_2026_06_15`, we grabbed some files from the Reddit PushShift dataset.
 
 We'll now use that dataset again as part of our data collection.
 
-Unlike in that previous experiment, here we'll keep ...
+Unlike in that previous experiment (where we specifically curated high-toxicity posts), here we'll keep most comments and downstream callers will manage filtering and cleanup.
 
-(The shape of this will match what Reddit data already looks like, so we can use the same interfaces).
+Our datasets, `RC_2025-05.zst` and `RC_2025-06.zst`, contain Reddit comments across 6 political subreddits. This dataset is specifically for comments, not posts. Generally, for our project we care mostly about the comments anyways, as posts tend to be less interesting to analyze (the "action" on Reddit happens in the comments section).
+
+Here is what one example comment looks like:
+
+```json
+{
+  "id": "mvbyos2",
+  "author": "momamil",
+  "link_id": "t3_1l09l1b",
+  "parent_id": "t3_1l09l1b",
+  "subreddit": "politics",
+  "body": "I want to throw tacos on the lawn of the nimrod who’s had the giant Trump No More Bullshit sign on his lawn for the last 10 years.",
+  "score": 1,
+  "created_utc": 1748736018,
+  "permalink": "/r/politics/comments/1l09l1b/trumps_hated_taco_nickname_is_catching_on/mvbyos2/"
+}
+```
+
+We have two types of comments:
+
+1. Top-level comments: a direct reply to a post. The aforementioned example is a top-level comment (the `link_id` and `parent_id` are the same).
+2. Nested comments: a comment of a comment.
+
+Here is an example of a nested comment:
+
+```json
+{
+  "id": "mvbyn04",
+  "author": "Impossible-Scene-416",
+  "link_id": "t3_1l09l1b",
+  "parent_id": "t1_mvbyhla",
+  "subreddit": "politics",
+  "body": "lol yes but tacos always fold",
+  "score": 7,
+  "created_utc": 1748736000,
+  "permalink": "/r/politics/comments/1l09l1b/trumps_hated_taco_nickname_is_catching_on/mvbyn04/"
+}
+```
+
+For our use case, we only care about `id` and `body`.
+
+We also filter out posts that have been deleted or removed. For these, we look for either `post["author"] == "[deleted]"` or `post["body"] == "[deleted]"`. Here's an example:
+
+```json
+{
+  "id": "mvbynz6",
+  "author": "[deleted]",
+  "link_id": "t3_1l07f6o",
+  "parent_id": "t3_1l07f6o",
+  "subreddit": "Conservative",
+  "body": "[removed]",
+  "score": 1,
+  "created_utc": 1748736010,
+  "permalink": "/r/Conservative/comments/1l07f6o/be_warned_rosie_odonnell_vows_to_return_to_the_us/mvbynz6/"
+}
+```
+
+What we do here is:
+
+1. Process each of the two `.zst` files separately.
+2. Filter out comments that have been deleted or removed.
+3. Represent each comment using the same Pydantic model that we use for other Reddit data.
+4. Sample a random sample of 500,000 posts from each file.
+5. Store as `.parquet` files (`filtered/RC_2025-{05/06}.parquet`).

--- a/data_platform/ingestion/data_dumps/reddit/README.md
+++ b/data_platform/ingestion/data_dumps/reddit/README.md
@@ -1,0 +1,9 @@
+# Reddit data dump
+
+In `experiments/fetch_reddit_pushshift_dump_2026_06_15`, we grabbed some files from the Reddit PushShift dataset.
+
+We'll now use that dataset again as part of our data collection.
+
+Unlike in that previous experiment, here we'll keep ...
+
+(The shape of this will match what Reddit data already looks like, so we can use the same interfaces).

--- a/data_platform/ingestion/data_dumps/reddit/filtered/RC_2025-05.parquet
+++ b/data_platform/ingestion/data_dumps/reddit/filtered/RC_2025-05.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c0adb4302728c7ef879f8b870978a0f25798ce67ce83f15c225723c4e726337
+size 80622760

--- a/data_platform/ingestion/data_dumps/reddit/filtered/RC_2025-06.parquet
+++ b/data_platform/ingestion/data_dumps/reddit/filtered/RC_2025-06.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8b5f27b2c470847809a51b8dd116b6b37087c947fc5bd5e17bdede7d6700540
+size 79505707

--- a/data_platform/ingestion/data_dumps/reddit/filters.py
+++ b/data_platform/ingestion/data_dumps/reddit/filters.py
@@ -21,4 +21,10 @@ def keep_dump_comment(comment: DumpCommentRaw) -> bool:
         False when author or body, after stripping, is ``[deleted]`` or
         ``[removed]``. True otherwise.
     """
-    raise NotImplementedError
+    author = comment.author.strip()
+    body = comment.body.strip()
+    if author in DELETED_BODY_OR_AUTHOR_TOKENS:
+        return False
+    if body in DELETED_BODY_OR_AUTHOR_TOKENS:
+        return False
+    return True

--- a/data_platform/ingestion/data_dumps/reddit/filters.py
+++ b/data_platform/ingestion/data_dumps/reddit/filters.py
@@ -8,7 +8,7 @@ DELETED_BODY_OR_AUTHOR_TOKENS = frozenset({"[deleted]", "[removed]"})
 
 
 def keep_dump_comment(comment: DumpCommentRaw) -> bool:
-    """Return True when author and body are not deleted or removed tokens.
+    """Return True when author and body are not the strings ``[deleted]`` or ``[removed]``.
 
     Parameters
     ----------
@@ -18,8 +18,8 @@ def keep_dump_comment(comment: DumpCommentRaw) -> bool:
     Returns
     -------
     bool
-        False when author or body, after stripping, is ``[deleted]`` or
-        ``[removed]``. True otherwise.
+        False when author or body, after leading and trailing spaces are
+        removed, is ``[deleted]`` or ``[removed]``. True in every other case.
     """
     author = comment.author.strip()
     body = comment.body.strip()

--- a/data_platform/ingestion/data_dumps/reddit/filters.py
+++ b/data_platform/ingestion/data_dumps/reddit/filters.py
@@ -1,0 +1,24 @@
+"""Keep dump comments that are not deleted or removed."""
+
+from __future__ import annotations
+
+from data_platform.ingestion.data_dumps.reddit.models import DumpCommentRaw
+
+DELETED_BODY_OR_AUTHOR_TOKENS = frozenset({"[deleted]", "[removed]"})
+
+
+def keep_dump_comment(comment: DumpCommentRaw) -> bool:
+    """Return True when author and body are not deleted or removed tokens.
+
+    Parameters
+    ----------
+    comment
+        One dump comment.
+
+    Returns
+    -------
+    bool
+        False when author or body, after stripping, is ``[deleted]`` or
+        ``[removed]``. True otherwise.
+    """
+    raise NotImplementedError

--- a/data_platform/ingestion/data_dumps/reddit/models.py
+++ b/data_platform/ingestion/data_dumps/reddit/models.py
@@ -1,0 +1,25 @@
+"""Raw comment objects parsed from a Reddit dump JSONL line."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class DumpCommentRaw(BaseModel):
+    """One comment line from a Reddit dump file.
+
+    Extra dump JSON keys are ignored. Only the fields needed to build a
+    Reddit ingest comment row are kept.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    author: str
+    link_id: str
+    parent_id: str
+    subreddit: str
+    body: str
+    score: int
+    created_utc: int
+    permalink: str | None = None

--- a/data_platform/ingestion/data_dumps/reddit/process_dump.py
+++ b/data_platform/ingestion/data_dumps/reddit/process_dump.py
@@ -12,7 +12,8 @@ Process one file:
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+import argparse
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 from random import Random
 
@@ -21,7 +22,11 @@ import pandas as pd
 from data_platform.ingestion.data_dumps.reddit.filters import keep_dump_comment
 from data_platform.ingestion.data_dumps.reddit.models import DumpCommentRaw
 from data_platform.ingestion.data_dumps.reddit.reader import iter_dump_comments
-from data_platform.ingestion.data_dumps.reddit.sample import reservoir_sample
+from data_platform.ingestion.data_dumps.reddit.sample import (
+    DEFAULT_SAMPLE_SEED,
+    DEFAULT_SAMPLE_SIZE,
+    reservoir_sample,
+)
 from data_platform.ingestion.data_dumps.reddit.transform import dump_comment_to_sync_row
 from data_platform.models.sync import SyncRedditCommentModel
 from lib.timestamp_utils import get_current_timestamp
@@ -30,6 +35,8 @@ DUMP_DIR = Path("data_platform/ingestion/data_dumps/reddit")
 FILTERED_DIR = DUMP_DIR / "filtered"
 DEFAULT_DUMP_STEMS = ("RC_2025-05", "RC_2025-06")
 PARQUET_INDEX = False
+ZST_SUFFIX = ".zst"
+PARQUET_SUFFIX = ".parquet"
 
 
 def _require_processable_paths(input_path: Path, output_path: Path) -> None:
@@ -108,6 +115,23 @@ def process_dump_file(
     return output_path
 
 
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Filter and sample Reddit dump comments into parquet."
+    )
+    parser.add_argument("--input-file", action="append", dest="input_files")
+    parser.add_argument("--output-dir", type=Path, default=FILTERED_DIR)
+    parser.add_argument("--sample-size", type=int, default=DEFAULT_SAMPLE_SIZE)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SAMPLE_SEED)
+    return parser.parse_args(argv)
+
+
+def _input_paths(input_files: Sequence[str] | None) -> list[Path]:
+    if input_files:
+        return [Path(path) for path in input_files]
+    return [DUMP_DIR / f"{stem}{ZST_SUFFIX}" for stem in DEFAULT_DUMP_STEMS]
+
+
 def main(argv: list[str] | None = None) -> None:
     """Process dump files from command-line arguments.
 
@@ -116,7 +140,16 @@ def main(argv: list[str] | None = None) -> None:
     argv
         Argument list without the program name. ``None`` reads ``sys.argv``.
     """
-    raise NotImplementedError
+    args = _parse_args(argv)
+    for input_path in _input_paths(args.input_files):
+        output_path = args.output_dir / f"{input_path.stem}{PARQUET_SUFFIX}"
+        process_dump_file(
+            input_path,
+            output_path,
+            args.sample_size,
+            args.seed,
+            get_current_timestamp(),
+        )
 
 
 if __name__ == "__main__":

--- a/data_platform/ingestion/data_dumps/reddit/process_dump.py
+++ b/data_platform/ingestion/data_dumps/reddit/process_dump.py
@@ -1,10 +1,10 @@
-"""Filter, sample, and write Reddit dump comments to parquet.
+"""Filter Reddit dump comments and write a sampled parquet file.
 
-Run from the repo root:
+Run this from the repo root.
 
     PYTHONPATH=. uv run python data_platform/ingestion/data_dumps/reddit/process_dump.py
 
-Process one file:
+To process one file, pass `--input-file` like this.
 
     PYTHONPATH=. uv run python data_platform/ingestion/data_dumps/reddit/process_dump.py \\
         --input-file data_platform/ingestion/data_dumps/reddit/RC_2025-05.zst
@@ -117,7 +117,7 @@ def process_dump_file(
 
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Filter and sample Reddit dump comments into parquet."
+        description="Filter Reddit dump comments, sample the comments that remain, and write them to parquet."
     )
     parser.add_argument("--input-file", action="append", dest="input_files")
     parser.add_argument("--output-dir", type=Path, default=FILTERED_DIR)

--- a/data_platform/ingestion/data_dumps/reddit/process_dump.py
+++ b/data_platform/ingestion/data_dumps/reddit/process_dump.py
@@ -71,7 +71,7 @@ def _rows_for_sampled_comments(
 def _write_comment_parquet(rows: list[dict[str, object]], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     fieldnames = list(SyncRedditCommentModel.model_fields.keys())
-    frame = pd.DataFrame(rows) if rows else pd.DataFrame(columns=fieldnames)
+    frame = pd.DataFrame(rows, columns=fieldnames, dtype="str")
     frame.to_parquet(output_path, index=PARQUET_INDEX)
 
 
@@ -116,6 +116,7 @@ def process_dump_file(
         Random(sample_seed),
     )
     rows = _rows_for_sampled_comments(sampled, sync_timestamp)
+    del sampled
     _write_comment_parquet(rows, output_path)
     return output_path
 
@@ -137,6 +138,38 @@ def _input_paths(input_files: Sequence[str] | None) -> list[Path]:
     return [SOURCE_DUMP_DIR / f"{stem}{ZST_SUFFIX}" for stem in DEFAULT_DUMP_STEMS]
 
 
+def _default_input_paths_that_exist(paths: list[Path]) -> list[Path]:
+    existing: list[Path] = []
+    for path in paths:
+        if path.is_file():
+            existing.append(path)
+            continue
+        print(f"Skipping missing dump file {path}", flush=True)
+    if not existing:
+        raise FileNotFoundError(SOURCE_DUMP_DIR)
+    return existing
+
+
+def _jobs_to_process(
+    input_files: Sequence[str] | None,
+    output_dir: Path,
+) -> list[tuple[Path, Path]]:
+    requested = _input_paths(input_files)
+    if input_files:
+        for path in requested:
+            if not path.is_file():
+                raise FileNotFoundError(path)
+        selected = requested
+    else:
+        selected = _default_input_paths_that_exist(requested)
+    jobs = [
+        (path, output_dir / f"{path.stem}{PARQUET_SUFFIX}") for path in selected
+    ]
+    for input_path, output_path in jobs:
+        _require_processable_paths(input_path, output_path)
+    return jobs
+
+
 def main(argv: list[str] | None = None) -> None:
     """Process dump files from command-line arguments.
 
@@ -146,8 +179,8 @@ def main(argv: list[str] | None = None) -> None:
         Argument list without the program name. ``None`` reads ``sys.argv``.
     """
     args = _parse_args(argv)
-    for input_path in _input_paths(args.input_files):
-        output_path = args.output_dir / f"{input_path.stem}{PARQUET_SUFFIX}"
+    jobs = _jobs_to_process(args.input_files, args.output_dir)
+    for input_path, output_path in jobs:
         print(f"Processing {input_path} -> {output_path}", flush=True)
         process_dump_file(
             input_path,

--- a/data_platform/ingestion/data_dumps/reddit/process_dump.py
+++ b/data_platform/ingestion/data_dumps/reddit/process_dump.py
@@ -4,10 +4,12 @@ Run this from the repo root.
 
     PYTHONPATH=. uv run python data_platform/ingestion/data_dumps/reddit/process_dump.py
 
-To process one file, pass `--input-file` like this.
+With no ``--input-file``, the command reads the May and June dump files in
+``experiments/fetch_reddit_pushshift_dump_2026_06_15/data/raw/bolun/comments/``.
+To process one file, pass ``--input-file``.
 
     PYTHONPATH=. uv run python data_platform/ingestion/data_dumps/reddit/process_dump.py \\
-        --input-file data_platform/ingestion/data_dumps/reddit/RC_2025-05.zst
+        --input-file experiments/fetch_reddit_pushshift_dump_2026_06_15/data/raw/bolun/comments/RC_2025-05.zst
 """
 
 from __future__ import annotations
@@ -31,6 +33,9 @@ from data_platform.ingestion.data_dumps.reddit.transform import dump_comment_to_
 from data_platform.models.sync import SyncRedditCommentModel
 from lib.timestamp_utils import get_current_timestamp
 
+SOURCE_DUMP_DIR = Path(
+    "experiments/fetch_reddit_pushshift_dump_2026_06_15/data/raw/bolun/comments"
+)
 DUMP_DIR = Path("data_platform/ingestion/data_dumps/reddit")
 FILTERED_DIR = DUMP_DIR / "filtered"
 DEFAULT_DUMP_STEMS = ("RC_2025-05", "RC_2025-06")
@@ -129,7 +134,7 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
 def _input_paths(input_files: Sequence[str] | None) -> list[Path]:
     if input_files:
         return [Path(path) for path in input_files]
-    return [DUMP_DIR / f"{stem}{ZST_SUFFIX}" for stem in DEFAULT_DUMP_STEMS]
+    return [SOURCE_DUMP_DIR / f"{stem}{ZST_SUFFIX}" for stem in DEFAULT_DUMP_STEMS]
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -143,6 +148,7 @@ def main(argv: list[str] | None = None) -> None:
     args = _parse_args(argv)
     for input_path in _input_paths(args.input_files):
         output_path = args.output_dir / f"{input_path.stem}{PARQUET_SUFFIX}"
+        print(f"Processing {input_path} -> {output_path}", flush=True)
         process_dump_file(
             input_path,
             output_path,
@@ -150,6 +156,7 @@ def main(argv: list[str] | None = None) -> None:
             args.seed,
             get_current_timestamp(),
         )
+        print(f"Wrote {output_path}", flush=True)
 
 
 if __name__ == "__main__":

--- a/data_platform/ingestion/data_dumps/reddit/process_dump.py
+++ b/data_platform/ingestion/data_dumps/reddit/process_dump.py
@@ -1,0 +1,71 @@
+"""Filter, sample, and write Reddit dump comments to parquet.
+
+Run from the repo root:
+
+    PYTHONPATH=. uv run python data_platform/ingestion/data_dumps/reddit/process_dump.py
+
+Process one file:
+
+    PYTHONPATH=. uv run python data_platform/ingestion/data_dumps/reddit/process_dump.py \\
+        --input-file data_platform/ingestion/data_dumps/reddit/RC_2025-05.zst
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DUMP_DIR = Path("data_platform/ingestion/data_dumps/reddit")
+FILTERED_DIR = DUMP_DIR / "filtered"
+DEFAULT_DUMP_STEMS = ("RC_2025-05", "RC_2025-06")
+
+
+def process_dump_file(
+    input_path: Path,
+    output_path: Path,
+    sample_size: int,
+    sample_seed: int,
+    sync_timestamp: str,
+) -> Path:
+    """Filter, sample, and write one dump file to parquet.
+
+    Parameters
+    ----------
+    input_path
+        Compressed dump JSONL file.
+    output_path
+        Destination parquet path. Must not already exist.
+    sample_size
+        Maximum number of kept comments to write.
+    sample_seed
+        Seed for reservoir sampling.
+    sync_timestamp
+        Run timestamp written onto every output row.
+
+    Returns
+    -------
+    Path
+        ``output_path`` after a successful write.
+
+    Raises
+    ------
+    FileNotFoundError
+        When ``input_path`` is not a file.
+    FileExistsError
+        When ``output_path`` already exists.
+    """
+    raise NotImplementedError
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Process dump files from command-line arguments.
+
+    Parameters
+    ----------
+    argv
+        Argument list without the program name. ``None`` reads ``sys.argv``.
+    """
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    main()

--- a/data_platform/ingestion/data_dumps/reddit/process_dump.py
+++ b/data_platform/ingestion/data_dumps/reddit/process_dump.py
@@ -12,13 +12,55 @@ Process one file:
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
+from random import Random
 
+import pandas as pd
+
+from data_platform.ingestion.data_dumps.reddit.filters import keep_dump_comment
+from data_platform.ingestion.data_dumps.reddit.models import DumpCommentRaw
+from data_platform.ingestion.data_dumps.reddit.reader import iter_dump_comments
+from data_platform.ingestion.data_dumps.reddit.sample import reservoir_sample
+from data_platform.ingestion.data_dumps.reddit.transform import dump_comment_to_sync_row
+from data_platform.models.sync import SyncRedditCommentModel
 from lib.timestamp_utils import get_current_timestamp
 
 DUMP_DIR = Path("data_platform/ingestion/data_dumps/reddit")
 FILTERED_DIR = DUMP_DIR / "filtered"
 DEFAULT_DUMP_STEMS = ("RC_2025-05", "RC_2025-06")
+PARQUET_INDEX = False
+
+
+def _require_processable_paths(input_path: Path, output_path: Path) -> None:
+    if not input_path.is_file():
+        raise FileNotFoundError(input_path)
+    if output_path.exists():
+        raise FileExistsError(output_path)
+
+
+def _iter_kept_dump_comments(input_path: Path) -> Iterator[DumpCommentRaw]:
+    for comment in iter_dump_comments(input_path):
+        if keep_dump_comment(comment):
+            yield comment
+
+
+def _rows_for_sampled_comments(
+    comments: list[DumpCommentRaw],
+    sync_timestamp: str,
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for comment in comments:
+        mapped = dump_comment_to_sync_row(comment, sync_timestamp)
+        rows.append(SyncRedditCommentModel.model_validate(mapped).model_dump())
+    return rows
+
+
+def _write_comment_parquet(rows: list[dict[str, object]], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = list(SyncRedditCommentModel.model_fields.keys())
+    frame = pd.DataFrame(rows) if rows else pd.DataFrame(columns=fieldnames)
+    frame.to_parquet(output_path, index=PARQUET_INDEX)
 
 
 def process_dump_file(
@@ -55,7 +97,15 @@ def process_dump_file(
     FileExistsError
         When ``output_path`` already exists.
     """
-    raise NotImplementedError
+    _require_processable_paths(input_path, output_path)
+    sampled = reservoir_sample(
+        _iter_kept_dump_comments(input_path),
+        sample_size,
+        Random(sample_seed),
+    )
+    rows = _rows_for_sampled_comments(sampled, sync_timestamp)
+    _write_comment_parquet(rows, output_path)
+    return output_path
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/data_platform/ingestion/data_dumps/reddit/process_dump.py
+++ b/data_platform/ingestion/data_dumps/reddit/process_dump.py
@@ -165,9 +165,18 @@ def _jobs_to_process(
     jobs = [
         (path, output_dir / f"{path.stem}{PARQUET_SUFFIX}") for path in selected
     ]
+    _require_unique_output_paths(jobs)
     for input_path, output_path in jobs:
         _require_processable_paths(input_path, output_path)
     return jobs
+
+
+def _require_unique_output_paths(jobs: list[tuple[Path, Path]]) -> None:
+    seen: set[Path] = set()
+    for _, output_path in jobs:
+        if output_path in seen:
+            raise ValueError(f"duplicate output path {output_path}")
+        seen.add(output_path)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/data_platform/ingestion/data_dumps/reddit/process_dump.py
+++ b/data_platform/ingestion/data_dumps/reddit/process_dump.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from lib.timestamp_utils import get_current_timestamp
+
 DUMP_DIR = Path("data_platform/ingestion/data_dumps/reddit")
 FILTERED_DIR = DUMP_DIR / "filtered"
 DEFAULT_DUMP_STEMS = ("RC_2025-05", "RC_2025-06")

--- a/data_platform/ingestion/data_dumps/reddit/reader.py
+++ b/data_platform/ingestion/data_dumps/reddit/reader.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import io
+import json
 from collections.abc import Iterator
 from pathlib import Path
 
+import zstandard as zstd
+
 from data_platform.ingestion.data_dumps.reddit.models import DumpCommentRaw
+
+ZSTD_MAX_WINDOW_SIZE = 2**31
 
 
 def iter_dump_comments(input_path: Path) -> Iterator[DumpCommentRaw]:
@@ -28,4 +34,19 @@ def iter_dump_comments(input_path: Path) -> Iterator[DumpCommentRaw]:
     FileNotFoundError
         When ``input_path`` is not a file.
     """
-    raise NotImplementedError
+    if not input_path.is_file():
+        raise FileNotFoundError(input_path)
+
+    decompressor = zstd.ZstdDecompressor(max_window_size=ZSTD_MAX_WINDOW_SIZE)
+    with input_path.open("rb") as handle:
+        with decompressor.stream_reader(handle) as compressed_reader:
+            text_reader = io.TextIOWrapper(compressed_reader, encoding="utf-8")
+            for line in text_reader:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    raw = json.loads(stripped)
+                    yield DumpCommentRaw.model_validate(raw)
+                except (json.JSONDecodeError, ValueError):
+                    continue

--- a/data_platform/ingestion/data_dumps/reddit/reader.py
+++ b/data_platform/ingestion/data_dumps/reddit/reader.py
@@ -1,0 +1,31 @@
+"""Stream JSONL comment records from compressed Reddit dump files."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from data_platform.ingestion.data_dumps.reddit.models import DumpCommentRaw
+
+
+def iter_dump_comments(input_path: Path) -> Iterator[DumpCommentRaw]:
+    """Yield parsed dump comments from a compressed JSONL file.
+
+    Blank lines, invalid JSON, and rows that fail validation are skipped.
+
+    Parameters
+    ----------
+    input_path
+        Path to a zstd-compressed JSONL dump file.
+
+    Yields
+    ------
+    DumpCommentRaw
+        One validated dump comment.
+
+    Raises
+    ------
+    FileNotFoundError
+        When ``input_path`` is not a file.
+    """
+    raise NotImplementedError

--- a/data_platform/ingestion/data_dumps/reddit/reader.py
+++ b/data_platform/ingestion/data_dumps/reddit/reader.py
@@ -47,6 +47,7 @@ def iter_dump_comments(input_path: Path) -> Iterator[DumpCommentRaw]:
                     continue
                 try:
                     raw = json.loads(stripped)
-                    yield DumpCommentRaw.model_validate(raw)
-                except (json.JSONDecodeError, ValueError):
+                    comment = DumpCommentRaw.model_validate(raw)
+                except ValueError:
                     continue
+                yield comment

--- a/data_platform/ingestion/data_dumps/reddit/sample.py
+++ b/data_platform/ingestion/data_dumps/reddit/sample.py
@@ -10,6 +10,8 @@ T = TypeVar("T")
 
 DEFAULT_SAMPLE_SIZE = 500_000
 DEFAULT_SAMPLE_SEED = 20260615
+MIN_SAMPLE_SIZE = 1
+ONE_BASED_OFFSET = 1
 
 
 def reservoir_sample(items: Iterator[T], sample_size: int, rng: Random) -> list[T]:
@@ -35,4 +37,15 @@ def reservoir_sample(items: Iterator[T], sample_size: int, rng: Random) -> list[
     ValueError
         When ``sample_size`` is less than 1.
     """
-    raise NotImplementedError
+    if sample_size < MIN_SAMPLE_SIZE:
+        raise ValueError("sample_size must be at least 1")
+
+    sample: list[T] = []
+    for item_number, item in enumerate(items, start=ONE_BASED_OFFSET):
+        if item_number <= sample_size:
+            sample.append(item)
+            continue
+        replacement_index = rng.randrange(item_number)
+        if replacement_index < sample_size:
+            sample[replacement_index] = item
+    return sample

--- a/data_platform/ingestion/data_dumps/reddit/sample.py
+++ b/data_platform/ingestion/data_dumps/reddit/sample.py
@@ -1,0 +1,38 @@
+"""Reservoir-sample dump comments without loading the full stream."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from random import Random
+from typing import TypeVar
+
+T = TypeVar("T")
+
+DEFAULT_SAMPLE_SIZE = 500_000
+DEFAULT_SAMPLE_SEED = 20260615
+
+
+def reservoir_sample(items: Iterator[T], sample_size: int, rng: Random) -> list[T]:
+    """Return up to ``sample_size`` items chosen uniformly from a stream.
+
+    Parameters
+    ----------
+    items
+        Stream of values. Consumed once.
+    sample_size
+        Maximum number of items to keep. Must be at least 1.
+    rng
+        Random generator used for replacement draws.
+
+    Returns
+    -------
+    list[T]
+        Sampled items. If the stream is shorter than ``sample_size``, every
+        item is returned in stream order.
+
+    Raises
+    ------
+    ValueError
+        When ``sample_size`` is less than 1.
+    """
+    raise NotImplementedError

--- a/data_platform/ingestion/data_dumps/reddit/transform.py
+++ b/data_platform/ingestion/data_dumps/reddit/transform.py
@@ -1,4 +1,4 @@
-"""Map dump comments onto the Reddit comment ingest row shape."""
+"""Convert dump comments into the same fields used by Reddit comment ingest."""
 
 from __future__ import annotations
 

--- a/data_platform/ingestion/data_dumps/reddit/transform.py
+++ b/data_platform/ingestion/data_dumps/reddit/transform.py
@@ -2,7 +2,19 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from data_platform.ingestion.data_dumps.reddit.models import DumpCommentRaw
+from data_platform.ingestion.generate_record_id import (
+    INTEGRATION_REDDIT,
+    attach_record_id,
+)
+
+COMMENT_FULLNAME_PREFIX = "t1_"
+
+
+def _created_at_from_unix(created_utc: int) -> str:
+    return datetime.fromtimestamp(created_utc, tz=timezone.utc).isoformat()
 
 
 def dump_comment_to_sync_row(
@@ -12,8 +24,8 @@ def dump_comment_to_sync_row(
     """Return a Reddit ingest comment row for one dump comment.
 
     The row includes ``record_id`` and UTC ISO-8601 ``created_at``. It does
-    not include ``created_utc``. Top-level comments have depth 0. Nested
-    comments have depth 1.
+    not include ``created_utc``. Only fields on ``SyncRedditCommentModel``
+    are written.
 
     Parameters
     ----------
@@ -27,4 +39,11 @@ def dump_comment_to_sync_row(
     dict[str, object]
         A dict that validates as ``SyncRedditCommentModel``.
     """
-    raise NotImplementedError
+    row: dict[str, object] = {
+        "comment_fullname": f"{COMMENT_FULLNAME_PREFIX}{comment.id}",
+        "author": comment.author,
+        "body": comment.body,
+        "created_at": _created_at_from_unix(comment.created_utc),
+        "sync_timestamp": sync_timestamp,
+    }
+    return attach_record_id(row, INTEGRATION_REDDIT)

--- a/data_platform/ingestion/data_dumps/reddit/transform.py
+++ b/data_platform/ingestion/data_dumps/reddit/transform.py
@@ -1,0 +1,30 @@
+"""Map dump comments onto the Reddit comment ingest row shape."""
+
+from __future__ import annotations
+
+from data_platform.ingestion.data_dumps.reddit.models import DumpCommentRaw
+
+
+def dump_comment_to_sync_row(
+    comment: DumpCommentRaw,
+    sync_timestamp: str,
+) -> dict[str, object]:
+    """Return a Reddit ingest comment row for one dump comment.
+
+    The row includes ``record_id`` and UTC ISO-8601 ``created_at``. It does
+    not include ``created_utc``. Top-level comments have depth 0. Nested
+    comments have depth 1.
+
+    Parameters
+    ----------
+    comment
+        One dump comment that already passed the deleted-or-removed check.
+    sync_timestamp
+        Run timestamp written onto the row.
+
+    Returns
+    -------
+    dict[str, object]
+        A dict that validates as ``SyncRedditCommentModel``.
+    """
+    raise NotImplementedError

--- a/docs/plans/2026-09-03_reddit_pushshift_dump_filter_c4b819/plan.md
+++ b/docs/plans/2026-09-03_reddit_pushshift_dump_filter_c4b819/plan.md
@@ -1,0 +1,67 @@
+# Filter Reddit dump comments into sampled parquet files
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Pull request 152 added a read-only spec for turning two monthly Reddit comment dump files into sampled parquet. The old dump experiment kept only high-toxicity comments. This work keeps almost every comment, drops deleted or removed ones, writes rows in the same shape as live Reddit ingest, and stores a random sample of 500,000 comments per month file. Live PRAW Reddit ingest and the old toxicity experiment stay as they are.
+
+## Happy flow
+
+An operator points the dump processor at one month dump file. The processor streams comments, drops deleted or removed ones, samples up to 500,000 keepers with a fixed seed, and writes a parquet file under the filtered directory named after that month. The same command is run once per month file.
+
+```mermaid
+flowchart TD
+  subgraph before [Before]
+    E1[Old toxicity dump experiment]
+    E2[Keep high-toxicity comments only]
+    E3[Experiment parquet outputs]
+    E1 --> E2 --> E3
+  end
+  subgraph after [After]
+    D1[Month dump file]
+    D2[Drop deleted or removed]
+    D3[Map onto Reddit comment ingest model]
+    D4[Sample 500,000]
+    D5[Filtered month parquet]
+    D1 --> D2 --> D3 --> D4 --> D5
+  end
+```
+
+## Approach
+
+Put a dump-only processor beside the spec, not inside live Reddit ingest. Stream each month file on its own. Reuse the existing comment ingest model and record-id helper. Do not reconstruct comment trees. Do not run toxicity, length, language, or extra subreddit filters. Do not commit the dump files or the filtered parquet.
+
+## Decisions
+
+1. Drop a comment when author or body, after stripping, is `[deleted]` or `[removed]`. Empty or short bodies that are not those tokens stay.
+2. Fill every field on the Reddit comment ingest model. Top-level comments get depth 0. Nested comments get depth 1. Comment rank is 0. Creation time is UTC ISO-8601 from the dump unix time, matching live Reddit ingest. Record id uses the existing Reddit helper. Run timestamp uses the shared current-timestamp helper.
+3. Sample with reservoir sampling, size 500,000, seed 20260615. If a file has fewer keepers than 500,000, write every keeper.
+4. Default inputs are the two month dump files next to the spec. Default outputs are `filtered/RC_2025-05.parquet` and `filtered/RC_2025-06.parquet` in that same directory. Refuse to overwrite an existing output file.
+5. Do not edit the spec README. Do not change live Reddit ingest, the comment ingest model, or the old toxicity experiment.
+
+## Steps
+
+### Step 1: Read dump comments, drop deleted or removed, map onto the ingest model
+
+Add a dump reader, a deleted-or-removed check, and a mapper that returns a row the Reddit comment ingest model accepts. Prove this on tiny compressed fixtures. Do not sample or write parquet yet.
+
+### Step 2: Sample 500,000 keepers per month file and write filtered parquet
+
+Add reservoir sampling, parquet write, and a CLI that processes one dump file at a time. Default to the two named month files. Ignore dump artifacts in git. Point the stimuli runbook at the dump directory used by the spec.
+
+## What "done" looks like
+
+1. An operator can process each month dump file on its own from the repo root.
+2. Deleted or removed comments are dropped. Other comments stay for later stages to filter.
+3. Each output row validates as the same Reddit comment ingest model used by live Reddit ingest, including record id and UTC ISO creation time.
+4. Each output file has at most 500,000 rows. The sample is repeatable for a given seed. A file with fewer keepers writes all of them.
+5. Default outputs are `data_platform/ingestion/data_dumps/reddit/filtered/RC_2025-05.parquet` and `data_platform/ingestion/data_dumps/reddit/filtered/RC_2025-06.parquet`.
+6. `data_platform/ingestion/data_dumps/reddit/README.md` is unchanged.
+7. `PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_reddit_data_dump.py -q` exits 0.
+8. `PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q` exits 0 with no new failures.
+9. Live Reddit ingest, the comment ingest model, and `experiments/fetch_reddit_pushshift_dump_2026_06_15/` are unchanged. Dump files and filtered parquet are not committed.

--- a/docs/plans/2026-09-03_reddit_pushshift_dump_filter_c4b819/steps/step1.md
+++ b/docs/plans/2026-09-03_reddit_pushshift_dump_filter_c4b819/steps/step1.md
@@ -1,0 +1,194 @@
+# Step 1: Read dump comments, drop deleted or removed, map onto the ingest model
+
+## Goal
+
+Stream comments from a compressed dump JSONL file, drop deleted or removed comments, and map keepers onto the same Reddit comment ingest model used by live Reddit ingest. Do not sample and do not write parquet.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/ingestion/data_dumps/reddit/transform.py` `dump_comment_to_sync_row`, reached from tests in this step and from the Step 2 file processor.
+
+**Task:** prove read → drop deleted or removed → map to a dict that `SyncRedditCommentModel.model_validate` accepts.
+
+**Out of scope:** Reservoir sampling. Parquet write. CLI. Gitignore. Runbook path update. Live PRAW ingest. Changing `SyncRedditCommentModel`. Editing `data_platform/ingestion/data_dumps/reddit/README.md`. The old toxicity experiment. `CHANGELOG.md`.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/data_platform/ingestion/data_dumps/reddit/README.md` | Spec. Do not edit. Deleted-or-removed rule, month files, ingest-model requirement |
+| `/workspace/data_platform/models/sync.py` | `SyncRedditCommentModel` field list, `extra="forbid"` |
+| `/workspace/data_platform/ingestion/sync_reddit.py` | `comment_to_row` UTC ISO `created_at` conversion. Copy the timestamp conversion, not PRAW objects |
+| `/workspace/data_platform/ingestion/generate_record_id.py` | `attach_record_id(row, "reddit")` / `generate_reddit_record_id` |
+| `/workspace/lib/timestamp_utils.py` | `get_current_timestamp` is for run timestamps in Step 2. Do not add another generator |
+| `/workspace/experiments/fetch_reddit_pushshift_dump_2026_06_15/reader.py` | zstd JSONL stream pattern to copy, not import |
+| `/workspace/experiments/fetch_reddit_pushshift_dump_2026_06_15/filters.py` | Deleted tokens `{[deleted], [removed]}`. Do not copy toxicity, length, AutoModerator, or subreddit filters |
+| `/workspace/experiments/fetch_reddit_pushshift_dump_2026_06_15/transform.py` | `link_id` prefix strip, `t1_{id}` fullname, permalink fallback. Do not copy Chicago timestamps or parent-tree depth |
+| `/workspace/experiments/fetch_reddit_pushshift_dump_2026_06_15/tests/test_reader.py` | Tiny zst fixture helper |
+| `/workspace/tests/data_platform/ingestion/reddit_conftest.py` | Example live comment row shape |
+
+## Files allowed to change
+
+- `/workspace/data_platform/ingestion/data_dumps/reddit/models.py`
+- `/workspace/data_platform/ingestion/data_dumps/reddit/reader.py`
+- `/workspace/data_platform/ingestion/data_dumps/reddit/filters.py`
+- `/workspace/data_platform/ingestion/data_dumps/reddit/transform.py`
+- `/workspace/tests/data_platform/ingestion/test_reddit_data_dump.py`
+
+Plan package files under `/workspace/docs/plans/2026-09-03_reddit_pushshift_dump_filter_c4b819/` may already be on the branch. Do not edit them during implementation.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/ingestion/data_dumps/reddit/README.md`
+- `/workspace/data_platform/ingestion/sync_reddit.py`
+- `/workspace/data_platform/models/sync.py`
+- `/workspace/data_platform/ingestion/generate_record_id.py`
+- `/workspace/lib/timestamp_utils.py`
+- `/workspace/experiments/fetch_reddit_pushshift_dump_2026_06_15/**`
+- `/workspace/CHANGELOG.md`
+- Any file outside the allowed list, except git commits of this work
+
+## Contracts to lock
+
+Add `DumpCommentRaw` in `models.py` with `extra="ignore"` so extra dump JSON keys are dropped:
+
+```text
+id: str
+author: str
+link_id: str
+parent_id: str
+subreddit: str
+body: str
+score: int
+created_utc: int
+permalink: str | None = None
+```
+
+Add `iter_dump_comments(input_path: Path) -> Iterator[DumpCommentRaw]` in `reader.py`.
+
+- Open the path as zstd-compressed JSONL, same stream approach as `experiments/fetch_reddit_pushshift_dump_2026_06_15/reader.py` `iter_pushshift_comments`.
+- Skip blank lines, invalid JSON, and rows that fail `DumpCommentRaw` validation. Do not raise on a bad line.
+- Raise `FileNotFoundError` when the path is not a file.
+
+Add `DELETED_BODY_OR_AUTHOR_TOKENS = frozenset({"[deleted]", "[removed]"})` and `keep_dump_comment(comment: DumpCommentRaw) -> bool` in `filters.py`.
+
+- Return False when `comment.author.strip()` is in the token set.
+- Return False when `comment.body.strip()` is in the token set.
+- Return True otherwise, including short or empty bodies that are not those tokens.
+- Do not filter AutoModerator, subreddit, or body length.
+
+Add `dump_comment_to_sync_row(comment: DumpCommentRaw, sync_timestamp: str) -> dict[str, object]` in `transform.py`.
+
+- `post_reddit_id` = `comment.link_id` with a leading `t3_` removed.
+- `post_reddit_fullname` = `comment.link_id`.
+- `subreddit` = `comment.subreddit`.
+- `comment_id` = `comment.id`.
+- `comment_fullname` = `t1_{comment.id}`.
+- `parent_id` = `comment.parent_id`.
+- `author` = `comment.author`.
+- `body` = `comment.body`.
+- `score` = `comment.score`.
+- `created_at` = `datetime.fromtimestamp(comment.created_utc, tz=timezone.utc).isoformat()`. Same conversion as `comment_to_row` in `sync_reddit.py`. Do not write `created_utc`.
+- `permalink` = `comment.permalink` when present and non-empty. Otherwise synthesize `/r/{subreddit}/comments/{post_reddit_id}/_/{comment_id}/`. If a provided permalink does not start with `/`, prefix `/`.
+- `depth` = 0 when `parent_id` starts with `t3_`, else 1. Do not walk parent chains.
+- `comment_rank` = 0.
+- `sync_timestamp` = the argument.
+- Return `attach_record_id(row, INTEGRATION_REDDIT)` so `record_id` is `reddit_{post_reddit_id}_{comment_id}`.
+- The returned dict must pass `SyncRedditCommentModel.model_validate`.
+
+Numpy docstrings on the public functions. Module docstrings include the `PYTHONPATH=. uv run python ...` run line for files that are runnable later. Reader, filter, and transform modules are importable libraries; their module docstrings state purpose only.
+
+Do not import from `experiments/`.
+
+## Test design
+
+One test class per public function. Build tiny `.zst` fixtures in `tmp_path` the same way as `test_iter_pushshift_comments_reads_fixture`. Use a shared helper in the test file to build `DumpCommentRaw` objects. Patch nothing in Step 1 except where a test needs a missing file.
+
+```text
+given a zst JSONL file with one valid dump comment
+when iter_dump_comments(path)
+then yield one DumpCommentRaw with that id
+
+given a zst JSONL file with a blank line, invalid JSON, and one valid comment
+when iter_dump_comments(path)
+then yield only the valid comment
+
+given a path that is not a file
+when iter_dump_comments(path)
+then raise FileNotFoundError
+
+given author "user" and body "hello"
+when keep_dump_comment(comment)
+then True
+
+given author "[deleted]"
+when keep_dump_comment(comment)
+then False
+
+given body "[removed]"
+when keep_dump_comment(comment)
+then False
+
+given body "  [deleted]  "
+when keep_dump_comment(comment)
+then False
+
+given body "short"
+when keep_dump_comment(comment)
+then True
+
+given a top-level dump comment with permalink and created_utc 1748736018
+when dump_comment_to_sync_row(comment, "2026_09_03-12:00:00")
+then SyncRedditCommentModel.model_validate(result) succeeds
+and post_reddit_id is link_id without t3_
+and comment_fullname is t1_{id}
+and record_id is reddit_{post_reddit_id}_{comment_id}
+and created_at is UTC ISO-8601 from the unix time
+and created_utc is not a key
+and depth is 0
+and comment_rank is 0
+and sync_timestamp is the argument
+
+given a nested comment whose parent_id starts with t1_
+when dump_comment_to_sync_row(...)
+then depth is 1
+
+given permalink missing
+when dump_comment_to_sync_row(...)
+then permalink is the synthesized /r/{subreddit}/comments/{post_id}/_/{comment_id}/ path
+```
+
+## Implementation notes (implement-from-spec)
+
+Files do not exist yet. Scaffold means adding the four modules with public functions that `raise NotImplementedError`, plus an empty test module that imports them.
+
+Phase order, one Git commit per phase that changes the repo, and one commit per Phase 5 unit:
+
+1. Phase 1 scope. Confirm caller, file tree, and out-of-scope. No product-code commit if nothing on disk changes.
+2. Phase 2 scaffold. Add the four modules with stub bodies and numpy docstrings. Add the test file with imports only. Commit.
+3. Phase 3 contracts. Confirm signatures and `DumpCommentRaw` fields match the freeze. Bodies stay stubs. Full auto. Commit only if signatures change.
+4. Phase 4 test design. Add the tests from the pseudocode. They must fail for `NotImplementedError`. Commit.
+5. Phase 5 units, in this order, one commit each:
+   1. Implement `DumpCommentRaw` and `iter_dump_comments`. Reader tests pass.
+   2. Implement `keep_dump_comment`. Filter tests pass. Reader tests stay green.
+   3. Implement `dump_comment_to_sync_row`. All Step 1 tests pass.
+6. Phase 6. Run the must-pass command. Confirm README, `sync_reddit.py`, and `SyncRedditCommentModel` are untouched.
+
+## Must pass
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_reddit_data_dump.py -q
+```
+
+Expected: exit 0.
+
+## Must fail / not happen
+
+- `README.md` in the dump directory edited.
+- `sync_reddit.py` or `SyncRedditCommentModel` edited.
+- Import from `experiments/fetch_reddit_pushshift_dump_2026_06_15`.
+- Toxicity, length, AutoModerator, or extra subreddit filters.
+- Sampling or parquet write in this step.
+- `created_utc` present on mapped rows.
+- Parent-tree depth walking.

--- a/docs/plans/2026-09-03_reddit_pushshift_dump_filter_c4b819/steps/step2.md
+++ b/docs/plans/2026-09-03_reddit_pushshift_dump_filter_c4b819/steps/step2.md
@@ -1,0 +1,219 @@
+# Step 2: Sample 500,000 keepers per month file and write filtered parquet
+
+## Goal
+
+Process one dump file at a time: stream comments, drop deleted or removed, reservoir-sample up to 500,000 keepers with a fixed seed, map onto the ingest model, and write parquet. Add a CLI that defaults to the two named month files. Ignore dump artifacts in git. Point the stimuli runbook at the dump directory from the spec.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/ingestion/data_dumps/reddit/process_dump.py` `main`, which calls `process_dump_file` once per input file.
+
+**Task:** prove filter → sample → map → parquet for one file, then the default two-file CLI dispatch.
+
+**Out of scope:** Live PRAW ingest. Changing Step 1 contracts. Editing the spec README. Changing `SyncRedditCommentModel`. The old toxicity experiment. Running against the real monthly dump files (they are not in the repo). `CHANGELOG.md`.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/data_platform/ingestion/data_dumps/reddit/README.md` | Output names `filtered/RC_2025-{05/06}.parquet`, 500,000 sample, process files separately |
+| `/workspace/data_platform/ingestion/data_dumps/reddit/reader.py` | `iter_dump_comments` |
+| `/workspace/data_platform/ingestion/data_dumps/reddit/filters.py` | `keep_dump_comment` |
+| `/workspace/data_platform/ingestion/data_dumps/reddit/transform.py` | `dump_comment_to_sync_row` |
+| `/workspace/data_platform/utils/storage.py` | `_write_parquet` column order from the model field list |
+| `/workspace/lib/timestamp_utils.py` | `get_current_timestamp` for `sync_timestamp` |
+| `/workspace/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md` | Currently says dumps live in `data_platform/ingestion/dumps` |
+| `/workspace/.gitignore` | Add dump zst and filtered parquet ignores |
+| `/workspace/tests/data_platform/ingestion/test_reddit_data_dump.py` | Extend with sample, write, and CLI tests |
+
+## Files allowed to change
+
+- `/workspace/data_platform/ingestion/data_dumps/reddit/sample.py`
+- `/workspace/data_platform/ingestion/data_dumps/reddit/process_dump.py`
+- `/workspace/tests/data_platform/ingestion/test_reddit_data_dump.py`
+- `/workspace/.gitignore`
+- `/workspace/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md`
+- `/workspace/data_platform/ingestion/data_dumps/reddit/filtered/.gitkeep`
+
+Do not edit the plan package during implementation.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/ingestion/data_dumps/reddit/README.md`
+- `/workspace/data_platform/ingestion/data_dumps/reddit/models.py`
+- `/workspace/data_platform/ingestion/data_dumps/reddit/reader.py`
+- `/workspace/data_platform/ingestion/data_dumps/reddit/filters.py`
+- `/workspace/data_platform/ingestion/data_dumps/reddit/transform.py`
+- `/workspace/data_platform/ingestion/sync_reddit.py`
+- `/workspace/data_platform/models/sync.py`
+- `/workspace/experiments/fetch_reddit_pushshift_dump_2026_06_15/**`
+- `/workspace/CHANGELOG.md`
+- Any file outside the allowed list, except git commits of this work
+
+## Contracts to lock
+
+Add in `sample.py`:
+
+```text
+DEFAULT_SAMPLE_SIZE = 500_000
+DEFAULT_SAMPLE_SEED = 20260615
+
+def reservoir_sample(items: Iterator[T], sample_size: int, rng: random.Random) -> list[T]:
+```
+
+- If `sample_size` is less than 1, raise `ValueError` matching `"sample_size"`.
+- Algorithm R: keep the first `sample_size` items, then for item number `i` (1-based) replace a uniform index in `[0, i)` when that index is less than `sample_size`.
+- If the stream is shorter than `sample_size`, return all items in stream order.
+- Do not load the full stream into a list first.
+
+Add in `process_dump.py`:
+
+```text
+DUMP_DIR = Path("data_platform/ingestion/data_dumps/reddit")
+FILTERED_DIR = DUMP_DIR / "filtered"
+DEFAULT_DUMP_STEMS = ("RC_2025-05", "RC_2025-06")
+
+def process_dump_file(
+    input_path: Path,
+    output_path: Path,
+    sample_size: int,
+    sample_seed: int,
+    sync_timestamp: str,
+) -> Path:
+```
+
+Behavior of `process_dump_file`:
+
+- Raise `FileNotFoundError` if `input_path` is not a file.
+- Raise `FileExistsError` if `output_path` already exists.
+- Stream `iter_dump_comments(input_path)`, keep rows where `keep_dump_comment` is True, reservoir-sample with `random.Random(sample_seed)` and `sample_size`.
+- Map sampled dump comments with `dump_comment_to_sync_row(..., sync_timestamp)`.
+- Validate each mapped dict with `SyncRedditCommentModel.model_validate` and `model_dump()`.
+- Create parent directories of `output_path`. Write parquet with pandas, `index=False`, columns in `SyncRedditCommentModel.model_fields` order.
+- Return `output_path`.
+
+CLI `main(argv: list[str] | None = None) -> None`:
+
+- `--input-file` may be passed multiple times. Each value is a path.
+- `--output-dir` defaults to `FILTERED_DIR`.
+- `--sample-size` defaults to `DEFAULT_SAMPLE_SIZE`.
+- `--seed` defaults to `DEFAULT_SAMPLE_SEED`.
+- If no `--input-file`, process `DUMP_DIR / f"{stem}.zst"` for each stem in `DEFAULT_DUMP_STEMS`. Output name is `{stem}.parquet` under `--output-dir`.
+- If `--input-file` is set, process those paths in order. Output name is `{input_path.stem}.parquet` under `--output-dir`.
+- `sync_timestamp` is `get_current_timestamp()` once per `process_dump_file` call.
+- `if __name__ == "__main__": main()`.
+
+Module docstring on `process_dump.py` must include:
+
+```text
+PYTHONPATH=. uv run python data_platform/ingestion/data_dumps/reddit/process_dump.py
+```
+
+and the single-file form with `--input-file`.
+
+`.gitignore` additions:
+
+```text
+data_platform/ingestion/data_dumps/reddit/*.zst
+data_platform/ingestion/data_dumps/reddit/filtered/*.parquet
+```
+
+Keep `filtered/.gitkeep` tracked.
+
+In `docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md`, replace `data_platform/ingestion/dumps` with `data_platform/ingestion/data_dumps`. Keep the sentence that dump rows follow the same models as other ingest.
+
+## Test design
+
+Add test classes `TestReservoirSample`, `TestProcessDumpFile`, `TestMain`. Reuse the Step 1 zst fixture helper. Monkeypatch `get_current_timestamp` in process tests. Call `main` with argv lists and `tmp_path` files. Do not read real month dumps.
+
+```text
+given a stream of 5 items and sample_size 3 and Random(0)
+when reservoir_sample(iter(items), 3, Random(0))
+then length is 3
+and running again with Random(0) returns the same 3 items
+
+given a stream of 2 items and sample_size 5
+when reservoir_sample(...)
+then return both items in stream order
+
+given sample_size 0
+when reservoir_sample(...)
+then raise ValueError matching "sample_size"
+
+given a zst with 4 keepers and 1 deleted comment, sample_size 2, seed 1
+when process_dump_file(input, output, 2, 1, "2026_09_03-12:00:00")
+then output parquet exists
+and row count is 2
+and every row passes SyncRedditCommentModel
+and no row author or body is [deleted] or [removed]
+and sync_timestamp on every row is the argument
+
+given 2 keepers and sample_size 10
+when process_dump_file(...)
+then parquet row count is 2
+
+given output_path already exists
+when process_dump_file(...)
+then raise FileExistsError
+and the existing file is unchanged
+
+given a missing input file
+when process_dump_file(...)
+then raise FileNotFoundError
+
+given two zst files passed as --input-file and --output-dir tmp
+when main(argv)
+then two parquet files named after the input stems exist
+and get_current_timestamp is used for sync_timestamp
+```
+
+Step 1 tests stay green.
+
+## Implementation notes (implement-from-spec)
+
+Scaffold means adding `sample.py` and `process_dump.py` with `raise NotImplementedError` bodies, plus `filtered/.gitkeep`. Do not implement sampling or write in scaffold.
+
+Phase order, one Git commit per phase that changes the repo, and one commit per Phase 5 unit:
+
+1. Phase 1 scope. Confirm caller, file tree, and out-of-scope.
+2. Phase 2 scaffold. Stub `reservoir_sample` and `process_dump_file` / `main`. Add `filtered/.gitkeep`. Commit.
+3. Phase 3 contracts. Confirm signatures and constants. Bodies stay stubs. Full auto. Commit only if signatures change.
+4. Phase 4 test design. Add the new tests. They must fail for `NotImplementedError`. Commit.
+5. Phase 5 units, in this order, one commit each:
+   1. Implement `reservoir_sample`. Its tests pass.
+   2. Implement `process_dump_file`. File processor tests pass. Sample tests stay green.
+   3. Implement `main`, gitignore, runbook path, and CLI tests. All Step 2 tests pass.
+6. Phase 6. Run the must-pass commands. Confirm README, live ingest, models, and experiment tree are untouched.
+
+## Must pass
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_reddit_data_dump.py -q
+```
+
+Expected: exit 0.
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
+```
+
+Expected: exit 0.
+
+```bash
+cd /workspace
+git diff --name-only origin/main -- data_platform/ingestion/data_dumps/reddit/README.md
+```
+
+Expected: that path is listed only because it already existed on the dump branch. `git diff origin/get-reddit-data-dumps -- data_platform/ingestion/data_dumps/reddit/README.md` is empty.
+
+## Must fail / not happen
+
+- README edited.
+- Live Reddit ingest or `SyncRedditCommentModel` edited.
+- Experiment package edited.
+- Output overwrite when the parquet already exists.
+- Loading the full keeper stream into a list before sampling.
+- Committing `.zst` or filtered `.parquet` files.
+- Calling Perspective or any other comment filter beyond deleted or removed.

--- a/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md
+++ b/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md
@@ -22,7 +22,7 @@ We also get data dumps from 2 sources:
 1. Bluesky, from the lab data integrations interface project (see [this repo](https://github.com/METResearchGroup/lab_data_integrations_interface/tree/main/data_platform))
 2. Reddit, from the pushshift data dump.
 
-These data dumps live in `data_platform/ingestion/dumps`. They're intended to follow the same data models that the other ingestion models follow, for consistency.
+These data dumps live in `data_platform/ingestion/data_dumps`. They're intended to follow the same data models that the other ingestion models follow, for consistency.
 
 ## Where does data live?
 

--- a/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md
+++ b/docs/runbooks/HOW_TO_GET_POSTS_FOR_STIMULI_DATASET.md
@@ -22,7 +22,7 @@ We also get data dumps from 2 sources:
 1. Bluesky, from the lab data integrations interface project (see [this repo](https://github.com/METResearchGroup/lab_data_integrations_interface/tree/main/data_platform))
 2. Reddit, from the pushshift data dump.
 
-These data dumps live in `data_platform/ingestion/data_dumps`. They're intended to follow the same data models that the other ingestion models follow, for consistency.
+These data dumps live in `data_platform/ingestion/data_dumps`. Reddit dump files are in `data_platform/ingestion/data_dumps/reddit`. Those files use the same comment fields as live Reddit ingest.
 
 ## Where does data live?
 

--- a/tests/data_platform/ingestion/test_reddit_data_dump.py
+++ b/tests/data_platform/ingestion/test_reddit_data_dump.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from random import Random
 
+import pandas as pd
 import pytest
 import zstandard as zstd
 
 from data_platform.ingestion.data_dumps.reddit.filters import keep_dump_comment
 from data_platform.ingestion.data_dumps.reddit.models import DumpCommentRaw
+from data_platform.ingestion.data_dumps.reddit.process_dump import main, process_dump_file
 from data_platform.ingestion.data_dumps.reddit.reader import iter_dump_comments
+from data_platform.ingestion.data_dumps.reddit.sample import reservoir_sample
 from data_platform.ingestion.data_dumps.reddit.transform import dump_comment_to_sync_row
 from data_platform.ingestion.generate_record_id import INTEGRATION_REDDIT
 from data_platform.models.sync import SyncRedditCommentModel
@@ -164,3 +168,142 @@ class TestDumpCommentToSyncRow:
         assert "permalink" not in result
         assert "score" not in result
         assert "parent_id" not in result
+
+
+def _dump_record(comment_id: str, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = dict(VALID_DUMP_COMMENT)
+    payload["id"] = comment_id
+    payload.update(overrides)
+    return payload
+
+
+class TestReservoirSample:
+    """Tests for reservoir_sample()."""
+
+    def test_is_repeatable_for_the_same_seed(self) -> None:
+        """The same seed returns the same sample."""
+        items = ["a", "b", "c", "d", "e"]
+        sample_size = 3
+
+        first = reservoir_sample(iter(items), sample_size, Random(0))
+        second = reservoir_sample(iter(items), sample_size, Random(0))
+
+        assert len(first) == sample_size
+        assert first == second
+
+    def test_returns_all_items_when_stream_is_shorter(self) -> None:
+        """A short stream is returned in order."""
+        items = ["a", "b"]
+        expected = ["a", "b"]
+
+        result = reservoir_sample(iter(items), 5, Random(0))
+
+        assert result == expected
+
+    def test_rejects_sample_size_below_one(self) -> None:
+        """sample_size must be at least 1."""
+        with pytest.raises(ValueError, match="sample_size"):
+            reservoir_sample(iter(["a"]), 0, Random(0))
+
+
+class TestProcessDumpFile:
+    """Tests for process_dump_file()."""
+
+    def test_writes_sampled_parquet_without_deleted_comments(
+        self, tmp_path: Path
+    ) -> None:
+        """Deleted comments are dropped and the parquet has the sampled keepers."""
+        input_path = tmp_path / "RC_test.zst"
+        output_path = tmp_path / "filtered" / "RC_test.parquet"
+        records = [
+            _dump_record("keep1"),
+            _dump_record("keep2"),
+            _dump_record("keep3"),
+            _dump_record("keep4"),
+            _dump_record("gone", author="[deleted]"),
+        ]
+        _write_zst(input_path, records)
+        expected_rows = 2
+        deleted_tokens = {"[deleted]", "[removed]"}
+
+        result = process_dump_file(
+            input_path, output_path, expected_rows, 1, SYNC_TIMESTAMP
+        )
+        frame = pd.read_parquet(result)
+
+        assert result == output_path
+        assert len(frame) == expected_rows
+        for row in frame.to_dict(orient="records"):
+            SyncRedditCommentModel.model_validate(row)
+            assert row["author"] not in deleted_tokens
+            assert row["body"] not in deleted_tokens
+            assert row["sync_timestamp"] == SYNC_TIMESTAMP
+
+    def test_writes_all_keepers_when_below_sample_size(self, tmp_path: Path) -> None:
+        """A file with fewer keepers than the sample size writes every keeper."""
+        input_path = tmp_path / "RC_test.zst"
+        output_path = tmp_path / "RC_test.parquet"
+        _write_zst(input_path, [_dump_record("keep1"), _dump_record("keep2")])
+        expected_rows = 2
+
+        process_dump_file(input_path, output_path, 10, 1, SYNC_TIMESTAMP)
+        frame = pd.read_parquet(output_path)
+
+        assert len(frame) == expected_rows
+
+    def test_raises_when_output_exists(self, tmp_path: Path) -> None:
+        """An existing parquet is not overwritten."""
+        input_path = tmp_path / "RC_test.zst"
+        output_path = tmp_path / "RC_test.parquet"
+        _write_zst(input_path, [_dump_record("keep1")])
+        expected = "already written"
+        output_path.write_text(expected)
+
+        with pytest.raises(FileExistsError):
+            process_dump_file(input_path, output_path, 10, 1, SYNC_TIMESTAMP)
+
+        assert output_path.read_text() == expected
+
+    def test_raises_when_input_is_missing(self, tmp_path: Path) -> None:
+        """A missing dump file raises FileNotFoundError."""
+        missing = tmp_path / "missing.zst"
+        output_path = tmp_path / "out.parquet"
+
+        with pytest.raises(FileNotFoundError):
+            process_dump_file(missing, output_path, 10, 1, SYNC_TIMESTAMP)
+
+
+class TestMain:
+    """Tests for main()."""
+
+    def test_writes_parquet_for_each_input_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CLI writes one parquet per --input-file under --output-dir."""
+        first_input = tmp_path / "RC_2025-05.zst"
+        second_input = tmp_path / "RC_2025-06.zst"
+        output_dir = tmp_path / "filtered"
+        _write_zst(first_input, [_dump_record("may1")])
+        _write_zst(second_input, [_dump_record("jun1")])
+        monkeypatch.setattr(
+            "data_platform.ingestion.data_dumps.reddit.process_dump.get_current_timestamp",
+            lambda: SYNC_TIMESTAMP,
+        )
+
+        main(
+            [
+                "--input-file",
+                str(first_input),
+                "--input-file",
+                str(second_input),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+
+        first_frame = pd.read_parquet(output_dir / "RC_2025-05.parquet")
+        second_frame = pd.read_parquet(output_dir / "RC_2025-06.parquet")
+        assert len(first_frame) == 1
+        assert len(second_frame) == 1
+        assert first_frame.iloc[0]["sync_timestamp"] == SYNC_TIMESTAMP
+        assert second_frame.iloc[0]["sync_timestamp"] == SYNC_TIMESTAMP

--- a/tests/data_platform/ingestion/test_reddit_data_dump.py
+++ b/tests/data_platform/ingestion/test_reddit_data_dump.py
@@ -81,6 +81,16 @@ class TestIterDumpComments:
         assert len(result) == 1
         assert result[0].id == "mvbyos2"
 
+    def test_skips_rows_that_fail_validation(self, tmp_path: Path) -> None:
+        """A line that is JSON but not a dump comment is skipped."""
+        fixture = tmp_path / "RC_test.zst"
+        _write_zst(fixture, [{"id": "missing-fields"}, VALID_DUMP_COMMENT])
+
+        result = list(iter_dump_comments(fixture))
+
+        assert len(result) == 1
+        assert result[0].id == "mvbyos2"
+
     def test_raises_when_path_is_not_a_file(self, tmp_path: Path) -> None:
         """A missing dump file raises FileNotFoundError."""
         missing = tmp_path / "missing.zst"
@@ -277,6 +287,20 @@ class TestProcessDumpFile:
         with pytest.raises(FileNotFoundError):
             process_dump_file(missing, output_path, 10, 1, SYNC_TIMESTAMP)
 
+    def test_writes_string_columns_when_no_keepers(self, tmp_path: Path) -> None:
+        """An empty sample still writes the ingest string columns."""
+        input_path = tmp_path / "RC_test.zst"
+        output_path = tmp_path / "RC_test.parquet"
+        _write_zst(input_path, [_dump_record("gone", author="[deleted]")])
+        expected_columns = list(SyncRedditCommentModel.model_fields.keys())
+
+        process_dump_file(input_path, output_path, 10, 1, SYNC_TIMESTAMP)
+        frame = pd.read_parquet(output_path)
+
+        assert list(frame.columns) == expected_columns
+        assert len(frame) == 0
+        assert all(pd.api.types.is_string_dtype(frame[column]) for column in frame.columns)
+
 
 class TestMain:
     """Tests for main()."""
@@ -312,6 +336,96 @@ class TestMain:
         assert len(second_frame) == 1
         assert first_frame.iloc[0]["sync_timestamp"] == SYNC_TIMESTAMP
         assert second_frame.iloc[0]["sync_timestamp"] == SYNC_TIMESTAMP
+
+    def test_skips_missing_default_month_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default month files that are missing are skipped."""
+        may_input = tmp_path / "RC_2025-05.zst"
+        output_dir = tmp_path / "filtered"
+        _write_zst(may_input, [_dump_record("may1")])
+        monkeypatch.setattr(
+            "data_platform.ingestion.data_dumps.reddit.process_dump.SOURCE_DUMP_DIR",
+            tmp_path,
+        )
+        monkeypatch.setattr(
+            "data_platform.ingestion.data_dumps.reddit.process_dump.get_current_timestamp",
+            lambda: SYNC_TIMESTAMP,
+        )
+
+        main(["--output-dir", str(output_dir), "--sample-size", "10"])
+
+        assert (output_dir / "RC_2025-05.parquet").is_file()
+        assert not (output_dir / "RC_2025-06.parquet").exists()
+
+    def test_raises_when_no_default_month_files_exist(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If every default month file is missing, the source dump dir is reported."""
+        output_dir = tmp_path / "filtered"
+        monkeypatch.setattr(
+            "data_platform.ingestion.data_dumps.reddit.process_dump.SOURCE_DUMP_DIR",
+            tmp_path,
+        )
+
+        with pytest.raises(FileNotFoundError) as raised:
+            main(["--output-dir", str(output_dir)])
+
+        assert raised.value.args[0] == tmp_path
+        assert not output_dir.exists()
+
+    def test_raises_when_explicit_input_file_is_missing(self, tmp_path: Path) -> None:
+        """An explicit --input-file that is missing fails before any write."""
+        existing = tmp_path / "RC_ok.zst"
+        missing = tmp_path / "RC_missing.zst"
+        output_dir = tmp_path / "filtered"
+        _write_zst(existing, [_dump_record("keep1")])
+
+        with pytest.raises(FileNotFoundError):
+            main(
+                [
+                    "--input-file",
+                    str(existing),
+                    "--input-file",
+                    str(missing),
+                    "--output-dir",
+                    str(output_dir),
+                ]
+            )
+
+        assert not output_dir.exists()
+
+    def test_raises_before_write_when_later_output_exists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An existing later parquet fails the run before the first write."""
+        first_input = tmp_path / "RC_2025-05.zst"
+        second_input = tmp_path / "RC_2025-06.zst"
+        output_dir = tmp_path / "filtered"
+        later_output = output_dir / "RC_2025-06.parquet"
+        _write_zst(first_input, [_dump_record("may1")])
+        _write_zst(second_input, [_dump_record("jun1")])
+        output_dir.mkdir()
+        later_output.write_text("already written")
+        monkeypatch.setattr(
+            "data_platform.ingestion.data_dumps.reddit.process_dump.get_current_timestamp",
+            lambda: SYNC_TIMESTAMP,
+        )
+
+        with pytest.raises(FileExistsError):
+            main(
+                [
+                    "--input-file",
+                    str(first_input),
+                    "--input-file",
+                    str(second_input),
+                    "--output-dir",
+                    str(output_dir),
+                ]
+            )
+
+        assert not (output_dir / "RC_2025-05.parquet").exists()
+        assert later_output.read_text() == "already written"
 
 
 class TestInputPaths:

--- a/tests/data_platform/ingestion/test_reddit_data_dump.py
+++ b/tests/data_platform/ingestion/test_reddit_data_dump.py
@@ -427,8 +427,33 @@ class TestMain:
         assert not (output_dir / "RC_2025-05.parquet").exists()
         assert later_output.read_text() == "already written"
 
+    def test_raises_before_write_when_two_inputs_share_an_output_stem(
+        self, tmp_path: Path
+    ) -> None:
+        """Two inputs with the same stem fail before any parquet is written."""
+        first_dir = tmp_path / "a"
+        second_dir = tmp_path / "b"
+        first_dir.mkdir()
+        second_dir.mkdir()
+        first_input = first_dir / "RC_2025-05.zst"
+        second_input = second_dir / "RC_2025-05.zst"
+        output_dir = tmp_path / "filtered"
+        _write_zst(first_input, [_dump_record("first")])
+        _write_zst(second_input, [_dump_record("second")])
 
-class TestInputPaths:
+        with pytest.raises(ValueError, match="duplicate output path"):
+            main(
+                [
+                    "--input-file",
+                    str(first_input),
+                    "--input-file",
+                    str(second_input),
+                    "--output-dir",
+                    str(output_dir),
+                ]
+            )
+
+        assert not output_dir.exists()
     """Tests for _input_paths()."""
 
     def test_defaults_to_experiment_month_files(self) -> None:

--- a/tests/data_platform/ingestion/test_reddit_data_dump.py
+++ b/tests/data_platform/ingestion/test_reddit_data_dump.py
@@ -2,14 +2,163 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
+import pytest
+import zstandard as zstd
+
 from data_platform.ingestion.data_dumps.reddit.filters import keep_dump_comment
+from data_platform.ingestion.data_dumps.reddit.models import DumpCommentRaw
 from data_platform.ingestion.data_dumps.reddit.reader import iter_dump_comments
 from data_platform.ingestion.data_dumps.reddit.transform import dump_comment_to_sync_row
-from data_platform.ingestion.data_dumps.reddit.models import DumpCommentRaw
+from data_platform.ingestion.generate_record_id import INTEGRATION_REDDIT
+from data_platform.models.sync import SyncRedditCommentModel
 
-_ = (
-    DumpCommentRaw,
-    dump_comment_to_sync_row,
-    iter_dump_comments,
-    keep_dump_comment,
-)
+VALID_DUMP_COMMENT = {
+    "id": "mvbyos2",
+    "author": "momamil",
+    "link_id": "t3_1l09l1b",
+    "parent_id": "t3_1l09l1b",
+    "subreddit": "politics",
+    "body": "Example comment body.",
+    "score": 1,
+    "created_utc": 1_748_736_018,
+    "permalink": "/r/politics/comments/1l09l1b/title/mvbyos2/",
+}
+SYNC_TIMESTAMP = "2026_09_03-12:00:00"
+
+
+def _dump_comment(**overrides: object) -> DumpCommentRaw:
+    payload = dict(VALID_DUMP_COMMENT)
+    payload.update(overrides)
+    return DumpCommentRaw.model_validate(payload)
+
+
+def _write_zst(path: Path, records: list[object]) -> None:
+    lines: list[str] = []
+    for record in records:
+        if record is None:
+            lines.append("")
+        elif isinstance(record, str):
+            lines.append(record)
+        else:
+            lines.append(json.dumps(record))
+    payload = "\n".join(lines).encode("utf-8")
+    path.write_bytes(zstd.ZstdCompressor().compress(payload))
+
+
+class TestIterDumpComments:
+    """Tests for iter_dump_comments()."""
+
+    def test_yields_one_valid_comment(self, tmp_path: Path) -> None:
+        """A compressed file with one valid comment yields that comment."""
+        fixture = tmp_path / "RC_test.zst"
+        _write_zst(fixture, [VALID_DUMP_COMMENT])
+        expected = "mvbyos2"
+
+        result = list(iter_dump_comments(fixture))
+
+        assert len(result) == 1
+        assert result[0].id == expected
+
+    def test_skips_blank_and_invalid_lines(self, tmp_path: Path) -> None:
+        """Blank lines and invalid JSON are skipped."""
+        fixture = tmp_path / "RC_test.zst"
+        _write_zst(fixture, [None, "not-json", VALID_DUMP_COMMENT])
+
+        result = list(iter_dump_comments(fixture))
+
+        assert len(result) == 1
+        assert result[0].id == "mvbyos2"
+
+    def test_raises_when_path_is_not_a_file(self, tmp_path: Path) -> None:
+        """A missing dump file raises FileNotFoundError."""
+        missing = tmp_path / "missing.zst"
+
+        with pytest.raises(FileNotFoundError):
+            list(iter_dump_comments(missing))
+
+
+class TestKeepDumpComment:
+    """Tests for keep_dump_comment()."""
+
+    def test_keeps_ordinary_comment(self) -> None:
+        """A normal author and body are kept."""
+        comment = _dump_comment(author="user", body="hello")
+
+        result = keep_dump_comment(comment)
+
+        assert result is True
+
+    def test_drops_deleted_author(self) -> None:
+        """Author [deleted] is dropped."""
+        comment = _dump_comment(author="[deleted]")
+
+        result = keep_dump_comment(comment)
+
+        assert result is False
+
+    def test_drops_removed_body(self) -> None:
+        """Body [removed] is dropped."""
+        comment = _dump_comment(body="[removed]")
+
+        result = keep_dump_comment(comment)
+
+        assert result is False
+
+    def test_drops_stripped_deleted_body(self) -> None:
+        """Body [deleted] with surrounding spaces is dropped."""
+        comment = _dump_comment(body="  [deleted]  ")
+
+        result = keep_dump_comment(comment)
+
+        assert result is False
+
+    def test_keeps_short_body(self) -> None:
+        """Short bodies that are not deleted tokens are kept."""
+        comment = _dump_comment(body="short")
+
+        result = keep_dump_comment(comment)
+
+        assert result is True
+
+
+class TestDumpCommentToSyncRow:
+    """Tests for dump_comment_to_sync_row()."""
+
+    def test_maps_top_level_comment_onto_ingest_model(self) -> None:
+        """A top-level dump comment becomes a valid Reddit ingest row."""
+        comment = _dump_comment()
+        expected_record_id = f"{INTEGRATION_REDDIT}_1l09l1b_mvbyos2"
+        expected_created_at = "2025-06-01T00:00:18+00:00"
+
+        result = dump_comment_to_sync_row(comment, SYNC_TIMESTAMP)
+        validated = SyncRedditCommentModel.model_validate(result)
+
+        assert validated.post_reddit_id == "1l09l1b"
+        assert validated.post_reddit_fullname == "t3_1l09l1b"
+        assert validated.comment_fullname == "t1_mvbyos2"
+        assert validated.record_id == expected_record_id
+        assert validated.created_at == expected_created_at
+        assert "created_utc" not in result
+        assert validated.depth == 0
+        assert validated.comment_rank == 0
+        assert validated.sync_timestamp == SYNC_TIMESTAMP
+
+    def test_nested_comment_has_depth_one(self) -> None:
+        """A reply to a comment has depth 1."""
+        comment = _dump_comment(parent_id="t1_mvbyhla")
+
+        result = dump_comment_to_sync_row(comment, SYNC_TIMESTAMP)
+
+        assert result["depth"] == 1
+
+    def test_synthesizes_permalink_when_missing(self) -> None:
+        """A missing permalink is built from subreddit, post id, and comment id."""
+        comment = _dump_comment(permalink=None)
+        expected = "/r/politics/comments/1l09l1b/_/mvbyos2/"
+
+        result = dump_comment_to_sync_row(comment, SYNC_TIMESTAMP)
+
+        assert result["permalink"] == expected

--- a/tests/data_platform/ingestion/test_reddit_data_dump.py
+++ b/tests/data_platform/ingestion/test_reddit_data_dump.py
@@ -127,38 +127,40 @@ class TestKeepDumpComment:
 class TestDumpCommentToSyncRow:
     """Tests for dump_comment_to_sync_row()."""
 
-    def test_maps_top_level_comment_onto_ingest_model(self) -> None:
-        """A top-level dump comment becomes a valid Reddit ingest row."""
+    def test_maps_dump_comment_onto_ingest_model(self) -> None:
+        """A dump comment becomes a valid Reddit ingest row."""
         comment = _dump_comment()
-        expected_record_id = f"{INTEGRATION_REDDIT}_1l09l1b_mvbyos2"
+        expected_record_id = f"{INTEGRATION_REDDIT}_t1_mvbyos2"
         expected_created_at = "2025-06-01T00:00:18+00:00"
 
         result = dump_comment_to_sync_row(comment, SYNC_TIMESTAMP)
         validated = SyncRedditCommentModel.model_validate(result)
 
-        assert validated.post_reddit_id == "1l09l1b"
-        assert validated.post_reddit_fullname == "t3_1l09l1b"
         assert validated.comment_fullname == "t1_mvbyos2"
         assert validated.record_id == expected_record_id
+        assert validated.author == "momamil"
+        assert validated.body == "Example comment body."
         assert validated.created_at == expected_created_at
-        assert "created_utc" not in result
-        assert validated.depth == 0
-        assert validated.comment_rank == 0
         assert validated.sync_timestamp == SYNC_TIMESTAMP
+        assert "created_utc" not in result
 
-    def test_nested_comment_has_depth_one(self) -> None:
-        """A reply to a comment has depth 1."""
-        comment = _dump_comment(parent_id="t1_mvbyhla")
-
-        result = dump_comment_to_sync_row(comment, SYNC_TIMESTAMP)
-
-        assert result["depth"] == 1
-
-    def test_synthesizes_permalink_when_missing(self) -> None:
-        """A missing permalink is built from subreddit, post id, and comment id."""
-        comment = _dump_comment(permalink=None)
-        expected = "/r/politics/comments/1l09l1b/_/mvbyos2/"
+    def test_nested_comment_uses_comment_fullname(self) -> None:
+        """A reply still maps onto comment_fullname and record_id."""
+        comment = _dump_comment(id="mvbyn04", parent_id="t1_mvbyhla")
+        expected_record_id = f"{INTEGRATION_REDDIT}_t1_mvbyn04"
 
         result = dump_comment_to_sync_row(comment, SYNC_TIMESTAMP)
 
-        assert result["permalink"] == expected
+        assert result["comment_fullname"] == "t1_mvbyn04"
+        assert result["record_id"] == expected_record_id
+
+    def test_omits_dump_only_fields(self) -> None:
+        """Dump-only keys such as subreddit are not copied onto the ingest row."""
+        comment = _dump_comment()
+
+        result = dump_comment_to_sync_row(comment, SYNC_TIMESTAMP)
+
+        assert "subreddit" not in result
+        assert "permalink" not in result
+        assert "score" not in result
+        assert "parent_id" not in result

--- a/tests/data_platform/ingestion/test_reddit_data_dump.py
+++ b/tests/data_platform/ingestion/test_reddit_data_dump.py
@@ -1,0 +1,15 @@
+"""Tests for Reddit dump comment read, filter, and ingest-model mapping."""
+
+from __future__ import annotations
+
+from data_platform.ingestion.data_dumps.reddit.filters import keep_dump_comment
+from data_platform.ingestion.data_dumps.reddit.reader import iter_dump_comments
+from data_platform.ingestion.data_dumps.reddit.transform import dump_comment_to_sync_row
+from data_platform.ingestion.data_dumps.reddit.models import DumpCommentRaw
+
+_ = (
+    DumpCommentRaw,
+    dump_comment_to_sync_row,
+    iter_dump_comments,
+    keep_dump_comment,
+)

--- a/tests/data_platform/ingestion/test_reddit_data_dump.py
+++ b/tests/data_platform/ingestion/test_reddit_data_dump.py
@@ -12,7 +12,12 @@ import zstandard as zstd
 
 from data_platform.ingestion.data_dumps.reddit.filters import keep_dump_comment
 from data_platform.ingestion.data_dumps.reddit.models import DumpCommentRaw
-from data_platform.ingestion.data_dumps.reddit.process_dump import main, process_dump_file
+from data_platform.ingestion.data_dumps.reddit.process_dump import (
+    SOURCE_DUMP_DIR,
+    _input_paths,
+    main,
+    process_dump_file,
+)
 from data_platform.ingestion.data_dumps.reddit.reader import iter_dump_comments
 from data_platform.ingestion.data_dumps.reddit.sample import reservoir_sample
 from data_platform.ingestion.data_dumps.reddit.transform import dump_comment_to_sync_row
@@ -307,3 +312,18 @@ class TestMain:
         assert len(second_frame) == 1
         assert first_frame.iloc[0]["sync_timestamp"] == SYNC_TIMESTAMP
         assert second_frame.iloc[0]["sync_timestamp"] == SYNC_TIMESTAMP
+
+
+class TestInputPaths:
+    """Tests for _input_paths()."""
+
+    def test_defaults_to_experiment_month_files(self) -> None:
+        """With no --input-file, the May and June experiment dumps are used."""
+        expected = [
+            SOURCE_DUMP_DIR / "RC_2025-05.zst",
+            SOURCE_DUMP_DIR / "RC_2025-06.zst",
+        ]
+
+        result = _input_paths(None)
+
+        assert result == expected


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Filter Reddit dump comments into sampled parquet files

## Summary

Adds a dump processor that turns monthly Reddit comment dump files into sampled parquet files for data collection.

An operator runs the processor with no extra flags. It reads the May and June dump files that already live in the Pushshift experiment, drops deleted or removed comments, maps the rest onto the same Reddit comment ingest model used by live Reddit ingest, and writes a random sample of 500,000 comments per month under the filtered directory. Those parquet files are stored with git LFS.

## Purpose

The old dump experiment kept only high-toxicity comments. We now need a broader comment sample from `RC_2025-05.zst` and `RC_2025-06.zst`, using the ingest model so later stages can filter.

This implements the spec in pull request 152. Live PRAW Reddit ingest and the old toxicity experiment stay as they are. The spec README is unchanged.

Plan: `docs/plans/2026-09-03_reddit_pushshift_dump_filter_c4b819/`

## Architecture

Components:

- Dump processor CLI: reads the experiment month files by default, writes parquet, and stamps the run time with the shared current-timestamp helper.
- Comment stream: reads compressed JSONL, drops deleted or removed comments, and maps remaining comments onto the Reddit comment ingest model.
- Sampler and parquet write: reservoir-samples up to 500,000 remaining comments with a fixed seed and writes a parquet file named after the month. Git LFS stores those parquet files.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    E1[Old toxicity dump experiment]
    E2[Keep high-toxicity comments]
    E3[Experiment parquet]
    E1 --> E2 --> E3
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    D1[Experiment month dump file]
    D2[Drop deleted or removed]
    D3[Map onto ingest model]
    D4[Sample 500,000]
    D5[Filtered month parquet in git LFS]
    D1 --> D2 --> D3 --> D4 --> D5
  end
```

## Interfaces

### CLI

```bash
PYTHONPATH=. uv run python data_platform/ingestion/data_dumps/reddit/process_dump.py
```

```bash
PYTHONPATH=. uv run python data_platform/ingestion/data_dumps/reddit/process_dump.py \
  --input-file experiments/fetch_reddit_pushshift_dump_2026_06_15/data/raw/bolun/comments/RC_2025-05.zst
```

Flags:

| Flag | Default | Notes |
| ---- | ------- | ----- |
| `--input-file` | May and June dumps in the experiment comments directory | Repeatable. Output name is `{stem}.parquet` |
| `--output-dir` | `data_platform/ingestion/data_dumps/reddit/filtered` | Must not already contain that parquet |
| `--sample-size` | 500000 | Writes every remaining comment when the file has fewer |
| `--seed` | 20260615 | Repeatable reservoir sample |

An explicit `--input-file` that is missing fails before any write. Default month files that are missing are skipped and printed. If none of the default month files exist, the run fails. An existing output parquet fails before any write.

### Source dump files

These files are already in the repo from the Pushshift experiment:

- `experiments/fetch_reddit_pushshift_dump_2026_06_15/data/raw/bolun/comments/RC_2025-05.zst`
- `experiments/fetch_reddit_pushshift_dump_2026_06_15/data/raw/bolun/comments/RC_2025-06.zst`

### Filtered parquet (git LFS)

After a clone, run `git lfs pull` if the parquet files are still pointers.

| File | Rows | Size | LFS oid |
| ---- | ---- | ---- | ------- |
| `data_platform/ingestion/data_dumps/reddit/filtered/RC_2025-05.parquet` | 500,000 | 77 MB | `sha256:9c0adb4302728c7ef879f8b870978a0f25798ce67ce83f15c225723c4e726337` |
| `data_platform/ingestion/data_dumps/reddit/filtered/RC_2025-06.parquet` | 500,000 | 76 MB | `sha256:f8b5f27b2c470847809a51b8dd116b6b37087c947fc5bd5e17bdede7d6700540` |

Each output row matches the live Reddit comment ingest model:

| Field | Type | Notes |
| ----- | ---- | ----- |
| comment_fullname | string | `t1_{dump id}` |
| record_id | string | `reddit_{comment_fullname}` |
| author | string | From the dump. `[deleted]` and `[removed]` authors are dropped |
| body | string | From the dump. `[deleted]` and `[removed]` bodies are dropped |
| created_at | string | UTC ISO-8601 from dump unix time |
| sync_timestamp | string | Shared current-timestamp helper, once per file |

`.gitattributes` tracks `data_platform/ingestion/data_dumps/reddit/filtered/*.parquet` with git LFS.

## How to run

From the repo root:

```bash
PYTHONPATH=. uv run python data_platform/ingestion/data_dumps/reddit/process_dump.py
```

Expected: writes the two filtered parquet files. A second run fails if those files already exist.

```bash
PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_reddit_data_dump.py -q
```

Expected: exit 0.

```bash
PYTHONPATH=. uv run pytest tests/data_platform/ingestion -q
```

Expected: exit 0.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5330263-6652-423c-a0ec-1f31f9082179?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5330263-6652-423c-a0ec-1f31f9082179&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for processing compressed Reddit comment dumps into validated Parquet output.
  - Added configurable input files, output locations, sample sizes, and deterministic sampling.
  - Added conversion of Reddit comments into sync-ready records with timestamps and integration identifiers.
- **Data Quality**
  - Invalid, blank, deleted, and removed comments are excluded during ingestion.
  - Large compressed dumps are streamed without loading the full dataset into memory.
- **Tests**
  - Added coverage for reading, filtering, sampling, transformation, output generation, and processing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->