### PR TITLE
Update Cloud Agent dev environment to pre-install uv Python deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ All current timestamps come from `lib.timestamp_utils.get_current_timestamp`. Th
 
 ## Cursor Cloud specific instructions
 
-The startup/update script is intentionally minimal: it only verifies that `uv` is available (`uv --version`) and does **not** install project dependencies. The app does not need to run in this environment. If you need Python deps, run `uv sync` yourself; if you need the web deps, run `npm install` from `webapp/`. `uv` is installed at `~/.local/bin` and is on `PATH` in interactive shells (Python 3.12).
+The install step verifies that `uv` is available (`uv --version`) and then provisions the Python environment with `uv sync --frozen`, so `.venv` is ready and `uv run pytest` works without extra setup. This installs the `dev` dependency group (torch/transformers/spacy) plus the private `research-tools` git dependency; re-running `uv sync` is a fast no-op. The web deps are **not** installed automatically; run `npm install` from `webapp/` when you need them. `uv` is installed at `~/.local/bin` and is on `PATH` in interactive shells (Python 3.12).
 
 ### Secrets / environment variables
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Updates the existing dashboard-managed (DB-managed) Cloud Agent development environment so its install step provisions the Python environment instead of only checking that `uv` exists.

- Old install: `uv --version` (no project dependencies installed)
- New install:
  ```
  uv --version
  uv sync --frozen
  ```

The `uv --version` verification is preserved. `uv sync --frozen` installs the locked dependency set from `uv.lock` (base + `dev` group + the private `research-tools` git dependency), so `.venv` is ready and `uv run pytest` works with no extra setup. The heavy one-time install is baked into the environment build snapshot rather than paid by every agent.

This PR only updates the now-stale note in `AGENTS.md` to describe the new behavior. The actual environment change is applied through the dashboard environment proposal and takes effect when the environment is Saved.

## Why

`README.md` states the only setup required is the `uv` Python environment, yet every new agent previously had to run `uv sync` themselves. Pre-installing it removes that friction while preserving all existing working behavior (uv, git auth, node, AWS credential pattern all unchanged).

## Validation

- `uv sync --frozen`: 185 packages installed; re-run is a no-op (`Checked 185 packages in 4ms`).
- Imports: `torch 2.12.0+cu130`, `transformers 5.12.1`, `spacy 3.8.14`, `research_tools` all import.
- Tests: `PYTHONPATH=. uv run pytest tests/data_platform` → 517 passed.
- Draft environment build + fresh Cloud Agent verification performed as part of the DB-managed update workflow.

## Note on coupling

The environment install-script change is delivered via the environment proposal + Save (dashboard), not via this repo. This doc edit describes the post-Save behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb1157e2-904d-4a2b-bf65-f60c995f00d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb1157e2-904d-4a2b-bf65-f60c995f00d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

