### PR TITLE
Plan S3-backed Bluesky LLM feature generation

### DIFF
--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md
@@ -1,0 +1,301 @@
+# Bluesky LLM features campaign contract
+
+This file is the single cross-step contract for epic `2026-09-05_generate_bluesky_llm_features_4d8a7c`. Every implementation and run step that touches this campaign must match these values. Each step file also repeats the values its delegated task needs so the task cannot be misread.
+
+## Pinned identities
+
+| Field | Value |
+|-------|-------|
+| Bucket | `mirrorview-experimental-artifacts` |
+| Region | `us-east-2` |
+| Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| Pinned preprocessed run | `2026_09_03-23:51:30` |
+| Preprocessed row count | `200000` |
+| Campaign id | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Model id | `gpt-5.4-nano` |
+| Batch size | `2000` |
+| Expected rows per feature | `200000` |
+| Canonical batch count | `100` (`part-00000` through `part-00099`) |
+
+Preprocessed input object:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet`
+
+## S3 feature root and layout
+
+Feature root (exact):
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/`
+
+Per feature `{feature}` under that root:
+
+| Object | Path | Notes |
+|--------|------|-------|
+| Smoke input | `{feature}/smoke/input.parquet` | Ten-post deterministic sample input. Untagged. |
+| Smoke output | `{feature}/smoke/output.parquet` | Ten labeled rows with Q44 columns. Untagged. |
+| Smoke cost report | `{feature}/smoke/cost_report.json` | Token and pricing estimates. Untagged. |
+| Smoke resume evidence | `{feature}/smoke/resume_evidence.json` | Interrupt and resume proof. Untagged. |
+| Active provider state | `{feature}/active_openai_batch.json` | Mutable. Untagged. Conditional atomic replace. |
+| Batch parquet | `{feature}/batches/part-NNNNN.parquet` | Zero-based five-digit index. Immutable once written. Tagged `intermediate-artifact=true`. |
+| Final parquet | `{feature}/final.parquet` | One consolidated file per feature. Untagged. |
+| Manifest | `{feature}/manifest.json` | SHA-256 digests only. Untagged. Conditional atomic replace. |
+| Progress | `{feature}/progress.jsonl` | Logical append via read, append, conditional replace. Untagged. |
+| Errors | `{feature}/errors.jsonl` | Same append semantics when needed. Untagged. |
+| Watcher state | `{feature}/watcher.json` | Rolling GitHub comment id and last posted 10k milestone. Untagged. Conditional atomic replace. |
+
+Wide outputs under the same feature root:
+
+| Object | Path |
+|--------|------|
+| Wide parquet | `wide/features.parquet` |
+| Wide manifest | `wide/manifest.json` |
+
+Forbidden layout elements:
+
+- No `campaigns/` prefix.
+- No `shards/` directory or `shard_*` object names.
+- No `final/` subdirectory or per-feature final filenames such as `final/is_news_or_opinion.parquet`.
+- No `manifest/` directory or `manifest.sha256.json`.
+- No `progress/` directory.
+- No per-run timestamp subfolder under a feature prefix.
+- No `metadata.json` at the feature prefix (run identity lives in `manifest.json` and row provenance).
+- No canonical `batches/part-*.parquet` written during smoke. Smoke never writes production batch objects.
+
+Intermediate batch objects only carry S3 object tag `intermediate-artifact=true`. Smoke artifacts, `active_openai_batch.json`, final parquet, manifests, progress, errors, watcher state, wide outputs, and reports are untagged.
+
+## Smoke S3 evidence (Steps 6 and 8 through 14 Phase A)
+
+Smoke writes exactly these untagged objects under `{feature}/smoke/`:
+
+- `input.parquet` (ten deterministic posts)
+- `output.parquet` (ten Q44 label rows)
+- `cost_report.json`
+- `resume_evidence.json`
+
+Smoke performs one deliberate interruption and resume through `smoke_bluesky_campaign.py`. That single invocation records `resume_evidence.json`. Feature run steps must not repeat the interruption procedure.
+
+Smoke never writes `batches/part-00000.parquet` or any other canonical batch object.
+
+Temporary Git copies of smoke evidence live under `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/{feature}/` during Phase A and are deleted before merge. S3 smoke evidence under `{feature}/smoke/` remains.
+
+## Production batch schedule (after parent approval)
+
+After parent approval, each feature runs exactly 100 provider jobs and writes exactly 100 canonical batch objects totaling 200,000 rows.
+
+| Canonical part | Provider job size | Row composition |
+|----------------|-------------------|-----------------|
+| `part-00000` | 1,990 new posts | Ten unchanged smoke output rows (original smoke `batch_id` and `request_id` preserved) plus 1,990 new labeled rows |
+| `part-00001` through `part-00099` | 2,000 new posts each | All new labeled rows |
+
+The first provider job after approval labels 1,990 posts only. Its successful rows are combined with the ten smoke output rows into immutable `batches/part-00000.parquet` (2,000 rows total). The next 99 provider jobs each process 2,000 posts and each write one canonical batch object.
+
+`manifest.json` batch entry for `part_index=0` may list both the smoke provider `batch_id` and the first production provider `batch_id` because those ten rows retain smoke provenance.
+
+Do not relabel the ten smoke posts. Do not run smoke twice.
+
+## Active OpenAI batch state (`active_openai_batch.json`)
+
+Step 4 defines the state contract independent of storage backend. Step 5 persists campaign state at `{feature}/active_openai_batch.json` in S3.
+
+Before the first `batches.retrieve` poll call, conditionally write (If-Match when object exists) a JSON object with at least:
+
+| Field | Meaning |
+|-------|---------|
+| `input_file_id` | OpenAI files id for the submitted batch input |
+| `batch_id` | OpenAI Batch provider id |
+| `logical_batch_index` | Zero-based canonical part index this job will populate |
+| `pending_source_record_ids` | Ordered ids still expected from this provider job |
+| `attempt_count` | Per-job attempt counter |
+| `state` | `polling`, `writing`, or `terminal` |
+
+On restart, reload `active_openai_batch.json` and reattach to the same `batch_id` when provider status is non-terminal. Never call `files.create` or `batches.create` again for that in-flight job.
+
+Delete `active_openai_batch.json` only after all successful rows from that provider job are durably written to an immutable batch object and recorded in `manifest.json`.
+
+## S3 logical append and conditional replace
+
+`progress.jsonl` and `errors.jsonl` use logical append:
+
+1. One feature writer reads existing object bytes (empty if missing).
+2. Appends one or more complete newline-terminated JSON records.
+3. Conditionally replaces the whole object using S3 `If-Match` with the prior object ETag for concurrency control only.
+
+SHA-256 remains the content integrity check for parquet and manifest bytes. Never accept S3 ETag as a content hash.
+
+If a conditional put fails, retry from the latest object bytes and ETag.
+
+S3 atomic object replacement can leave the prior object visible on interruption. Immutable batch objects plus `manifest.json` are the source of truth. Resume may reconstruct missing observability events in `progress.jsonl` or `errors.jsonl` from batch and manifest state.
+
+`manifest.json`, `watcher.json`, and `active_openai_batch.json` also use conditional atomic whole-object replacement with `If-Match` ETag for concurrency control.
+
+## Deterministic run id and immutability
+
+Per-feature run id (stored in every row as `run_id`):
+
+`bluesky_2026_09_03_235130_llm_features_v1:{feature}`
+
+Restart and resume reuse the same `run_id` and the same feature prefix. Feature prefixes are immutable except:
+
+- Logical append to `progress.jsonl` and `errors.jsonl`.
+- Conditional atomic replacement of `manifest.json`, `watcher.json`, and `active_openai_batch.json`.
+- New batch objects with the next unused `part-NNNNN.parquet` index.
+
+Existing completed batch objects are never overwritten.
+
+## Seven features
+
+| Feature | Raw label field | Pydantic model (label subset) | Accepted values |
+|---------|-----------------|------------------------------|-----------------|
+| `is_news_or_opinion` | `category` | `IsNewsOrOpinionModel` | `news`, `opinion`, `neither` |
+| `is_political` | `is_political` | `IsPoliticalModel` | boolean |
+| `is_likely_spam` | `is_likely_spam` | `IsLikelySpamModel` | boolean |
+| `is_self_contained` | `is_self_contained` | `IsSelfContainedModel` | boolean |
+| `is_structurally_complete` | `is_structurally_complete` | `IsStructurallyCompleteModel` | boolean |
+| `political_stance` | `political_stance` | `PoliticalStanceModel` | `left`, `right`, `neutral`, `unclear` |
+| `llm_toxicity_tiered` | `toxicity_tier` | `LlmToxicityTieredModel` | `low`, `medium`, `high` |
+
+Do not run Perspective feature `is_toxic_tiered` in this campaign.
+
+## Row schema (Q44)
+
+Every row in `smoke/output.parquet`, `batches/part-*.parquet`, and `final.parquet` must contain exactly these columns:
+
+| Column | Meaning |
+|--------|---------|
+| `source_record_id` | Pinned preprocessed post id |
+| `run_id` | `bluesky_2026_09_03_235130_llm_features_v1:{feature}` |
+| `batch_id` | OpenAI Batch provider id for the batch that produced the row |
+| `request_id` | Provider request id for the row |
+| `attempt_count` | Integer attempt count for this row (1 through 4) |
+| `label_timestamp` | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
+| `{label_field}` | That feature's raw label column from the table above |
+
+Validation applies the feature Pydantic model to the label-field subset and separately validates provenance columns.
+
+## Campaign CLI
+
+Extend existing `data_platform/generate_features/generate_bluesky_features.py` with `--campaign-id` and `--preprocessed-run` for production campaign mode. Keep legacy mode when those flags are absent.
+
+Campaign mode rules:
+
+- Pass exactly one value to `--features`.
+- Pass `--batch-size 2000`.
+- Campaign mode automatically resumes feature state in its canonical prefix on restart.
+- Do not add `run_bluesky_llm_campaign.py`, `--resume`, `APPROVED.txt`, or a timestamp `--checkpoint`.
+
+Example campaign command:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --features is_news_or_opinion \
+  --batch-size 2000
+```
+
+The blocking engine stays. At most one OpenAI Batch job is active per feature at a time.
+
+## Smoke tooling and approval flow (Step 6)
+
+Step 6 adds reusable tooling only:
+
+- `data_platform/generate_features/smoke_bluesky_campaign.py`
+- An aggregation command that sums seven per-feature cost estimates
+
+Step 6 does not run full 200k labeling and does not add a file-based approval marker.
+
+Deterministic ten-post sample (shared by all seven features):
+
+1. Load pinned preprocessed run `2026_09_03-23:51:30`.
+2. Keep rows with non-empty `text`.
+3. Sort by ascending `source_record_id`.
+4. Take the first ten rows.
+
+Steps 8 through 14 (each in its own feature PR):
+
+1. Run `smoke_bluesky_campaign.py` once for that feature (includes deliberate interruption and resume).
+2. Commit temporary Git smoke evidence under `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/{feature}/`.
+3. Post the estimated full-run cost to that feature's GitHub issue.
+4. Pause until all seven feature issues have estimates and the parent campaign issue has one aggregate estimate plus explicit human approval.
+
+Human approval is recorded on the parent GitHub issue only. No `APPROVED.txt` or other repository approval file.
+
+## Progress and watcher (Step 7)
+
+`progress.jsonl` is the only progress event file. Each append records durable row totals and batch metadata after a canonical batch lands.
+
+`watcher.json` stores:
+
+- `github_comment_id` (rolling feature-issue comment)
+- `last_posted_milestone` (last 10k boundary posted: 10000, 20000, …, 200000)
+
+The watcher CLI prints a prepared markdown report. A restartable agent outside repository code posts or updates one feature-issue comment through authenticated GitHub integration. Repository code must not launch Cursor and must not call GitHub write APIs directly.
+
+## Permanent report paths
+
+| Report | Path |
+|--------|------|
+| Per-feature | `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/{feature}_run_report.md` |
+| Wide consolidation | `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/wide_run_report.md` |
+
+Temporary Git smoke evidence (committed during Phase A, deleted before merge):
+
+`docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/{feature}/`
+
+## Wide table (Step 15)
+
+Wide output: exactly nineteen columns.
+
+Twelve preprocessed columns (exact names):
+
+`uri`, `record_id`, `url`, `author_handle`, `text`, `created_at`, `like_count`, `repost_count`, `reply_count`, `quote_count`, `sync_timestamp`, `source_record_id`
+
+Seven aliased label columns:
+
+| Wide column | Source feature | Source column |
+|-------------|----------------|---------------|
+| `news_or_opinion_category` | `is_news_or_opinion` | `category` |
+| `is_political` | `is_political` | `is_political` |
+| `is_likely_spam` | `is_likely_spam` | `is_likely_spam` |
+| `is_self_contained` | `is_self_contained` | `is_self_contained` |
+| `is_structurally_complete` | `is_structurally_complete` | `is_structurally_complete` |
+| `political_stance` | `political_stance` | `political_stance` |
+| `llm_toxicity_tier` | `llm_toxicity_tiered` | `toxicity_tier` |
+
+Wide manifest links all seven per-feature provenance manifests plus preprocessed input hash.
+
+Forbidden wide columns: `toxicity_tier`, `toxicity_prob`, `label_timestamp`, `run_id`, any Perspective column.
+
+## Step dependencies
+
+| Step | Depends on | Can run parallel with | Delivers |
+|------|------------|----------------------|----------|
+| 1 | none | 2, 4 | S3 copy of pinned Bluesky pipeline and dump trees |
+| 2 | none | 1, 4 | Configurable S3 object store |
+| 3 | 1, 2 | none (after 1 and 2) | S3 default backend; remove Bluesky pipeline LFS pointers |
+| 4 | none | 1, 2 | OpenAI Batch resume and partial-success engine |
+| 5 | 2, 4 | none (after 2 and 4) | Campaign S3 layout, Q44 rows, `active_openai_batch.json`, batch tagging, append semantics |
+| 6 | 5 | 7 | Smoke tooling and cost aggregation |
+| 7 | 5 | 6 | Progress enrichment and watcher CLI |
+| 8 through 14 | 3, 6, 7 (transitively 2, 4, 5) | each other | One feature run each (docs-only PRs) |
+| 15 | 8 through 14 | none | Wide join |
+| 16 | 5 tagging only | listed last | 30-day lifecycle on tagged batch objects |
+
+Step 16 is last in the schedule. Its only technical prerequisite is Step 5 intermediate tagging, not Step 15.
+
+Feature Steps 8 through 14 require Step 3 (production S3 backend), Step 6 (smoke tooling), and Step 7 (watcher). They transitively rely on Steps 2, 4, and 5 through those dependencies.
+
+## Verification rules
+
+- Content hashes are SHA-256 lowercase hex of full object bytes. Never accept S3 ETag as a content hash.
+- S3 ETag with `If-Match` is permitted only for concurrency control on conditional replace of `progress.jsonl`, `errors.jsonl`, `manifest.json`, `watcher.json`, and `active_openai_batch.json`.
+- No automated tests are added or run for this epic. Use live smoke and basic runtime checks only.
+- Temporary Git smoke files may be committed during review and must be removed before merge.
+
+## Hash and manifest rules
+
+`manifest.json` at each feature prefix and `wide/manifest.json` use SHA-256 hex digests only. Do not use MD5, ETag alone, or size-only checks as acceptance gates.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md
@@ -1,0 +1,119 @@
+# Generate seven reliable S3-backed LLM features for 200,000 Bluesky posts
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY and YAGNI
+- Use only the approved smoke checks. Do not add or run automated tests.
+- Frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Move the current pipeline data from Git LFS to the `mirrorview-experimental-artifacts` S3 bucket, and make S3 the production storage backend while retaining local storage for development. Harden the OpenAI Batch feature generator, then generate seven LLM features for the pinned 200,000-post Bluesky dataset from PR #164.
+
+Each feature run writes immutable 2,000-row Parquet shards, a final feature Parquet file, a hash manifest, progress records, and a permanent run report. A final step joins the seven outputs with the complete preprocessed post records.
+
+## Happy flow
+
+An operator starts seven feature agents after the storage and reliability work has merged. Each agent runs the same ten-post smoke sample and posts its cost estimate to its feature issue. The parent issue records the total estimate and waits for one approval before the agents process the remaining posts.
+
+```mermaid
+flowchart TD
+    A[Copy pipeline LFS artifacts to S3] --> C[Make S3 the production backend]
+    B[Add S3 storage support] --> C
+    D[Harden OpenAI Batch generation] --> E[Write immutable Parquet shards]
+    B --> E
+    E --> F[Run ten-post smoke checks]
+    F --> G[Approve the total estimated cost]
+    C --> H[Run seven feature issues in parallel]
+    D --> H
+    E --> H
+    G --> H
+    I[Add durable progress records] --> H
+    H --> J[Join seven features into one wide Parquet file]
+    K[Add the 30-day intermediate shard lifecycle rule]
+```
+
+## Approach
+
+Use the fixed dataset `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` and preprocessed run `2026_09_03-23:51:30`. Record the input hash so a later dataset requires a separate campaign.
+
+Store pipeline artifacts under `s3://mirrorview-experimental-artifacts/data_platform/data/`. Use one campaign ID and one isolated prefix per feature so parallel agents cannot change the same metadata. Keep one blocking OpenAI Batch job per feature agent, persist provider job IDs before polling, and resume the existing provider job after an interruption.
+
+Each feature issue is one future pull request. Temporary smoke inputs, outputs, cost records, and resume evidence are committed for review and removed before merge. The permanent run report records the S3 locations, hashes, model and prompt identity, costs, throughput, retries, validation checks, and label counts.
+
+## Steps
+
+### Step 1: Copy current pipeline LFS artifacts to S3
+
+Copy the current pipeline data and required source dumps to matching S3 keys. Verify every object with SHA-256 hashes, retain the Git LFS copies, and commit the migration inventory.
+
+### Step 2: Add first-class S3 storage support to the data pipeline
+
+Add configurable S3 reads and writes while preserving local storage for development. Reject Git LFS pointer text, unsafe paths, missing hashes, and accidental overwrites.
+
+### Step 3: Make S3 the default pipeline backend and remove current LFS artifacts
+
+Set S3 as the production backend after the copied objects and S3 reader have been verified. Remove current pipeline artifacts from Git LFS without rewriting repository history.
+
+### Step 4: Harden OpenAI Batch feature generation and resume
+
+Persist in-flight OpenAI job identity, keep successful records from partly failed jobs, retry only transient failures, and make every run resumable. Mark a feature complete only after every pinned input ID has one valid output.
+
+### Step 5: Write resumable 2,000-row Parquet feature shards
+
+Write immutable S3 shards, progress records, error records, hash manifests, and one final Parquet file per feature. Keep one provider job active per feature and preserve deterministic record order during resume and consolidation.
+
+### Step 6: Add ten-post smoke cost reports and a campaign approval gate
+
+Use one deterministic ten-post sample for every feature. Record average and maximum token usage, current model pricing, estimated full-run cost, S3 checks, and one deliberate interruption and resume before requesting one campaign approval.
+
+### Step 7: Add durable progress reports for feature run watchers
+
+Write structured progress records after each durable shard. Give short, restartable watcher subagents enough information to update one rolling GitHub issue comment at every 10,000 completed records.
+
+### Step 8: Generate is_news_or_opinion for 200,000 Bluesky posts
+
+Run the approved smoke and full generation flow for `is_news_or_opinion`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+
+### Step 9: Generate is_political for 200,000 Bluesky posts
+
+Run the approved smoke and full generation flow for `is_political`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+
+### Step 10: Generate is_likely_spam for 200,000 Bluesky posts
+
+Run the approved smoke and full generation flow for `is_likely_spam`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+
+### Step 11: Generate is_self_contained for 200,000 Bluesky posts
+
+Run the approved smoke and full generation flow for `is_self_contained`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+
+### Step 12: Generate is_structurally_complete for 200,000 Bluesky posts
+
+Run the approved smoke and full generation flow for `is_structurally_complete`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+
+### Step 13: Generate political_stance for 200,000 Bluesky posts
+
+Run the approved smoke and full generation flow for `political_stance`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+
+### Step 14: Generate llm_toxicity_tiered for 200,000 Bluesky posts
+
+Run the approved smoke and full generation flow for `llm_toxicity_tiered`. Keep its output distinct from the Perspective API toxicity feature, and publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+
+### Step 15: Consolidate seven Bluesky LLM features into one wide Parquet artifact
+
+Join the seven verified feature outputs to all 12 preprocessed post columns by `source_record_id`. Require exactly 200,000 unique records with no missing feature values, and publish the wide artifact, hash manifest, validation results, and permanent report.
+
+### Step 16: Expire intermediate data platform S3 shards after 30 days
+
+Add an S3 lifecycle rule that combines the `data_platform/data/` prefix with an intermediate-artifact tag. Expire only tagged batch shards and retain final Parquet files, manifests, progress records, and reports.
+
+## What "done" looks like
+
+1. The current pipeline data is available from S3 with verified hashes, and production pipeline runs no longer depend on current Git LFS artifacts.
+2. Interrupted OpenAI Batch work resumes without duplicate provider jobs or duplicate charges.
+3. Seven feature issues each produce exactly 200,000 unique, valid LLM labels and one permanent run report.
+4. Each issue reports progress every 10,000 durable records and records estimated and actual cost.
+5. One wide Parquet artifact contains the 12 pinned post columns and all seven LLM feature outputs.
+6. Intermediate shards expire after 30 days, while final artifacts and audit records remain in S3.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md
@@ -12,108 +12,120 @@
 
 Move the current pipeline data from Git LFS to the `mirrorview-experimental-artifacts` S3 bucket, and make S3 the production storage backend while retaining local storage for development. Harden the OpenAI Batch feature generator, then generate seven LLM features for the pinned 200,000-post Bluesky dataset from PR #164.
 
-Each feature run writes immutable 2,000-row Parquet shards, a final feature Parquet file, a hash manifest, progress records, and a permanent run report. A final step joins the seven outputs with the complete preprocessed post records.
+Each feature run writes 100 immutable 2,000-row Parquet batch objects, a final feature Parquet file, a hash manifest, progress records, and a permanent run report. A final step joins the seven outputs with the complete preprocessed post records.
 
 ## Happy flow
 
-An operator starts seven feature agents after the storage and reliability work has merged. Each agent runs the same ten-post smoke sample and posts its cost estimate to its feature issue. The parent issue records the total estimate and waits for one approval before the agents process the remaining posts.
+An operator starts seven feature agents after the storage, reliability, smoke tooling, and watcher work has merged. Each agent runs the same ten-post smoke sample once through `smoke_bluesky_campaign.py` and posts its cost estimate to its feature issue. The parent issue records the total estimate and waits for one approval before the agents process the remaining posts.
 
 ```mermaid
 flowchart TD
-    A[Copy pipeline LFS artifacts to S3] --> C[Make S3 the production backend]
-    B[Add S3 storage support] --> C
-    D[Harden OpenAI Batch generation] --> E[Write immutable Parquet shards]
-    B --> E
-    E --> F[Run ten-post smoke checks]
-    F --> G[Approve the total estimated cost]
-    C --> H[Run seven feature issues in parallel]
-    D --> H
-    E --> H
+    A[Step1 Copy pipeline LFS to S3]
+    B[Step2 Add S3 storage support]
+    D[Step4 Harden OpenAI Batch resume]
+    A --> C[Step3 S3 default backend]
+    B --> C
+    B --> E[Step5 Campaign S3 batches]
+    D --> E
+    E --> F[Step6 Smoke tooling]
+    E --> G[Step7 Progress watcher]
+    C --> H[Steps8-14 Feature runs]
+    F --> H
     G --> H
-    I[Add durable progress records] --> H
-    H --> J[Join seven features into one wide Parquet file]
-    K[Add the 30-day intermediate shard lifecycle rule]
+    H --> J[Step15 Wide join]
+    E --> K[Step16 Lifecycle rule]
 ```
 
 ## Approach
 
 Use the fixed dataset `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` and preprocessed run `2026_09_03-23:51:30`. Record the input hash so a later dataset requires a separate campaign.
 
-Store pipeline artifacts under `s3://mirrorview-experimental-artifacts/data_platform/data/`. Use one campaign ID and one isolated prefix per feature so parallel agents cannot change the same metadata. Keep one blocking OpenAI Batch job per feature agent, persist provider job IDs before polling, and resume the existing provider job after an interruption.
+Store pipeline artifacts under `s3://mirrorview-experimental-artifacts/data_platform/data/`. Use one campaign ID and one isolated prefix per feature so parallel agents cannot change the same metadata. Keep one blocking OpenAI Batch job per feature agent, persist provider job IDs in `active_openai_batch.json` before polling, and resume the existing provider job after an interruption.
 
-Each feature issue is one future pull request. Temporary smoke inputs, outputs, cost records, and resume evidence are committed for review and removed before merge. The permanent run report records the S3 locations, hashes, model and prompt identity, costs, throughput, retries, validation checks, and label counts.
+Smoke writes untagged evidence under `{feature}/smoke/` and never writes canonical `batches/part-*.parquet`. After parent approval, the first production provider job labels 1,990 new posts; those rows are combined with the ten unchanged smoke output rows into `part-00000.parquet`. The next 99 provider jobs each label 2,000 posts.
+
+Each feature issue is one future pull request. Temporary Git smoke inputs, outputs, cost records, and resume evidence are committed for review and removed before merge. S3 smoke evidence under `{feature}/smoke/` remains. The permanent run report records the S3 locations, hashes, model and prompt identity, costs, throughput, retries, validation checks, and label counts.
+
+See `campaign_contract.md` for the full dependency graph, S3 layout, and schemas.
+
+## Decisions
+
+- Canonical identities, S3 layout, schemas, and the dependency graph live in `campaign_contract.md`.
+- Each feature pull request runs one canonical smoke, then waits for aggregate parent-issue cost approval before the full 200,000-post run.
+- Human approval is recorded on the parent GitHub issue only. No repository approval file.
+- Do not add or run automated tests. Use only the approved smoke and basic runtime checks defined in the step specs.
 
 ## Steps
 
 ### Step 1: Copy current pipeline LFS artifacts to S3
 
-Copy the current pipeline data and required source dumps to matching S3 keys. Verify every object with SHA-256 hashes, retain the Git LFS copies, and commit the migration inventory.
+Copy the current pipeline data and required source dumps to matching S3 keys. Verify every object with SHA-256 hashes, retain the Git LFS copies, and commit the migration inventory. No dependencies. May run in parallel with Steps 2 and 4.
 
 ### Step 2: Add first-class S3 storage support to the data pipeline
 
-Add configurable S3 reads and writes while preserving local storage for development. Reject Git LFS pointer text, unsafe paths, missing hashes, and accidental overwrites.
+Add configurable S3 reads and writes while preserving local storage for development. Reject Git LFS pointer text, unsafe paths, missing hashes, and accidental overwrites. No dependencies. May run in parallel with Steps 1 and 4.
 
 ### Step 3: Make S3 the default pipeline backend and remove current LFS artifacts
 
-Set S3 as the production backend after the copied objects and S3 reader have been verified. Remove current pipeline artifacts from Git LFS without rewriting repository history.
+Set S3 as the production backend after the copied objects and S3 reader have been verified. Remove current pipeline artifacts from Git LFS without rewriting repository history. Depends on Steps 1 and 2.
 
 ### Step 4: Harden OpenAI Batch feature generation and resume
 
-Persist in-flight OpenAI job identity, keep successful records from partly failed jobs, retry only transient failures, and make every run resumable. Mark a feature complete only after every pinned input ID has one valid output.
+Persist in-flight OpenAI job identity, keep successful records from partly failed jobs, retry only transient failures, and make every run resumable. Define `active_openai_batch.json` state contract independent of storage. Mark a feature complete only after every pinned input ID has one valid output. No dependencies. May run in parallel with Steps 1 and 2.
 
-### Step 5: Write resumable 2,000-row Parquet feature shards
+### Step 5: Write resumable 2,000-row Parquet feature batches
 
-Write immutable S3 shards, progress records, error records, hash manifests, and one final Parquet file per feature. Keep one provider job active per feature and preserve deterministic record order during resume and consolidation.
+Write immutable S3 batches, `active_openai_batch.json`, logical-append progress and error records, hash manifests, and one final Parquet file per feature. Keep one provider job active per feature and preserve deterministic record order during resume and consolidation. Depends on Steps 2 and 4.
 
-### Step 6: Add ten-post smoke cost reports and a campaign approval gate
+### Step 6: Add smoke tooling and cost aggregation
 
-Use one deterministic ten-post sample for every feature. Record average and maximum token usage, current model pricing, estimated full-run cost, S3 checks, and one deliberate interruption and resume before requesting one campaign approval.
+Use one deterministic ten-post sample for every feature. Write untagged smoke evidence to `{feature}/smoke/`. Record average and maximum token usage, current model pricing, estimated full-run cost, S3 checks, and one deliberate interruption and resume inside the smoke caller. Depends on Step 5. May run in parallel with Step 7.
 
 ### Step 7: Add durable progress reports for feature run watchers
 
-Write structured progress records after each durable shard. Give short, restartable watcher subagents enough information to update one rolling GitHub issue comment at every 10,000 completed records.
+Write structured progress records after each durable batch. Give short, restartable watcher subagents enough information to update one rolling GitHub issue comment at every 10,000 completed records. Depends on Step 5. May run in parallel with Step 6.
 
 ### Step 8: Generate is_news_or_opinion for 200,000 Bluesky posts
 
-Run the approved smoke and full generation flow for `is_news_or_opinion`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+Run the approved smoke and full generation flow for `is_news_or_opinion`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report. Depends on Steps 3, 6, and 7.
 
 ### Step 9: Generate is_political for 200,000 Bluesky posts
 
-Run the approved smoke and full generation flow for `is_political`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+Run the approved smoke and full generation flow for `is_political`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report. Depends on Steps 3, 6, and 7.
 
 ### Step 10: Generate is_likely_spam for 200,000 Bluesky posts
 
-Run the approved smoke and full generation flow for `is_likely_spam`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+Run the approved smoke and full generation flow for `is_likely_spam`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report. Depends on Steps 3, 6, and 7.
 
 ### Step 11: Generate is_self_contained for 200,000 Bluesky posts
 
-Run the approved smoke and full generation flow for `is_self_contained`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+Run the approved smoke and full generation flow for `is_self_contained`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report. Depends on Steps 3, 6, and 7.
 
 ### Step 12: Generate is_structurally_complete for 200,000 Bluesky posts
 
-Run the approved smoke and full generation flow for `is_structurally_complete`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+Run the approved smoke and full generation flow for `is_structurally_complete`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report. Depends on Steps 3, 6, and 7.
 
 ### Step 13: Generate political_stance for 200,000 Bluesky posts
 
-Run the approved smoke and full generation flow for `political_stance`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+Run the approved smoke and full generation flow for `political_stance`. Publish its final Parquet file, manifest, progress history, validation results, and permanent run report. Depends on Steps 3, 6, and 7.
 
 ### Step 14: Generate llm_toxicity_tiered for 200,000 Bluesky posts
 
-Run the approved smoke and full generation flow for `llm_toxicity_tiered`. Keep its output distinct from the Perspective API toxicity feature, and publish its final Parquet file, manifest, progress history, validation results, and permanent run report.
+Run the approved smoke and full generation flow for `llm_toxicity_tiered`. Keep its output distinct from the Perspective API toxicity feature, and publish its final Parquet file, manifest, progress history, validation results, and permanent run report. Depends on Steps 3, 6, and 7.
 
 ### Step 15: Consolidate seven Bluesky LLM features into one wide Parquet artifact
 
-Join the seven verified feature outputs to all 12 preprocessed post columns by `source_record_id`. Require exactly 200,000 unique records with no missing feature values, and publish the wide artifact, hash manifest, validation results, and permanent report.
+Join the seven verified feature outputs to all 12 preprocessed post columns by `source_record_id`. Require exactly 200,000 unique records with no missing feature values, and publish the wide artifact, hash manifest, validation results, and permanent report. Depends on Steps 8 through 14.
 
-### Step 16: Expire intermediate data platform S3 shards after 30 days
+### Step 16: Expire intermediate data platform S3 batches after 30 days
 
-Add an S3 lifecycle rule that combines the `data_platform/data/` prefix with an intermediate-artifact tag. Expire only tagged batch shards and retain final Parquet files, manifests, progress records, and reports.
+Add an S3 lifecycle rule that combines the `data_platform/data/` prefix with an intermediate-artifact tag. Expire only tagged batch objects and retain final Parquet files, manifests, progress records, and reports. Depends on Step 5 tagging only. Listed last in the schedule.
 
 ## What "done" looks like
 
 1. The current pipeline data is available from S3 with verified hashes, and production pipeline runs no longer depend on current Git LFS artifacts.
 2. Interrupted OpenAI Batch work resumes without duplicate provider jobs or duplicate charges.
-3. Seven feature issues each produce exactly 200,000 unique, valid LLM labels and one permanent run report.
+3. Seven feature issues each produce exactly 200,000 unique, valid LLM labels across 100 canonical batch objects and one permanent run report.
 4. Each issue reports progress every 10,000 durable records and records estimated and actual cost.
 5. One wide Parquet artifact contains the 12 pinned post columns and all seven LLM feature outputs.
-6. Intermediate shards expire after 30 days, while final artifacts and audit records remain in S3.
+6. Intermediate batches expire after 30 days, while final artifacts and audit records remain in S3.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step1.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step1.md
@@ -1,0 +1,204 @@
+# Step 1: Copy current Bluesky pipeline LFS artifacts to S3
+
+## Goal
+
+Upload every pinned Bluesky pipeline artifact and every required Bluesky source dump to `s3://mirrorview-experimental-artifacts/` using exact repo-relative object keys. Resolve Git LFS pointers to real bytes before upload. Record a SHA-256 hash for every uploaded object in a committed migration inventory. Leave all Git LFS pointers and tracked parquet files in the repository unchanged.
+
+## Dependencies
+
+This step has no code dependencies on later epic steps. It does require:
+
+- Git LFS installed and able to smudge the pinned Bluesky paths.
+- AWS credentials with `s3:PutObject`, `s3:GetObject`, and `s3:HeadObject` on `mirrorview-experimental-artifacts`.
+- In the Cloud Agent environment, `LAB_AWS_ACCESS_KEY_ID` and `LAB_AWS_ACCESS_KEY_SECRET` exported as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` before any AWS or boto3 call.
+- `uv sync` if boto3 is not already available.
+
+Do not upload Reddit LFS objects, unrelated dump paths, or any file outside the locked scope below.
+
+## Main caller and implementation slice
+
+**Main caller:** `data_platform/scripts/migrate_bluesky_lfs_to_s3.py` `main`.
+
+**Implementation slice for this PR:** enumerate the locked local paths, resolve each file to real bytes (pull LFS when needed), upload to the matching S3 key, compute SHA-256 for local and remote bytes, and write `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json`. Do not change `StorageManager` or any pipeline read path in this step.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Locked dataset id, bucket, and pipeline root |
+| `/workspace/.gitattributes` | Bluesky LFS rules for pipeline and dump parquet |
+| `/workspace/.gitignore` | Pinned Bluesky dataset un-ignore rules |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json` | Dataset manifest that stays in git |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/metadata.json` | Raw run metadata |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Pinned preprocessed run metadata |
+| `/workspace/data_platform/ingestion/data_dumps/bluesky/data/summary_statistics.json` | Dump summary metadata |
+| `/workspace/lib/aws/s3.py` | Existing `S3` helper and default region `us-east-2` |
+| `/workspace/lib/constants.py` | `REPO_ROOT` |
+| `/workspace/data_platform/ingestion/data_dumps/bluesky/publish_dump_to_raw.py` | Locked dataset id and raw run timestamp |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.` and AWS credential export pattern |
+
+## Files allowed to change
+
+- `/workspace/data_platform/scripts/migrate_bluesky_lfs_to_s3.py` (new)
+- `/workspace/data_platform/scripts/verify_bluesky_s3_migration.py` (new, smoke verifier used by this step only)
+- `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json` (new, permanent report)
+
+Temporary smoke evidence under `experiments/bluesky_s3_migration_smoke_2026_09_05/` may be committed during review and must be deleted before merge.
+
+Do not edit files under `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/` during implementation.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/utils/storage.py`
+- `/workspace/lib/aws/s3.py` (reuse as-is; extend only if the migration script cannot call it without modification — prefer wrapping in the new script)
+- `/workspace/.gitattributes`
+- `/workspace/.gitignore`
+- `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json`
+- `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/**`
+- `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/**`
+- `/workspace/data_platform/ingestion/data_dumps/bluesky/data/**`
+- `/workspace/data_platform/data/reddit/**`
+- `/workspace/CHANGELOG.md`
+- Any test file under `/workspace/tests/`
+- Any file outside the allowed list
+
+## Locked contracts
+
+| Item | Value |
+|------|-------|
+| S3 bucket | `mirrorview-experimental-artifacts` |
+| AWS region | `us-east-2` |
+| Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| Pinned raw run | `2026_09_01-00:00:00` |
+| Pinned preprocessed run | `2026_09_03-23:51:30` |
+| Pipeline S3 prefix | `data_platform/data/` (no duplicated `data_platform` segment in keys) |
+| Key rule | Repo-relative path with forward slashes. Example: local `data_platform/data/bluesky/.../posts.parquet` → key `data_platform/data/bluesky/.../posts.parquet` |
+| Dump key rule | Repo-relative path. Example: local `data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=00/{hash}.parquet` → same key under the bucket |
+| Upload scope — pipeline | `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json`, `raw/2026_09_01-00:00:00/metadata.json`, all `raw/2026_09_01-00:00:00/date=2026-09-01/hour=*/**.parquet` (24 files), `preprocessed/2026_09_03-23:51:30/metadata.json`, `preprocessed/2026_09_03-23:51:30/posts.parquet` |
+| Upload scope — source dumps | `data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=*/**.parquet` (24 files) and `data_platform/ingestion/data_dumps/bluesky/data/summary_statistics.json` |
+| Expected object count | 53 (28 pipeline files + 25 dump files; raw and dump parquet share LFS oids but are separate S3 keys) |
+| Hash algorithm | SHA-256 lowercase hex of full object bytes |
+| LFS retention | Do not `git rm`, rewrite history, or replace parquet pointers in git |
+| Inventory path | `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json` |
+| Inventory JSON shape | `{"bucket":"mirrorview-experimental-artifacts","region":"us-east-2","dataset_id":"bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73","uploaded_at":"<UTC from lib.timestamp_utils.get_current_timestamp>","object_count":53,"objects":[{"repo_relative_path":"...","s3_key":"...","bytes":N,"sha256":"..."}]}` sorted by `repo_relative_path` |
+| Pointer rejection | If a scoped file still begins with `version https://git-lfs.github.com/spec/v1`, abort the upload for that file after `git lfs pull` for the scoped include paths |
+
+## Ordered implementation work
+
+1. Add `migrate_bluesky_lfs_to_s3.py` with a frozen list of the 53 repo-relative paths above.
+2. Before upload, run `git lfs pull` for `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**` and `data_platform/ingestion/data_dumps/bluesky/data/parquet/**`.
+3. For each path, read bytes from disk, reject LFS pointer text, compute SHA-256, upload with `Content-Type` `application/json` for `.json` and `application/octet-stream` for `.parquet`.
+4. After each upload, `HeadObject` and optionally re-download to confirm the remote SHA-256 matches local.
+5. Write the inventory JSON under the pinned dataset directory.
+6. Add `verify_bluesky_s3_migration.py` that reads the inventory and checks every listed key exists with matching `ETag` or downloaded hash.
+7. Run the live smoke commands below. Commit the scripts and permanent inventory. Delete any temporary smoke directory before merge.
+
+## Live smoke and basic check commands
+
+From the repo root. Export AWS credentials first:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+aws sts get-caller-identity
+```
+
+Expected: JSON with `"Arn"` containing the lab IAM user and exit code 0.
+
+Pull LFS blobs for scoped paths:
+
+```bash
+git lfs pull --include "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**"
+git lfs pull --include "data_platform/ingestion/data_dumps/bluesky/data/parquet/**"
+```
+
+Expected: exit code 0. A spot-check file is larger than 200 bytes and is not an LFS pointer:
+
+```bash
+head -c 40 data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet | xxd | head -1
+```
+
+Expected: bytes `PAR1` magic at the start (parquet), not the ASCII text `version https://git-lfs`.
+
+Run the migration:
+
+```bash
+PYTHONPATH=. uv run python data_platform/scripts/migrate_bluesky_lfs_to_s3.py
+```
+
+Expected stdout ends with a line like `uploaded 53 objects to s3://mirrorview-experimental-artifacts/` and exit code 0.
+
+Verify with the companion script:
+
+```bash
+PYTHONPATH=. uv run python data_platform/scripts/verify_bluesky_s3_migration.py
+```
+
+Expected stdout: `OK: 53/53 objects present with matching sha256` and exit code 0.
+
+Spot-check one pipeline key and one dump key with the AWS CLI:
+
+```bash
+aws s3api head-object \
+  --bucket mirrorview-experimental-artifacts \
+  --key data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet \
+  --region us-east-2
+
+aws s3api head-object \
+  --bucket mirrorview-experimental-artifacts \
+  --key data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=00/87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef.parquet \
+  --region us-east-2
+```
+
+Expected: both return HTTP 200 metadata with non-zero `ContentLength`.
+
+Confirm LFS pointers remain in git:
+
+```bash
+git lfs ls-files | grep "bluesky_7e2c4a91" | wc -l
+```
+
+Expected: `25` (24 raw parquet + 1 preprocessed parquet under the pinned dataset).
+
+Confirm inventory committed:
+
+```bash
+python - <<'PY'
+import json
+from pathlib import Path
+inv = json.loads(Path("data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json").read_text())
+assert inv["object_count"] == 53
+assert len(inv["objects"]) == 53
+assert inv["objects"][0]["s3_key"].startswith("data_platform/")
+assert "data_platform/data_platform/" not in inv["objects"][0]["s3_key"]
+print("inventory ok", inv["uploaded_at"])
+PY
+```
+
+Expected: `inventory ok` plus timestamp and exit code 0.
+
+## Acceptance criteria
+
+- All 53 scoped objects exist in `mirrorview-experimental-artifacts` at repo-relative keys with no duplicated `data_platform` prefix.
+- Every inventory row has a matching local and remote SHA-256.
+- `s3_migration_inventory.json` is committed under the pinned dataset directory.
+- All Bluesky parquet files remain Git LFS pointers in the working tree; no Reddit or unrelated LFS paths were uploaded.
+- No pipeline storage code changed.
+
+## Failure conditions
+
+- Any scoped file uploads as an LFS pointer (133-byte text file).
+- Object count is not exactly 53.
+- Any S3 key starts with `data_platform/data_platform/`.
+- Reddit paths or non-Bluesky LFS files appear in the inventory.
+- Git LFS pointers for the pinned Bluesky dataset are removed or rewritten.
+- `StorageManager` or default pipeline read behavior changes in this PR.
+
+## PR artifact and commit rules
+
+- One independently mergeable PR for this step only.
+- Commit the migration scripts and permanent `s3_migration_inventory.json` in logical commits (script first, inventory after successful upload).
+- Temporary smoke logs or sample downloads under `experiments/bluesky_s3_migration_smoke_2026_09_05/` may be committed for review; delete that directory in the final commit before merge.
+- Do not add or run automated tests.
+- Do not edit `plan.md` or other step specs in the implementation PR.
+- PR title suggestion: `Copy pinned Bluesky LFS artifacts to S3 with hash inventory`.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step1.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step1.md
@@ -1,4 +1,4 @@
-# Step 1: Copy current Bluesky pipeline LFS artifacts to S3
+# Step 1: Copy current pipeline LFS artifacts to S3
 
 ## Goal
 
@@ -6,7 +6,9 @@ Upload every pinned Bluesky pipeline artifact and every required Bluesky source 
 
 ## Dependencies
 
-This step has no code dependencies on later epic steps. It does require:
+See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` for pinned identities used by later steps.
+
+This step has no code dependencies on other epic steps. It may run in parallel with Steps 2 and 4. It does require:
 
 - Git LFS installed and able to smudge the pinned Bluesky paths.
 - AWS credentials with `s3:PutObject`, `s3:GetObject`, and `s3:HeadObject` on `mirrorview-experimental-artifacts`.
@@ -50,7 +52,7 @@ Do not edit files under `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_f
 ## Files forbidden to change
 
 - `/workspace/data_platform/utils/storage.py`
-- `/workspace/lib/aws/s3.py` (reuse as-is; extend only if the migration script cannot call it without modification — prefer wrapping in the new script)
+- `/workspace/lib/aws/s3.py` (reuse as-is; extend only if the migration script cannot call it without modification; prefer wrapping in the new script)
 - `/workspace/.gitattributes`
 - `/workspace/.gitignore`
 - `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json`
@@ -74,10 +76,10 @@ Do not edit files under `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_f
 | Pipeline S3 prefix | `data_platform/data/` (no duplicated `data_platform` segment in keys) |
 | Key rule | Repo-relative path with forward slashes. Example: local `data_platform/data/bluesky/.../posts.parquet` → key `data_platform/data/bluesky/.../posts.parquet` |
 | Dump key rule | Repo-relative path. Example: local `data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=00/{hash}.parquet` → same key under the bucket |
-| Upload scope — pipeline | `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json`, `raw/2026_09_01-00:00:00/metadata.json`, all `raw/2026_09_01-00:00:00/date=2026-09-01/hour=*/**.parquet` (24 files), `preprocessed/2026_09_03-23:51:30/metadata.json`, `preprocessed/2026_09_03-23:51:30/posts.parquet` |
-| Upload scope — source dumps | `data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=*/**.parquet` (24 files) and `data_platform/ingestion/data_dumps/bluesky/data/summary_statistics.json` |
+| Upload scope . pipeline | `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json`, `raw/2026_09_01-00:00:00/metadata.json`, all `raw/2026_09_01-00:00:00/date=2026-09-01/hour=*/**.parquet` (24 files), `preprocessed/2026_09_03-23:51:30/metadata.json`, `preprocessed/2026_09_03-23:51:30/posts.parquet` |
+| Upload scope . source dumps | `data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=*/**.parquet` (24 files) and `data_platform/ingestion/data_dumps/bluesky/data/summary_statistics.json` |
 | Expected object count | 53 (28 pipeline files + 25 dump files; raw and dump parquet share LFS oids but are separate S3 keys) |
-| Hash algorithm | SHA-256 lowercase hex of full object bytes |
+| Hash algorithm | SHA-256 lowercase hex of full object bytes. Never use S3 ETag as a content hash. |
 | LFS retention | Do not `git rm`, rewrite history, or replace parquet pointers in git |
 | Inventory path | `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json` |
 | Inventory JSON shape | `{"bucket":"mirrorview-experimental-artifacts","region":"us-east-2","dataset_id":"bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73","uploaded_at":"<UTC from lib.timestamp_utils.get_current_timestamp>","object_count":53,"objects":[{"repo_relative_path":"...","s3_key":"...","bytes":N,"sha256":"..."}]}` sorted by `repo_relative_path` |
@@ -90,7 +92,7 @@ Do not edit files under `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_f
 3. For each path, read bytes from disk, reject LFS pointer text, compute SHA-256, upload with `Content-Type` `application/json` for `.json` and `application/octet-stream` for `.parquet`.
 4. After each upload, `HeadObject` and optionally re-download to confirm the remote SHA-256 matches local.
 5. Write the inventory JSON under the pinned dataset directory.
-6. Add `verify_bluesky_s3_migration.py` that reads the inventory and checks every listed key exists with matching `ETag` or downloaded hash.
+6. Add `verify_bluesky_s3_migration.py` that reads the inventory and checks every listed key exists with matching SHA-256 (re-download and hash bytes; never accept ETag as a content hash).
 7. Run the live smoke commands below. Commit the scripts and permanent inventory. Delete any temporary smoke directory before merge.
 
 ## Live smoke and basic check commands
@@ -163,7 +165,7 @@ Expected: `25` (24 raw parquet + 1 preprocessed parquet under the pinned dataset
 Confirm inventory committed:
 
 ```bash
-python - <<'PY'
+PYTHONPATH=. uv run python - <<'PY'
 import json
 from pathlib import Path
 inv = json.loads(Path("data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json").read_text())
@@ -187,6 +189,7 @@ Expected: `inventory ok` plus timestamp and exit code 0.
 
 ## Failure conditions
 
+- Verification accepts ETag instead of SHA-256 for any object.
 - Any scoped file uploads as an LFS pointer (133-byte text file).
 - Object count is not exactly 53.
 - Any S3 key starts with `data_platform/data_platform/`.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step10.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step10.md
@@ -1,0 +1,274 @@
+# Step 10: Generate `is_likely_spam` for 200,000 Bluesky posts
+
+## Goal
+
+Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_likely_spam` feature only. Publish immutable S3 shards, the final Parquet file, hash manifest, progress history, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
+
+This step is one future pull request and one GitHub feature issue. The issue stays open until the feature run is complete and validated.
+
+## Dependencies on Steps 3–7
+
+Do not start this step until Steps 3–7 have merged to `main`.
+
+**Step 3 (S3 default backend).** Production feature generation reads preprocessed input and writes feature output through S3, not local `data_platform/data/` or Git LFS. Export AWS credentials before any S3-touching command:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+```
+
+**Step 4 (OpenAI Batch hardening and resume).** The engine persists in-flight OpenAI Batch job identity before polling, keeps successful records from partly failed jobs, retries only transient failures, and resumes without creating duplicate provider jobs. A failed or interrupted run reuses the same feature run directory and the same `--checkpoint` value.
+
+**Step 5 (Parquet shards and manifests).** Each durable batch writes one immutable 2,000-row Parquet shard under the feature S3 prefix, plus error records and a hash manifest. One blocking OpenAI Batch job stays active per feature. The run ends with one consolidated final Parquet file for `is_likely_spam`.
+
+**Step 6 (ten-post smoke and campaign approval gate).** Use the deterministic ten-post sample shipped in Step 6 for every feature. Record average and maximum token usage, current model pricing, estimated full-run cost, S3 presence checks, and one deliberate interruption plus resume. Post the smoke cost estimate to this feature issue. Wait until the parent campaign issue records the sum of all seven feature estimates and receives one explicit approval before starting the 200,000-post run.
+
+**Step 7 (progress watcher).** After each durable shard, the runner writes a structured progress record. A restartable watcher subagent reads those records and updates one rolling GitHub issue comment at every 10,000 completed records for this feature.
+
+## Pinned identity contract
+
+Use exactly these values for the full campaign. A different dataset, preprocessed run, campaign id, model, or prompt requires a new campaign and must not reuse this prefix.
+
+| Field | Pinned value |
+|-------|----------------|
+| Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| Preprocessed run | `2026_09_03-23:51:30` |
+| Preprocessed row count | `200000` (`metadata.json` `row_counts.output`) |
+| Preprocessed input S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/` |
+| Campaign id / feature run family | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Feature name | `is_likely_spam` |
+| Feature S3 campaign prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/` |
+| Model id | `gpt-5.4-nano` (`lib.constants.DEFAULT_LLM_MODEL`) |
+| Engine | OpenAI Batch (`engine_type="openai"`) |
+| Batch size | `2000` |
+| Temperature | `0.0` |
+| System prompt source | `data_platform/generate_features/is_likely_spam/generate_feature.py` → `SYSTEM_PROMPT` |
+| LLM output schema | `LlmIsLikelySpamModel` in the same file |
+| Stored label schema | `IsLikelySpamModel`: `source_record_id`, `label_timestamp`, `is_likely_spam` |
+| Prompt identity in metadata | `metadata.json` `features.is_likely_spam.model_id` = `gpt-5.4-nano` and `prompt_hash` = SHA-256 hex of `SYSTEM_PROMPT` |
+
+Record the exact `prompt_hash` from the smoke run metadata in the permanent run report. If `model_id` or `prompt_hash` drifts from the smoke run, stop and open a new campaign instead of resuming.
+
+## Caller command
+
+Run only this feature with batch size 2000. Do not pass any other `--features` value.
+
+**New feature run (smoke phase uses the Step 6 ten-post path; full run uses this command):**
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --features is_likely_spam \
+  --batch-size 2000
+```
+
+**Resume an interrupted run (same issue, same feature run directory name):**
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --features is_likely_spam \
+  --batch-size 2000 \
+  --checkpoint <feature_run_timestamp>
+```
+
+Replace `<feature_run_timestamp>` with the folder name under the campaign prefix (for example `2026_09_05-14:30:00`). Never start a second concurrent OpenAI Batch job for this feature while an unfinished run exists.
+
+## Two-phase pull request flow
+
+### Phase A — smoke, estimate, and review artifacts
+
+1. Confirm Steps 3–7 are on `main`.
+2. Run the Step 6 ten-post smoke for `is_likely_spam` only.
+3. Perform the deliberate interruption and resume required by Step 6 on the same feature run.
+4. Write temporary smoke artifacts under the plan reports folder (see Allowed files).
+5. Commit and push those temporary smoke artifacts to the feature branch. Do not commit labels.
+6. Post the estimated full-run cost (derived from smoke token usage and current `gpt-5.4-nano` Batch pricing) to this feature issue.
+7. Stop. Do not start the 200,000-post run until the parent campaign issue shows one approval covering all seven feature estimates.
+
+### Phase B — full run after parent approval
+
+1. Confirm the parent campaign issue has explicit approval for the combined estimate.
+2. Start or resume the full run with the caller command above.
+3. Start the Step 7 progress watcher for this feature. It must update the rolling GitHub comment at every 10,000 durable rows.
+4. When the run completes, validate S3 artifacts and row counts (see Acceptance checks).
+5. Write the permanent run report at `reports/is_likely_spam_run_report.md` with actual cost, throughput, retries, error rate, and label counts.
+6. Delete every temporary smoke artifact from the plan reports folder.
+7. Commit and push only the permanent run report. Push the final S3 objects (already written during the run). Open or update the pull request for merge.
+
+If the full run fails or is interrupted, keep the same GitHub issue and the same `--checkpoint` value. Resume; do not open a parallel run or a new campaign prefix.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope and done criteria |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Bluesky feature CLI entrypoint |
+| `/workspace/data_platform/generate_features/platform_cli.py` | `--features`, `--batch-size`, `--checkpoint` |
+| `/workspace/data_platform/generate_features/is_likely_spam/generate_feature.py` | `SYSTEM_PROMPT`, accepted label schema |
+| `/workspace/data_platform/generate_features/registry.py` | Feature registry entry for `is_likely_spam` |
+| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch engine and default model |
+| `/workspace/data_platform/generate_features/metadata.py` | `model_id`, `prompt_hash`, resume identity checks |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Pinned input row count and run id |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export, no automated tests |
+
+After Steps 3–7 merge, also read the Step 6 smoke helper, Step 7 progress watcher entrypoint, and any S3 layout docs those steps add.
+
+## Files allowed to change
+
+Only documentation artifacts for this feature run. No product code, no label data in Git.
+
+**Temporary smoke artifacts (committed during Phase A, deleted before merge):**
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_likely_spam_smoke_cost.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_likely_spam_smoke_resume_evidence.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_likely_spam_smoke_s3_checks.txt`
+
+**Permanent run report (committed during Phase B, kept after merge):**
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_likely_spam_run_report.md`
+
+## Files forbidden to change
+
+- Any file under `/workspace/data_platform/`, `/workspace/lib/`, `/workspace/ml_tooling/`, `/workspace/tests/`, `/workspace/pyproject.toml`, `/workspace/CHANGELOG.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
+- Any other step file under `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/`
+- Any path under the S3 prefixes for the other six features:
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_political/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
+- Any committed Parquet, CSV, or JSON label files anywhere in the repository
+
+Do not add or run automated tests.
+
+## S3 artifacts
+
+All objects live under:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
+
+Expected layout after Step 5 (exact subfolder names follow the Step 5 implementation):
+
+| Artifact | Purpose |
+|----------|---------|
+| `shards/` | Immutable 2,000-row Parquet shards |
+| `final/is_likely_spam.parquet` | Consolidated feature output |
+| `manifest/` | SHA-256 hash manifest over shards and final file |
+| `progress/` | Structured progress records (one per durable shard) |
+| `errors/` | Error records for rows that failed after retries |
+| `metadata.json` | Run metadata including `model_id`, `prompt_hash`, labeled counts, OpenAI job ids |
+
+Intermediate shards may carry the intermediate-artifact lifecycle tag from Step 16. Final Parquet, manifest, progress records, and reports are retained.
+
+## Basic commands and checks
+
+**List campaign prefix:**
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/ --recursive
+```
+
+**Download final Parquet for validation:**
+
+```bash
+aws s3 cp \
+  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/final/is_likely_spam.parquet \
+  /tmp/is_likely_spam.parquet
+```
+
+**Validate row count, uniqueness, schema, and accepted values:**
+
+```bash
+python - <<'PY'
+import pandas as pd
+
+REQUIRED_COLS = ["source_record_id", "label_timestamp", "is_likely_spam"]
+
+df = pd.read_parquet("/tmp/is_likely_spam.parquet")
+assert list(df.columns) == REQUIRED_COLS, df.columns.tolist()
+assert len(df) == 200_000, len(df)
+assert df["source_record_id"].is_unique, "duplicate source_record_id"
+assert df["is_likely_spam"].notna().all(), "missing is_likely_spam"
+assert df["is_likely_spam"].dtype == bool or set(df["is_likely_spam"].unique()) <= {True, False}
+print("ok", df["is_likely_spam"].value_counts().to_dict())
+PY
+```
+
+**Compare labeled ids to preprocessed input:**
+
+```bash
+python - <<'PY'
+import pandas as pd
+
+pre = pd.read_parquet(
+    "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
+)
+feat = pd.read_parquet("/tmp/is_likely_spam.parquet")
+input_ids = set(pre["source_record_id"])
+output_ids = set(feat["source_record_id"])
+assert input_ids == output_ids, (len(input_ids), len(output_ids), len(input_ids - output_ids))
+print("ok ids match")
+PY
+```
+
+When production reads preprocessed input from S3 (Step 3), download `posts.parquet` from the preprocessed S3 prefix instead of the local path.
+
+**Verify manifest hashes** using the Step 5 manifest verifier against `manifest/` and `final/is_likely_spam.parquet`.
+
+**Read progress for the watcher:**
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/progress/ --recursive /tmp/is_likely_spam_progress/
+```
+
+Confirm a new progress record exists after each 2,000-row shard and that the watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
+
+## Exact accepted values
+
+Each output row must validate as `IsLikelySpamModel`:
+
+| Column | Type | Accepted values |
+|--------|------|-----------------|
+| `source_record_id` | string | One per preprocessed post; exactly 200,000 unique values |
+| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
+| `is_likely_spam` | boolean | `true` or `false` (conservative spam classification per prompt) |
+
+No nulls. No extra columns. No duplicate `source_record_id`.
+
+## Acceptance criteria
+
+1. **Coverage:** Exactly 200,000 rows. Exactly 200,000 unique `source_record_id` values. Zero missing outputs relative to the pinned preprocessed run.
+2. **Schema:** Columns match `IsLikelySpamModel`. All `is_likely_spam` values are boolean.
+3. **Identity:** `metadata.json` records `model_id` = `gpt-5.4-nano` and the `prompt_hash` of the pinned `SYSTEM_PROMPT`.
+4. **S3:** Final Parquet, manifest, progress history, and error records (if any) are present under the feature campaign prefix.
+5. **Cost and operations:** The permanent run report records estimated cost (from smoke), actual cost (from OpenAI usage), throughput (posts per second and tokens per second), retry count, error rate, and label counts for `true` and `false`.
+6. **Progress:** Watcher updated the GitHub comment at every 10,000 durable rows.
+7. **Resume:** If the run was interrupted, resume used the same issue, same `--checkpoint`, and no duplicate OpenAI Batch job.
+8. **Repository hygiene:** No label files committed. Temporary smoke artifacts removed before merge. Only `reports/is_likely_spam_run_report.md` remains from this step in Git.
+
+## Permanent run report contents
+
+`reports/is_likely_spam_run_report.md` must include:
+
+- Pinned identity table (dataset, preprocessed run, campaign id, model, prompt file path, `prompt_hash`)
+- S3 URIs for final Parquet, manifest, and progress folder
+- Smoke estimated full-run cost (USD) and assumptions
+- Actual cost (USD), input/output/total tokens
+- Throughput (posts per second, tokens per second)
+- Retry count and error rate (failed rows / 200,000)
+- Label counts: `is_likely_spam=true`, `is_likely_spam=false`
+- Validation command outputs (pass/fail summary)
+- Feature run timestamp and `--checkpoint` value used
+- OpenAI Batch job id(s) from metadata

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step10.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step10.md
@@ -1,136 +1,90 @@
-# Step 10: Generate `is_likely_spam` for 200,000 Bluesky posts
+# Step 10: Generate is_likely_spam for 200,000 Bluesky posts
 
 ## Goal
 
-Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_likely_spam` feature only. Publish immutable S3 shards, the final Parquet file, hash manifest, progress history, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
+Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_likely_spam` feature only. Publish immutable S3 batches, `final.parquet`, `manifest.json`, `progress.jsonl`, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
 
 This step is one future pull request and one GitHub feature issue. The issue stays open until the feature run is complete and validated.
 
-## Dependencies on Steps 3–7
+## Dependencies
 
-Do not start this step until Steps 3–7 have merged to `main`.
+Do not start until Steps 3, 6, and 7 have merged to `main`. Steps 2, 4, and 5 are required transitively through Step 6 and Step 7. See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md`.
 
-**Step 3 (S3 default backend).** Production feature generation reads preprocessed input and writes feature output through S3, not local `data_platform/data/` or Git LFS. Export AWS credentials before any S3-touching command:
+| Step | Requirement |
+|------|-------------|
+| Step 3 | S3 is the production backend |
+| Step 6 | `smoke_bluesky_campaign.py` and cost aggregation command (single invocation includes deliberate interruption and resume) |
+| Step 7 | `progress.jsonl`, `watcher.json`, and watcher CLI |
+
+## Main caller and implementation slice
+
+**Main caller (campaign mode; same command resumes automatically):**
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --features is_likely_spam \
+  --batch-size 2000
 ```
 
-**Step 4 (OpenAI Batch hardening and resume).** The engine persists in-flight OpenAI Batch job identity before polling, keeps successful records from partly failed jobs, retries only transient failures, and resumes without creating duplicate provider jobs. A failed or interrupted run reuses the same feature run directory and the same `--checkpoint` value.
+**Smoke caller (Phase A only; available after Step 6):**
 
-**Step 5 (Parquet shards and manifests).** Each durable batch writes one immutable 2,000-row Parquet shard under the feature S3 prefix, plus error records and a hash manifest. One blocking OpenAI Batch job stays active per feature. The run ends with one consolidated final Parquet file for `is_likely_spam`.
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_bluesky_campaign.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --feature is_likely_spam \
+  --output-dir docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_likely_spam
+```
 
-**Step 6 (ten-post smoke and campaign approval gate).** Use the deterministic ten-post sample shipped in Step 6 for every feature. Record average and maximum token usage, current model pricing, estimated full-run cost, S3 presence checks, and one deliberate interruption plus resume. Post the smoke cost estimate to this feature issue. Wait until the parent campaign issue records the sum of all seven feature estimates and receives one explicit approval before starting the 200,000-post run.
-
-**Step 7 (progress watcher).** After each durable shard, the runner writes a structured progress record. A restartable watcher subagent reads those records and updates one rolling GitHub issue comment at every 10,000 completed records for this feature.
+**Implementation slice for this PR:** documentation and run artifacts only. No product code changes.
 
 ## Pinned identity contract
-
-Use exactly these values for the full campaign. A different dataset, preprocessed run, campaign id, model, or prompt requires a new campaign and must not reuse this prefix.
 
 | Field | Pinned value |
 |-------|----------------|
 | Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
 | Preprocessed run | `2026_09_03-23:51:30` |
-| Preprocessed row count | `200000` (`metadata.json` `row_counts.output`) |
-| Preprocessed input S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/` |
-| Campaign id / feature run family | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Preprocessed row count | `200000` |
+| Campaign id | `bluesky_2026_09_03_235130_llm_features_v1` |
 | Feature name | `is_likely_spam` |
-| Feature S3 campaign prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/` |
-| Model id | `gpt-5.4-nano` (`lib.constants.DEFAULT_LLM_MODEL`) |
-| Engine | OpenAI Batch (`engine_type="openai"`) |
+| Run id | `bluesky_2026_09_03_235130_llm_features_v1:is_likely_spam` |
+| Feature S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/` |
+| Model id | `gpt-5.4-nano` |
 | Batch size | `2000` |
-| Temperature | `0.0` |
-| System prompt source | `data_platform/generate_features/is_likely_spam/generate_feature.py` → `SYSTEM_PROMPT` |
-| LLM output schema | `LlmIsLikelySpamModel` in the same file |
-| Stored label schema | `IsLikelySpamModel`: `source_record_id`, `label_timestamp`, `is_likely_spam` |
-| Prompt identity in metadata | `metadata.json` `features.is_likely_spam.model_id` = `gpt-5.4-nano` and `prompt_hash` = SHA-256 hex of `SYSTEM_PROMPT` |
-
-Record the exact `prompt_hash` from the smoke run metadata in the permanent run report. If `model_id` or `prompt_hash` drifts from the smoke run, stop and open a new campaign instead of resuming.
-
-## Caller command
-
-Run only this feature with batch size 2000. Do not pass any other `--features` value.
-
-**New feature run (smoke phase uses the Step 6 ten-post path; full run uses this command):**
-
-```bash
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-
-PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --features is_likely_spam \
-  --batch-size 2000
-```
-
-**Resume an interrupted run (same issue, same feature run directory name):**
-
-```bash
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-
-PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --features is_likely_spam \
-  --batch-size 2000 \
-  --checkpoint <feature_run_timestamp>
-```
-
-Replace `<feature_run_timestamp>` with the folder name under the campaign prefix (for example `2026_09_05-14:30:00`). Never start a second concurrent OpenAI Batch job for this feature while an unfinished run exists.
-
-## Two-phase pull request flow
-
-### Phase A — smoke, estimate, and review artifacts
-
-1. Confirm Steps 3–7 are on `main`.
-2. Run the Step 6 ten-post smoke for `is_likely_spam` only.
-3. Perform the deliberate interruption and resume required by Step 6 on the same feature run.
-4. Write temporary smoke artifacts under the plan reports folder (see Allowed files).
-5. Commit and push those temporary smoke artifacts to the feature branch. Do not commit labels.
-6. Post the estimated full-run cost (derived from smoke token usage and current `gpt-5.4-nano` Batch pricing) to this feature issue.
-7. Stop. Do not start the 200,000-post run until the parent campaign issue shows one approval covering all seven feature estimates.
-
-### Phase B — full run after parent approval
-
-1. Confirm the parent campaign issue has explicit approval for the combined estimate.
-2. Start or resume the full run with the caller command above.
-3. Start the Step 7 progress watcher for this feature. It must update the rolling GitHub comment at every 10,000 durable rows.
-4. When the run completes, validate S3 artifacts and row counts (see Acceptance checks).
-5. Write the permanent run report at `reports/is_likely_spam_run_report.md` with actual cost, throughput, retries, error rate, and label counts.
-6. Delete every temporary smoke artifact from the plan reports folder.
-7. Commit and push only the permanent run report. Push the final S3 objects (already written during the run). Open or update the pull request for merge.
-
-If the full run fails or is interrupted, keep the same GitHub issue and the same `--checkpoint` value. Resume; do not open a parallel run or a new campaign prefix.
+| Label field | `is_likely_spam` |
+| Pydantic model | `IsLikelySpamModel` |
+| Accepted label values | boolean `true` or `false` |
+| Prompt source | `data_platform/generate_features/is_likely_spam/generate_feature.py` → `SYSTEM_PROMPT` |
 
 ## Files to inspect (read-only)
 
 | Path | Why |
 |------|-----|
-| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope and done criteria |
-| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Bluesky feature CLI entrypoint |
-| `/workspace/data_platform/generate_features/platform_cli.py` | `--features`, `--batch-size`, `--checkpoint` |
-| `/workspace/data_platform/generate_features/is_likely_spam/generate_feature.py` | `SYSTEM_PROMPT`, accepted label schema |
-| `/workspace/data_platform/generate_features/registry.py` | Feature registry entry for `is_likely_spam` |
-| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch engine and default model |
-| `/workspace/data_platform/generate_features/metadata.py` | `model_id`, `prompt_hash`, resume identity checks |
-| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Pinned input row count and run id |
-| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export, no automated tests |
-
-After Steps 3–7 merge, also read the Step 6 smoke helper, Step 7 progress watcher entrypoint, and any S3 layout docs those steps add.
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | Canonical layout and smoke flow |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Campaign CLI |
+| `/workspace/data_platform/generate_features/smoke_bluesky_campaign.py` | Ten-post smoke (Step 6) |
+| `/workspace/data_platform/generate_features/feature_progress_watcher.py` | Progress watcher (Step 7) |
+| `/workspace/data_platform/generate_features/is_likely_spam/generate_feature.py` | Prompt and schema |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credentials, no automated tests |
 
 ## Files allowed to change
 
-Only documentation artifacts for this feature run. No product code, no label data in Git.
+Documentation artifacts only.
 
-**Temporary smoke artifacts (committed during Phase A, deleted before merge):**
+**Temporary smoke artifacts (Phase A; deleted before merge):**
 
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_likely_spam_smoke_cost.json`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_likely_spam_smoke_resume_evidence.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_likely_spam_smoke_s3_checks.txt`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_likely_spam/is_likely_spam_cost_report.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_likely_spam/is_likely_spam_resume_evidence.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_likely_spam/is_likely_spam_s3_checks.txt`
 
-**Permanent run report (committed during Phase B, kept after merge):**
+**Permanent run report (Phase B; kept after merge):**
 
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_likely_spam_run_report.md`
 
@@ -138,40 +92,71 @@ Only documentation artifacts for this feature run. No product code, no label dat
 
 - Any file under `/workspace/data_platform/`, `/workspace/lib/`, `/workspace/ml_tooling/`, `/workspace/tests/`, `/workspace/pyproject.toml`, `/workspace/CHANGELOG.md`
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
-- Any other step file under `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/`
+- Any other step file under `steps/`
 - Any path under the S3 prefixes for the other six features:
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_political/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_political/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
 - Any committed Parquet, CSV, or JSON label files anywhere in the repository
+
 
 Do not add or run automated tests.
 
-## S3 artifacts
+## Locked contracts
 
-All objects live under:
+See `campaign_contract.md`. S3 objects for this feature:
 
-`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
+| Object | Path |
+|--------|------|
+| Smoke input | `.../is_likely_spam/smoke/input.parquet` |
+| Smoke output | `.../is_likely_spam/smoke/output.parquet` |
+| Smoke cost report | `.../is_likely_spam/smoke/cost_report.json` |
+| Smoke resume evidence | `.../is_likely_spam/smoke/resume_evidence.json` |
+| Batches | `.../is_likely_spam/batches/part-NNNNN.parquet` |
+| Final | `.../is_likely_spam/final.parquet` |
+| Manifest | `.../is_likely_spam/manifest.json` |
+| Progress | `.../is_likely_spam/progress.jsonl` |
+| Errors | `.../is_likely_spam/errors.jsonl` (when needed) |
+| Watcher | `.../is_likely_spam/watcher.json` |
 
-Expected layout after Step 5 (exact subfolder names follow the Step 5 implementation):
+Q44 columns in `final.parquet`: `source_record_id`, `run_id`, `batch_id`, `request_id`, `attempt_count`, `label_timestamp`, `is_likely_spam`.
 
-| Artifact | Purpose |
-|----------|---------|
-| `shards/` | Immutable 2,000-row Parquet shards |
-| `final/is_likely_spam.parquet` | Consolidated feature output |
-| `manifest/` | SHA-256 hash manifest over shards and final file |
-| `progress/` | Structured progress records (one per durable shard) |
-| `errors/` | Error records for rows that failed after retries |
-| `metadata.json` | Run metadata including `model_id`, `prompt_hash`, labeled counts, OpenAI job ids |
+After parent approval, `part-00000.parquet` must contain ten unchanged smoke labels plus 1,990 new labels (2,000 rows total). The next 99 provider jobs each write `part-00001` through `part-00099` with 2,000 rows each. Total: exactly 100 canonical batch objects and 200,000 rows. Preserve original smoke `batch_id` and `request_id` in the ten rows in `part-00000`. `manifest.json` batch entry for `part_index=0` may list both the smoke provider `batch_id` and the first production provider `batch_id`.
 
-Intermediate shards may carry the intermediate-artifact lifecycle tag from Step 16. Final Parquet, manifest, progress records, and reports are retained.
+## Two-phase pull request flow
 
-## Basic commands and checks
+### Phase A: smoke, estimate, and review artifacts
 
-**List campaign prefix:**
+1. Confirm Steps 3, 6, and 7 are on `main`.
+2. Run `smoke_bluesky_campaign.py` once for `is_likely_spam` only. The smoke caller performs one deliberate interruption and resume and writes untagged S3 evidence under `is_likely_spam/smoke/` including `resume_evidence.json`. Do not repeat the interruption procedure in this step.
+3. Commit temporary Git smoke artifacts under `reports/smoke/is_likely_spam/` (include a local copy of `resume_evidence.json`).
+4. Post estimated full-run cost to this feature's GitHub issue through authenticated GitHub integration.
+5. Stop. Do not start the 200,000-post run until the parent campaign issue has one aggregate estimate and explicit human approval.
+
+### Phase B: full run after parent approval
+
+1. Confirm parent campaign issue has explicit approval.
+2. Run the campaign CLI command above (same command resumes automatically).
+3. Run the Step 7 watcher at every 10,000 durable rows; post rolling comment through authenticated GitHub integration.
+4. Validate S3 artifacts and row counts.
+5. Write `reports/is_likely_spam_run_report.md`.
+6. Delete temporary smoke artifacts from Git. S3 smoke evidence remains.
+7. Commit and push only the permanent run report.
+
+## Ordered work
+
+1. Phase A smoke and cost estimate.
+2. Pause for parent aggregate and human approval.
+3. Phase B full run with watcher.
+4. Runtime validation.
+5. Permanent report and Git cleanup.
+
+## Exact commands and expected output
+
+### List feature prefix
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
@@ -180,95 +165,96 @@ export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/ --recursive
 ```
 
-**Download final Parquet for validation:**
+### Download final parquet for validation
 
 ```bash
 aws s3 cp \
-  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/final/is_likely_spam.parquet \
-  /tmp/is_likely_spam.parquet
+  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/final.parquet \
+  /tmp/is_likely_spam_final.parquet
 ```
 
-**Validate row count, uniqueness, schema, and accepted values:**
+### Validate row count, Q44 schema, and accepted values
 
 ```bash
-python - <<'PY'
+PYTHONPATH=. uv run python - <<'PY'
 import pandas as pd
 
-REQUIRED_COLS = ["source_record_id", "label_timestamp", "is_likely_spam"]
+Q44_COLS = [
+    "source_record_id", "run_id", "batch_id", "request_id",
+    "attempt_count", "label_timestamp", "is_likely_spam",
+]
 
-df = pd.read_parquet("/tmp/is_likely_spam.parquet")
-assert list(df.columns) == REQUIRED_COLS, df.columns.tolist()
+df = pd.read_parquet("/tmp/is_likely_spam_final.parquet")
+assert list(df.columns) == Q44_COLS, df.columns.tolist()
 assert len(df) == 200_000, len(df)
-assert df["source_record_id"].is_unique, "duplicate source_record_id"
-assert df["is_likely_spam"].notna().all(), "missing is_likely_spam"
+assert df["source_record_id"].is_unique
+assert df["run_id"].nunique() == 1
+assert df["run_id"].iloc[0] == "bluesky_2026_09_03_235130_llm_features_v1:is_likely_spam"
+assert df["is_likely_spam"].notna().all()
 assert df["is_likely_spam"].dtype == bool or set(df["is_likely_spam"].unique()) <= {True, False}
 print("ok", df["is_likely_spam"].value_counts().to_dict())
 PY
 ```
 
-**Compare labeled ids to preprocessed input:**
+Expected: `ok` plus value counts and exit code 0.
+
+### Verify manifest SHA-256
 
 ```bash
-python - <<'PY'
-import pandas as pd
-
-pre = pd.read_parquet(
-    "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
-)
-feat = pd.read_parquet("/tmp/is_likely_spam.parquet")
-input_ids = set(pre["source_record_id"])
-output_ids = set(feat["source_record_id"])
-assert input_ids == output_ids, (len(input_ids), len(output_ids), len(input_ids - output_ids))
-print("ok ids match")
-PY
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/manifest.json -
 ```
 
-When production reads preprocessed input from S3 (Step 3), download `posts.parquet` from the preprocessed S3 prefix instead of the local path.
+Expected: JSON with `final_parquet.sha256` matching downloaded bytes (SHA-256 only, not ETag).
 
-**Verify manifest hashes** using the Step 5 manifest verifier against `manifest/` and `final/is_likely_spam.parquet`.
-
-**Read progress for the watcher:**
+### Read progress for watcher
 
 ```bash
-aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/progress/ --recursive /tmp/is_likely_spam_progress/
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/progress.jsonl /tmp/is_likely_spam_progress.jsonl
 ```
 
-Confirm a new progress record exists after each 2,000-row shard and that the watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
-
-## Exact accepted values
-
-Each output row must validate as `IsLikelySpamModel`:
-
-| Column | Type | Accepted values |
-|--------|------|-----------------|
-| `source_record_id` | string | One per preprocessed post; exactly 200,000 unique values |
-| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
-| `is_likely_spam` | boolean | `true` or `false` (conservative spam classification per prompt) |
-
-No nulls. No extra columns. No duplicate `source_record_id`.
+Confirm watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
 
 ## Acceptance criteria
 
-1. **Coverage:** Exactly 200,000 rows. Exactly 200,000 unique `source_record_id` values. Zero missing outputs relative to the pinned preprocessed run.
-2. **Schema:** Columns match `IsLikelySpamModel`. All `is_likely_spam` values are boolean.
-3. **Identity:** `metadata.json` records `model_id` = `gpt-5.4-nano` and the `prompt_hash` of the pinned `SYSTEM_PROMPT`.
-4. **S3:** Final Parquet, manifest, progress history, and error records (if any) are present under the feature campaign prefix.
-5. **Cost and operations:** The permanent run report records estimated cost (from smoke), actual cost (from OpenAI usage), throughput (posts per second and tokens per second), retry count, error rate, and label counts for `true` and `false`.
-6. **Progress:** Watcher updated the GitHub comment at every 10,000 durable rows.
-7. **Resume:** If the run was interrupted, resume used the same issue, same `--checkpoint`, and no duplicate OpenAI Batch job.
-8. **Repository hygiene:** No label files committed. Temporary smoke artifacts removed before merge. Only `reports/is_likely_spam_run_report.md` remains from this step in Git.
+1. Exactly 200,000 unique `source_record_id` values with zero missing outputs.
+2. Q44 columns present with correct `run_id` and accepted `is_likely_spam` values.
+3. `manifest.json`, `progress.jsonl`, and `final.parquet` present under the feature prefix.
+4. Permanent run report records smoke estimate, actual cost, throughput, retries, error rate, and label counts.
+5. Watcher updated the GitHub comment at every 10,000 durable rows.
+6. Resume reused the same `run_id` with no duplicate OpenAI Batch job.
+7. S3 smoke evidence under `is_likely_spam/smoke/` includes `resume_evidence.json` from the single smoke invocation.
+8. Temporary Git smoke files removed before merge. S3 smoke evidence remains.
+9. Only `reports/is_likely_spam_run_report.md` remains from this step in Git.
+
+## Failure conditions
+
+- Full 200k run starts before parent campaign issue approval.
+- Smoke run twice for the same feature or different ten-post ids than other features.
+- Smoke writes any object under `batches/` (smoke never writes canonical batch objects).
+- `part-00000.parquet` after full run does not contain ten unchanged smoke labels plus 1,990 new labels.
+- Missing Q44 columns or wrong `run_id`.
+- Any non-boolean `is_likely_spam` value.
+- Using `--checkpoint`, `--resume`, `run_bluesky_llm_campaign.py`, or `APPROVED.txt`.
+- Objects under `campaigns/`, `shards/`, `final/` subdirectory, or per-run timestamp folders.
+- Label files committed to Git.
+- Temporary smoke artifacts left in Git after merge.
+- Any product code change in this PR.
+- Any automated test added or run.
+
+## PR artifact and commit rules
+
+- Phase A: commit temporary smoke artifacts for review.
+- Phase B: commit only permanent run report; delete temporary smoke files before merge.
+- Do not edit `plan.md` or other step specs.
 
 ## Permanent run report contents
 
 `reports/is_likely_spam_run_report.md` must include:
 
-- Pinned identity table (dataset, preprocessed run, campaign id, model, prompt file path, `prompt_hash`)
-- S3 URIs for final Parquet, manifest, and progress folder
-- Smoke estimated full-run cost (USD) and assumptions
-- Actual cost (USD), input/output/total tokens
-- Throughput (posts per second, tokens per second)
-- Retry count and error rate (failed rows / 200,000)
-- Label counts: `is_likely_spam=true`, `is_likely_spam=false`
-- Validation command outputs (pass/fail summary)
-- Feature run timestamp and `--checkpoint` value used
-- OpenAI Batch job id(s) from metadata
+- Pinned identity table (dataset, preprocessed run, campaign id, run id, model, prompt path, prompt hash)
+- S3 URIs for `final.parquet`, `manifest.json`, and `progress.jsonl`
+- Smoke estimated full-run cost and assumptions
+- Actual cost, tokens, throughput, retry count, error rate
+- Label counts for `is_likely_spam=true` and `is_likely_spam=false`
+- Validation command pass/fail summary
+- OpenAI Batch job id(s) from manifest or progress lines

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step11.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step11.md
@@ -1,136 +1,90 @@
-# Step 11: Generate `is_self_contained` for 200,000 Bluesky posts
+# Step 11: Generate is_self_contained for 200,000 Bluesky posts
 
 ## Goal
 
-Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_self_contained` feature only. Publish immutable S3 shards, the final Parquet file, hash manifest, progress history, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
+Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_self_contained` feature only. Publish immutable S3 batches, `final.parquet`, `manifest.json`, `progress.jsonl`, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
 
 This step is one future pull request and one GitHub feature issue. The issue stays open until the feature run is complete and validated.
 
-## Dependencies on Steps 3–7
+## Dependencies
 
-Do not start this step until Steps 3–7 have merged to `main`.
+Do not start until Steps 3, 6, and 7 have merged to `main`. Steps 2, 4, and 5 are required transitively through Step 6 and Step 7. See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md`.
 
-**Step 3 (S3 default backend).** Production feature generation reads preprocessed input and writes feature output through S3, not local `data_platform/data/` or Git LFS. Export AWS credentials before any S3-touching command:
+| Step | Requirement |
+|------|-------------|
+| Step 3 | S3 is the production backend |
+| Step 6 | `smoke_bluesky_campaign.py` and cost aggregation command (single invocation includes deliberate interruption and resume) |
+| Step 7 | `progress.jsonl`, `watcher.json`, and watcher CLI |
+
+## Main caller and implementation slice
+
+**Main caller (campaign mode; same command resumes automatically):**
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --features is_self_contained \
+  --batch-size 2000
 ```
 
-**Step 4 (OpenAI Batch hardening and resume).** The engine persists in-flight OpenAI Batch job identity before polling, keeps successful records from partly failed jobs, retries only transient failures, and resumes without creating duplicate provider jobs. A failed or interrupted run reuses the same feature run directory and the same `--checkpoint` value.
+**Smoke caller (Phase A only; available after Step 6):**
 
-**Step 5 (Parquet shards and manifests).** Each durable batch writes one immutable 2,000-row Parquet shard under the feature S3 prefix, plus error records and a hash manifest. One blocking OpenAI Batch job stays active per feature. The run ends with one consolidated final Parquet file for `is_self_contained`.
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_bluesky_campaign.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --feature is_self_contained \
+  --output-dir docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_self_contained
+```
 
-**Step 6 (ten-post smoke and campaign approval gate).** Use the deterministic ten-post sample shipped in Step 6 for every feature. Record average and maximum token usage, current model pricing, estimated full-run cost, S3 presence checks, and one deliberate interruption plus resume. Post the smoke cost estimate to this feature issue. Wait until the parent campaign issue records the sum of all seven feature estimates and receives one explicit approval before starting the 200,000-post run.
-
-**Step 7 (progress watcher).** After each durable shard, the runner writes a structured progress record. A restartable watcher subagent reads those records and updates one rolling GitHub issue comment at every 10,000 completed records for this feature.
+**Implementation slice for this PR:** documentation and run artifacts only. No product code changes.
 
 ## Pinned identity contract
-
-Use exactly these values for the full campaign. A different dataset, preprocessed run, campaign id, model, or prompt requires a new campaign and must not reuse this prefix.
 
 | Field | Pinned value |
 |-------|----------------|
 | Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
 | Preprocessed run | `2026_09_03-23:51:30` |
-| Preprocessed row count | `200000` (`metadata.json` `row_counts.output`) |
-| Preprocessed input S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/` |
-| Campaign id / feature run family | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Preprocessed row count | `200000` |
+| Campaign id | `bluesky_2026_09_03_235130_llm_features_v1` |
 | Feature name | `is_self_contained` |
-| Feature S3 campaign prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/` |
-| Model id | `gpt-5.4-nano` (`lib.constants.DEFAULT_LLM_MODEL`) |
-| Engine | OpenAI Batch (`engine_type="openai"`) |
+| Run id | `bluesky_2026_09_03_235130_llm_features_v1:is_self_contained` |
+| Feature S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/` |
+| Model id | `gpt-5.4-nano` |
 | Batch size | `2000` |
-| Temperature | `0.0` |
-| System prompt source | `data_platform/generate_features/is_self_contained/generate_feature.py` → `SYSTEM_PROMPT` |
-| LLM output schema | `LlmIsSelfContainedModel` in the same file |
-| Stored label schema | `IsSelfContainedModel`: `source_record_id`, `label_timestamp`, `is_self_contained` |
-| Prompt identity in metadata | `metadata.json` `features.is_self_contained.model_id` = `gpt-5.4-nano` and `prompt_hash` = SHA-256 hex of `SYSTEM_PROMPT` |
-
-Record the exact `prompt_hash` from the smoke run metadata in the permanent run report. If `model_id` or `prompt_hash` drifts from the smoke run, stop and open a new campaign instead of resuming.
-
-## Caller command
-
-Run only this feature with batch size 2000. Do not pass any other `--features` value.
-
-**New feature run (smoke phase uses the Step 6 ten-post path; full run uses this command):**
-
-```bash
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-
-PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --features is_self_contained \
-  --batch-size 2000
-```
-
-**Resume an interrupted run (same issue, same feature run directory name):**
-
-```bash
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-
-PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --features is_self_contained \
-  --batch-size 2000 \
-  --checkpoint <feature_run_timestamp>
-```
-
-Replace `<feature_run_timestamp>` with the folder name under the campaign prefix (for example `2026_09_05-14:30:00`). Never start a second concurrent OpenAI Batch job for this feature while an unfinished run exists.
-
-## Two-phase pull request flow
-
-### Phase A — smoke, estimate, and review artifacts
-
-1. Confirm Steps 3–7 are on `main`.
-2. Run the Step 6 ten-post smoke for `is_self_contained` only.
-3. Perform the deliberate interruption and resume required by Step 6 on the same feature run.
-4. Write temporary smoke artifacts under the plan reports folder (see Allowed files).
-5. Commit and push those temporary smoke artifacts to the feature branch. Do not commit labels.
-6. Post the estimated full-run cost (derived from smoke token usage and current `gpt-5.4-nano` Batch pricing) to this feature issue.
-7. Stop. Do not start the 200,000-post run until the parent campaign issue shows one approval covering all seven feature estimates.
-
-### Phase B — full run after parent approval
-
-1. Confirm the parent campaign issue has explicit approval for the combined estimate.
-2. Start or resume the full run with the caller command above.
-3. Start the Step 7 progress watcher for this feature. It must update the rolling GitHub comment at every 10,000 durable rows.
-4. When the run completes, validate S3 artifacts and row counts (see Acceptance checks).
-5. Write the permanent run report at `reports/is_self_contained_run_report.md` with actual cost, throughput, retries, error rate, and label counts.
-6. Delete every temporary smoke artifact from the plan reports folder.
-7. Commit and push only the permanent run report. Push the final S3 objects (already written during the run). Open or update the pull request for merge.
-
-If the full run fails or is interrupted, keep the same GitHub issue and the same `--checkpoint` value. Resume; do not open a parallel run or a new campaign prefix.
+| Label field | `is_self_contained` |
+| Pydantic model | `IsSelfContainedModel` |
+| Accepted label values | boolean `true` or `false` |
+| Prompt source | `data_platform/generate_features/is_self_contained/generate_feature.py` → `SYSTEM_PROMPT` |
 
 ## Files to inspect (read-only)
 
 | Path | Why |
 |------|-----|
-| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope and done criteria |
-| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Bluesky feature CLI entrypoint |
-| `/workspace/data_platform/generate_features/platform_cli.py` | `--features`, `--batch-size`, `--checkpoint` |
-| `/workspace/data_platform/generate_features/is_self_contained/generate_feature.py` | `SYSTEM_PROMPT`, accepted label schema |
-| `/workspace/data_platform/generate_features/registry.py` | Feature registry entry for `is_self_contained` |
-| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch engine and default model |
-| `/workspace/data_platform/generate_features/metadata.py` | `model_id`, `prompt_hash`, resume identity checks |
-| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Pinned input row count and run id |
-| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export, no automated tests |
-
-After Steps 3–7 merge, also read the Step 6 smoke helper, Step 7 progress watcher entrypoint, and any S3 layout docs those steps add.
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | Canonical layout and smoke flow |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Campaign CLI |
+| `/workspace/data_platform/generate_features/smoke_bluesky_campaign.py` | Ten-post smoke (Step 6) |
+| `/workspace/data_platform/generate_features/feature_progress_watcher.py` | Progress watcher (Step 7) |
+| `/workspace/data_platform/generate_features/is_self_contained/generate_feature.py` | Prompt and schema |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credentials, no automated tests |
 
 ## Files allowed to change
 
-Only documentation artifacts for this feature run. No product code, no label data in Git.
+Documentation artifacts only.
 
-**Temporary smoke artifacts (committed during Phase A, deleted before merge):**
+**Temporary smoke artifacts (Phase A; deleted before merge):**
 
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_self_contained_smoke_cost.json`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_self_contained_smoke_resume_evidence.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_self_contained_smoke_s3_checks.txt`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_self_contained/is_self_contained_cost_report.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_self_contained/is_self_contained_resume_evidence.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_self_contained/is_self_contained_s3_checks.txt`
 
-**Permanent run report (committed during Phase B, kept after merge):**
+**Permanent run report (Phase B; kept after merge):**
 
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_self_contained_run_report.md`
 
@@ -138,40 +92,71 @@ Only documentation artifacts for this feature run. No product code, no label dat
 
 - Any file under `/workspace/data_platform/`, `/workspace/lib/`, `/workspace/ml_tooling/`, `/workspace/tests/`, `/workspace/pyproject.toml`, `/workspace/CHANGELOG.md`
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
-- Any other step file under `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/`
+- Any other step file under `steps/`
 - Any path under the S3 prefixes for the other six features:
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_political/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_political/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
 - Any committed Parquet, CSV, or JSON label files anywhere in the repository
+
 
 Do not add or run automated tests.
 
-## S3 artifacts
+## Locked contracts
 
-All objects live under:
+See `campaign_contract.md`. S3 objects for this feature:
 
-`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
+| Object | Path |
+|--------|------|
+| Smoke input | `.../is_self_contained/smoke/input.parquet` |
+| Smoke output | `.../is_self_contained/smoke/output.parquet` |
+| Smoke cost report | `.../is_self_contained/smoke/cost_report.json` |
+| Smoke resume evidence | `.../is_self_contained/smoke/resume_evidence.json` |
+| Batches | `.../is_self_contained/batches/part-NNNNN.parquet` |
+| Final | `.../is_self_contained/final.parquet` |
+| Manifest | `.../is_self_contained/manifest.json` |
+| Progress | `.../is_self_contained/progress.jsonl` |
+| Errors | `.../is_self_contained/errors.jsonl` (when needed) |
+| Watcher | `.../is_self_contained/watcher.json` |
 
-Expected layout after Step 5 (exact subfolder names follow the Step 5 implementation):
+Q44 columns in `final.parquet`: `source_record_id`, `run_id`, `batch_id`, `request_id`, `attempt_count`, `label_timestamp`, `is_self_contained`.
 
-| Artifact | Purpose |
-|----------|---------|
-| `shards/` | Immutable 2,000-row Parquet shards |
-| `final/is_self_contained.parquet` | Consolidated feature output |
-| `manifest/` | SHA-256 hash manifest over shards and final file |
-| `progress/` | Structured progress records (one per durable shard) |
-| `errors/` | Error records for rows that failed after retries |
-| `metadata.json` | Run metadata including `model_id`, `prompt_hash`, labeled counts, OpenAI job ids |
+After parent approval, `part-00000.parquet` must contain ten unchanged smoke labels plus 1,990 new labels (2,000 rows total). The next 99 provider jobs each write `part-00001` through `part-00099` with 2,000 rows each. Total: exactly 100 canonical batch objects and 200,000 rows. Preserve original smoke `batch_id` and `request_id` in the ten rows in `part-00000`. `manifest.json` batch entry for `part_index=0` may list both the smoke provider `batch_id` and the first production provider `batch_id`.
 
-Intermediate shards may carry the intermediate-artifact lifecycle tag from Step 16. Final Parquet, manifest, progress records, and reports are retained.
+## Two-phase pull request flow
 
-## Basic commands and checks
+### Phase A: smoke, estimate, and review artifacts
 
-**List campaign prefix:**
+1. Confirm Steps 3, 6, and 7 are on `main`.
+2. Run `smoke_bluesky_campaign.py` once for `is_self_contained` only. The smoke caller performs one deliberate interruption and resume and writes untagged S3 evidence under `is_self_contained/smoke/` including `resume_evidence.json`. Do not repeat the interruption procedure in this step.
+3. Commit temporary Git smoke artifacts under `reports/smoke/is_self_contained/` (include a local copy of `resume_evidence.json`).
+4. Post estimated full-run cost to this feature's GitHub issue through authenticated GitHub integration.
+5. Stop. Do not start the 200,000-post run until the parent campaign issue has one aggregate estimate and explicit human approval.
+
+### Phase B: full run after parent approval
+
+1. Confirm parent campaign issue has explicit approval.
+2. Run the campaign CLI command above (same command resumes automatically).
+3. Run the Step 7 watcher at every 10,000 durable rows; post rolling comment through authenticated GitHub integration.
+4. Validate S3 artifacts and row counts.
+5. Write `reports/is_self_contained_run_report.md`.
+6. Delete temporary smoke artifacts from Git. S3 smoke evidence remains.
+7. Commit and push only the permanent run report.
+
+## Ordered work
+
+1. Phase A smoke and cost estimate.
+2. Pause for parent aggregate and human approval.
+3. Phase B full run with watcher.
+4. Runtime validation.
+5. Permanent report and Git cleanup.
+
+## Exact commands and expected output
+
+### List feature prefix
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
@@ -180,95 +165,96 @@ export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/ --recursive
 ```
 
-**Download final Parquet for validation:**
+### Download final parquet for validation
 
 ```bash
 aws s3 cp \
-  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/final/is_self_contained.parquet \
-  /tmp/is_self_contained.parquet
+  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/final.parquet \
+  /tmp/is_self_contained_final.parquet
 ```
 
-**Validate row count, uniqueness, schema, and accepted values:**
+### Validate row count, Q44 schema, and accepted values
 
 ```bash
-python - <<'PY'
+PYTHONPATH=. uv run python - <<'PY'
 import pandas as pd
 
-REQUIRED_COLS = ["source_record_id", "label_timestamp", "is_self_contained"]
+Q44_COLS = [
+    "source_record_id", "run_id", "batch_id", "request_id",
+    "attempt_count", "label_timestamp", "is_self_contained",
+]
 
-df = pd.read_parquet("/tmp/is_self_contained.parquet")
-assert list(df.columns) == REQUIRED_COLS, df.columns.tolist()
+df = pd.read_parquet("/tmp/is_self_contained_final.parquet")
+assert list(df.columns) == Q44_COLS, df.columns.tolist()
 assert len(df) == 200_000, len(df)
-assert df["source_record_id"].is_unique, "duplicate source_record_id"
-assert df["is_self_contained"].notna().all(), "missing is_self_contained"
+assert df["source_record_id"].is_unique
+assert df["run_id"].nunique() == 1
+assert df["run_id"].iloc[0] == "bluesky_2026_09_03_235130_llm_features_v1:is_self_contained"
+assert df["is_self_contained"].notna().all()
 assert df["is_self_contained"].dtype == bool or set(df["is_self_contained"].unique()) <= {True, False}
 print("ok", df["is_self_contained"].value_counts().to_dict())
 PY
 ```
 
-**Compare labeled ids to preprocessed input:**
+Expected: `ok` plus value counts and exit code 0.
+
+### Verify manifest SHA-256
 
 ```bash
-python - <<'PY'
-import pandas as pd
-
-pre = pd.read_parquet(
-    "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
-)
-feat = pd.read_parquet("/tmp/is_self_contained.parquet")
-input_ids = set(pre["source_record_id"])
-output_ids = set(feat["source_record_id"])
-assert input_ids == output_ids, (len(input_ids), len(output_ids), len(input_ids - output_ids))
-print("ok ids match")
-PY
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/manifest.json -
 ```
 
-When production reads preprocessed input from S3 (Step 3), download `posts.parquet` from the preprocessed S3 prefix instead of the local path.
+Expected: JSON with `final_parquet.sha256` matching downloaded bytes (SHA-256 only, not ETag).
 
-**Verify manifest hashes** using the Step 5 manifest verifier against `manifest/` and `final/is_self_contained.parquet`.
-
-**Read progress for the watcher:**
+### Read progress for watcher
 
 ```bash
-aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/progress/ --recursive /tmp/is_self_contained_progress/
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/progress.jsonl /tmp/is_self_contained_progress.jsonl
 ```
 
-Confirm a new progress record exists after each 2,000-row shard and that the watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
-
-## Exact accepted values
-
-Each output row must validate as `IsSelfContainedModel`:
-
-| Column | Type | Accepted values |
-|--------|------|-----------------|
-| `source_record_id` | string | One per preprocessed post; exactly 200,000 unique values |
-| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
-| `is_self_contained` | boolean | `true` if the post text alone is understandable with general US political knowledge; `false` if external context is required |
-
-No nulls. No extra columns. No duplicate `source_record_id`.
+Confirm watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
 
 ## Acceptance criteria
 
-1. **Coverage:** Exactly 200,000 rows. Exactly 200,000 unique `source_record_id` values. Zero missing outputs relative to the pinned preprocessed run.
-2. **Schema:** Columns match `IsSelfContainedModel`. All `is_self_contained` values are boolean.
-3. **Identity:** `metadata.json` records `model_id` = `gpt-5.4-nano` and the `prompt_hash` of the pinned `SYSTEM_PROMPT`.
-4. **S3:** Final Parquet, manifest, progress history, and error records (if any) are present under the feature campaign prefix.
-5. **Cost and operations:** The permanent run report records estimated cost (from smoke), actual cost (from OpenAI usage), throughput (posts per second and tokens per second), retry count, error rate, and label counts for `true` and `false`.
-6. **Progress:** Watcher updated the GitHub comment at every 10,000 durable rows.
-7. **Resume:** If the run was interrupted, resume used the same issue, same `--checkpoint`, and no duplicate OpenAI Batch job.
-8. **Repository hygiene:** No label files committed. Temporary smoke artifacts removed before merge. Only `reports/is_self_contained_run_report.md` remains from this step in Git.
+1. Exactly 200,000 unique `source_record_id` values with zero missing outputs.
+2. Q44 columns present with correct `run_id` and accepted `is_self_contained` values.
+3. `manifest.json`, `progress.jsonl`, and `final.parquet` present under the feature prefix.
+4. Permanent run report records smoke estimate, actual cost, throughput, retries, error rate, and label counts.
+5. Watcher updated the GitHub comment at every 10,000 durable rows.
+6. Resume reused the same `run_id` with no duplicate OpenAI Batch job.
+7. S3 smoke evidence under `is_self_contained/smoke/` includes `resume_evidence.json` from the single smoke invocation.
+8. Temporary Git smoke files removed before merge. S3 smoke evidence remains.
+9. Only `reports/is_self_contained_run_report.md` remains from this step in Git.
+
+## Failure conditions
+
+- Full 200k run starts before parent campaign issue approval.
+- Smoke run twice for the same feature or different ten-post ids than other features.
+- Smoke writes any object under `batches/` (smoke never writes canonical batch objects).
+- `part-00000.parquet` after full run does not contain ten unchanged smoke labels plus 1,990 new labels.
+- Missing Q44 columns or wrong `run_id`.
+- Any non-boolean `is_self_contained` value.
+- Using `--checkpoint`, `--resume`, `run_bluesky_llm_campaign.py`, or `APPROVED.txt`.
+- Objects under `campaigns/`, `shards/`, `final/` subdirectory, or per-run timestamp folders.
+- Label files committed to Git.
+- Temporary smoke artifacts left in Git after merge.
+- Any product code change in this PR.
+- Any automated test added or run.
+
+## PR artifact and commit rules
+
+- Phase A: commit temporary smoke artifacts for review.
+- Phase B: commit only permanent run report; delete temporary smoke files before merge.
+- Do not edit `plan.md` or other step specs.
 
 ## Permanent run report contents
 
 `reports/is_self_contained_run_report.md` must include:
 
-- Pinned identity table (dataset, preprocessed run, campaign id, model, prompt file path, `prompt_hash`)
-- S3 URIs for final Parquet, manifest, and progress folder
-- Smoke estimated full-run cost (USD) and assumptions
-- Actual cost (USD), input/output/total tokens
-- Throughput (posts per second, tokens per second)
-- Retry count and error rate (failed rows / 200,000)
-- Label counts: `is_self_contained=true`, `is_self_contained=false`
-- Validation command outputs (pass/fail summary)
-- Feature run timestamp and `--checkpoint` value used
-- OpenAI Batch job id(s) from metadata
+- Pinned identity table (dataset, preprocessed run, campaign id, run id, model, prompt path, prompt hash)
+- S3 URIs for `final.parquet`, `manifest.json`, and `progress.jsonl`
+- Smoke estimated full-run cost and assumptions
+- Actual cost, tokens, throughput, retry count, error rate
+- Label counts for `is_self_contained=true` and `is_self_contained=false`
+- Validation command pass/fail summary
+- OpenAI Batch job id(s) from manifest or progress lines

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step11.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step11.md
@@ -1,0 +1,274 @@
+# Step 11: Generate `is_self_contained` for 200,000 Bluesky posts
+
+## Goal
+
+Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_self_contained` feature only. Publish immutable S3 shards, the final Parquet file, hash manifest, progress history, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
+
+This step is one future pull request and one GitHub feature issue. The issue stays open until the feature run is complete and validated.
+
+## Dependencies on Steps 3–7
+
+Do not start this step until Steps 3–7 have merged to `main`.
+
+**Step 3 (S3 default backend).** Production feature generation reads preprocessed input and writes feature output through S3, not local `data_platform/data/` or Git LFS. Export AWS credentials before any S3-touching command:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+```
+
+**Step 4 (OpenAI Batch hardening and resume).** The engine persists in-flight OpenAI Batch job identity before polling, keeps successful records from partly failed jobs, retries only transient failures, and resumes without creating duplicate provider jobs. A failed or interrupted run reuses the same feature run directory and the same `--checkpoint` value.
+
+**Step 5 (Parquet shards and manifests).** Each durable batch writes one immutable 2,000-row Parquet shard under the feature S3 prefix, plus error records and a hash manifest. One blocking OpenAI Batch job stays active per feature. The run ends with one consolidated final Parquet file for `is_self_contained`.
+
+**Step 6 (ten-post smoke and campaign approval gate).** Use the deterministic ten-post sample shipped in Step 6 for every feature. Record average and maximum token usage, current model pricing, estimated full-run cost, S3 presence checks, and one deliberate interruption plus resume. Post the smoke cost estimate to this feature issue. Wait until the parent campaign issue records the sum of all seven feature estimates and receives one explicit approval before starting the 200,000-post run.
+
+**Step 7 (progress watcher).** After each durable shard, the runner writes a structured progress record. A restartable watcher subagent reads those records and updates one rolling GitHub issue comment at every 10,000 completed records for this feature.
+
+## Pinned identity contract
+
+Use exactly these values for the full campaign. A different dataset, preprocessed run, campaign id, model, or prompt requires a new campaign and must not reuse this prefix.
+
+| Field | Pinned value |
+|-------|----------------|
+| Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| Preprocessed run | `2026_09_03-23:51:30` |
+| Preprocessed row count | `200000` (`metadata.json` `row_counts.output`) |
+| Preprocessed input S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/` |
+| Campaign id / feature run family | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Feature name | `is_self_contained` |
+| Feature S3 campaign prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/` |
+| Model id | `gpt-5.4-nano` (`lib.constants.DEFAULT_LLM_MODEL`) |
+| Engine | OpenAI Batch (`engine_type="openai"`) |
+| Batch size | `2000` |
+| Temperature | `0.0` |
+| System prompt source | `data_platform/generate_features/is_self_contained/generate_feature.py` → `SYSTEM_PROMPT` |
+| LLM output schema | `LlmIsSelfContainedModel` in the same file |
+| Stored label schema | `IsSelfContainedModel`: `source_record_id`, `label_timestamp`, `is_self_contained` |
+| Prompt identity in metadata | `metadata.json` `features.is_self_contained.model_id` = `gpt-5.4-nano` and `prompt_hash` = SHA-256 hex of `SYSTEM_PROMPT` |
+
+Record the exact `prompt_hash` from the smoke run metadata in the permanent run report. If `model_id` or `prompt_hash` drifts from the smoke run, stop and open a new campaign instead of resuming.
+
+## Caller command
+
+Run only this feature with batch size 2000. Do not pass any other `--features` value.
+
+**New feature run (smoke phase uses the Step 6 ten-post path; full run uses this command):**
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --features is_self_contained \
+  --batch-size 2000
+```
+
+**Resume an interrupted run (same issue, same feature run directory name):**
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --features is_self_contained \
+  --batch-size 2000 \
+  --checkpoint <feature_run_timestamp>
+```
+
+Replace `<feature_run_timestamp>` with the folder name under the campaign prefix (for example `2026_09_05-14:30:00`). Never start a second concurrent OpenAI Batch job for this feature while an unfinished run exists.
+
+## Two-phase pull request flow
+
+### Phase A — smoke, estimate, and review artifacts
+
+1. Confirm Steps 3–7 are on `main`.
+2. Run the Step 6 ten-post smoke for `is_self_contained` only.
+3. Perform the deliberate interruption and resume required by Step 6 on the same feature run.
+4. Write temporary smoke artifacts under the plan reports folder (see Allowed files).
+5. Commit and push those temporary smoke artifacts to the feature branch. Do not commit labels.
+6. Post the estimated full-run cost (derived from smoke token usage and current `gpt-5.4-nano` Batch pricing) to this feature issue.
+7. Stop. Do not start the 200,000-post run until the parent campaign issue shows one approval covering all seven feature estimates.
+
+### Phase B — full run after parent approval
+
+1. Confirm the parent campaign issue has explicit approval for the combined estimate.
+2. Start or resume the full run with the caller command above.
+3. Start the Step 7 progress watcher for this feature. It must update the rolling GitHub comment at every 10,000 durable rows.
+4. When the run completes, validate S3 artifacts and row counts (see Acceptance checks).
+5. Write the permanent run report at `reports/is_self_contained_run_report.md` with actual cost, throughput, retries, error rate, and label counts.
+6. Delete every temporary smoke artifact from the plan reports folder.
+7. Commit and push only the permanent run report. Push the final S3 objects (already written during the run). Open or update the pull request for merge.
+
+If the full run fails or is interrupted, keep the same GitHub issue and the same `--checkpoint` value. Resume; do not open a parallel run or a new campaign prefix.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope and done criteria |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Bluesky feature CLI entrypoint |
+| `/workspace/data_platform/generate_features/platform_cli.py` | `--features`, `--batch-size`, `--checkpoint` |
+| `/workspace/data_platform/generate_features/is_self_contained/generate_feature.py` | `SYSTEM_PROMPT`, accepted label schema |
+| `/workspace/data_platform/generate_features/registry.py` | Feature registry entry for `is_self_contained` |
+| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch engine and default model |
+| `/workspace/data_platform/generate_features/metadata.py` | `model_id`, `prompt_hash`, resume identity checks |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Pinned input row count and run id |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export, no automated tests |
+
+After Steps 3–7 merge, also read the Step 6 smoke helper, Step 7 progress watcher entrypoint, and any S3 layout docs those steps add.
+
+## Files allowed to change
+
+Only documentation artifacts for this feature run. No product code, no label data in Git.
+
+**Temporary smoke artifacts (committed during Phase A, deleted before merge):**
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_self_contained_smoke_cost.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_self_contained_smoke_resume_evidence.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_self_contained_smoke_s3_checks.txt`
+
+**Permanent run report (committed during Phase B, kept after merge):**
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_self_contained_run_report.md`
+
+## Files forbidden to change
+
+- Any file under `/workspace/data_platform/`, `/workspace/lib/`, `/workspace/ml_tooling/`, `/workspace/tests/`, `/workspace/pyproject.toml`, `/workspace/CHANGELOG.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
+- Any other step file under `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/`
+- Any path under the S3 prefixes for the other six features:
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_political/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
+- Any committed Parquet, CSV, or JSON label files anywhere in the repository
+
+Do not add or run automated tests.
+
+## S3 artifacts
+
+All objects live under:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
+
+Expected layout after Step 5 (exact subfolder names follow the Step 5 implementation):
+
+| Artifact | Purpose |
+|----------|---------|
+| `shards/` | Immutable 2,000-row Parquet shards |
+| `final/is_self_contained.parquet` | Consolidated feature output |
+| `manifest/` | SHA-256 hash manifest over shards and final file |
+| `progress/` | Structured progress records (one per durable shard) |
+| `errors/` | Error records for rows that failed after retries |
+| `metadata.json` | Run metadata including `model_id`, `prompt_hash`, labeled counts, OpenAI job ids |
+
+Intermediate shards may carry the intermediate-artifact lifecycle tag from Step 16. Final Parquet, manifest, progress records, and reports are retained.
+
+## Basic commands and checks
+
+**List campaign prefix:**
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/ --recursive
+```
+
+**Download final Parquet for validation:**
+
+```bash
+aws s3 cp \
+  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/final/is_self_contained.parquet \
+  /tmp/is_self_contained.parquet
+```
+
+**Validate row count, uniqueness, schema, and accepted values:**
+
+```bash
+python - <<'PY'
+import pandas as pd
+
+REQUIRED_COLS = ["source_record_id", "label_timestamp", "is_self_contained"]
+
+df = pd.read_parquet("/tmp/is_self_contained.parquet")
+assert list(df.columns) == REQUIRED_COLS, df.columns.tolist()
+assert len(df) == 200_000, len(df)
+assert df["source_record_id"].is_unique, "duplicate source_record_id"
+assert df["is_self_contained"].notna().all(), "missing is_self_contained"
+assert df["is_self_contained"].dtype == bool or set(df["is_self_contained"].unique()) <= {True, False}
+print("ok", df["is_self_contained"].value_counts().to_dict())
+PY
+```
+
+**Compare labeled ids to preprocessed input:**
+
+```bash
+python - <<'PY'
+import pandas as pd
+
+pre = pd.read_parquet(
+    "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
+)
+feat = pd.read_parquet("/tmp/is_self_contained.parquet")
+input_ids = set(pre["source_record_id"])
+output_ids = set(feat["source_record_id"])
+assert input_ids == output_ids, (len(input_ids), len(output_ids), len(input_ids - output_ids))
+print("ok ids match")
+PY
+```
+
+When production reads preprocessed input from S3 (Step 3), download `posts.parquet` from the preprocessed S3 prefix instead of the local path.
+
+**Verify manifest hashes** using the Step 5 manifest verifier against `manifest/` and `final/is_self_contained.parquet`.
+
+**Read progress for the watcher:**
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/progress/ --recursive /tmp/is_self_contained_progress/
+```
+
+Confirm a new progress record exists after each 2,000-row shard and that the watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
+
+## Exact accepted values
+
+Each output row must validate as `IsSelfContainedModel`:
+
+| Column | Type | Accepted values |
+|--------|------|-----------------|
+| `source_record_id` | string | One per preprocessed post; exactly 200,000 unique values |
+| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
+| `is_self_contained` | boolean | `true` if the post text alone is understandable with general US political knowledge; `false` if external context is required |
+
+No nulls. No extra columns. No duplicate `source_record_id`.
+
+## Acceptance criteria
+
+1. **Coverage:** Exactly 200,000 rows. Exactly 200,000 unique `source_record_id` values. Zero missing outputs relative to the pinned preprocessed run.
+2. **Schema:** Columns match `IsSelfContainedModel`. All `is_self_contained` values are boolean.
+3. **Identity:** `metadata.json` records `model_id` = `gpt-5.4-nano` and the `prompt_hash` of the pinned `SYSTEM_PROMPT`.
+4. **S3:** Final Parquet, manifest, progress history, and error records (if any) are present under the feature campaign prefix.
+5. **Cost and operations:** The permanent run report records estimated cost (from smoke), actual cost (from OpenAI usage), throughput (posts per second and tokens per second), retry count, error rate, and label counts for `true` and `false`.
+6. **Progress:** Watcher updated the GitHub comment at every 10,000 durable rows.
+7. **Resume:** If the run was interrupted, resume used the same issue, same `--checkpoint`, and no duplicate OpenAI Batch job.
+8. **Repository hygiene:** No label files committed. Temporary smoke artifacts removed before merge. Only `reports/is_self_contained_run_report.md` remains from this step in Git.
+
+## Permanent run report contents
+
+`reports/is_self_contained_run_report.md` must include:
+
+- Pinned identity table (dataset, preprocessed run, campaign id, model, prompt file path, `prompt_hash`)
+- S3 URIs for final Parquet, manifest, and progress folder
+- Smoke estimated full-run cost (USD) and assumptions
+- Actual cost (USD), input/output/total tokens
+- Throughput (posts per second, tokens per second)
+- Retry count and error rate (failed rows / 200,000)
+- Label counts: `is_self_contained=true`, `is_self_contained=false`
+- Validation command outputs (pass/fail summary)
+- Feature run timestamp and `--checkpoint` value used
+- OpenAI Batch job id(s) from metadata

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step12.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step12.md
@@ -1,0 +1,306 @@
+# Step 12: Generate `is_structurally_complete` for 200,000 Bluesky posts
+
+## Goal
+
+Run the approved S3-backed LLM campaign flow for the boolean feature `is_structurally_complete` on the pinned 200,000-post Bluesky preprocessed dataset. Publish the final feature Parquet file, SHA-256 manifest, progress history, runtime validation results, and one permanent run report under campaign prefix `bluesky_2026_09_03_235130_llm_features_v1`.
+
+This step is one future pull request. It is a run-only PR: no product code changes.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/generate_features/run_bluesky_llm_campaign.py` (delivered by Steps 4–7).
+
+**Task:** label every pinned input row once with `is_structurally_complete`, using OpenAI Batch at batch size 2000, then verify completeness and publish audit artifacts.
+
+**Out of scope:** Changing feature prompts, registry entries, OpenAI engine code, S3 storage helpers, consolidation logic, curation, automated tests, or any file outside the allowed list below.
+
+## Dependencies
+
+Merge and verify these plan steps before opening this PR:
+
+| Step | Requirement |
+|------|-------------|
+| Step 3 | S3 is the production pipeline backend; pinned preprocessed Parquet is readable from S3 |
+| Step 4 | OpenAI Batch jobs persist provider job IDs and resume without duplicate jobs |
+| Step 5 | Immutable 2,000-row Parquet shards, final feature Parquet, hash manifest, deterministic order |
+| Step 6 | Deterministic ten-post smoke sample, cost estimate artifact, deliberate interrupt/resume check, parent campaign approval gate |
+| Step 7 | Durable progress records and rolling GitHub issue comment updates every 10,000 durable rows |
+
+Steps 8–11 are not blockers for starting this feature, but this step follows the same run contract as those steps.
+
+## Pinned identities
+
+Lock every command and artifact to these values. A different dataset, preprocess run, or campaign ID requires a new campaign.
+
+| Field | Value |
+|-------|-------|
+| Dataset ID | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| Preprocessed run | `2026_09_03-23:51:30` |
+| Preprocessed input object | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet` |
+| Expected input row count | `200000` |
+| Campaign prefix | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Feature name | `is_structurally_complete` (exactly one feature per command) |
+| Batch size | `2000` |
+| Model ID | `gpt-5.4-nano` (`DEFAULT_LLM_MODEL`) |
+| Prompt source | `data_platform/generate_features/is_structurally_complete/generate_feature.py` `SYSTEM_PROMPT` |
+| Join key in feature files | `source_record_id` |
+| Records id column in preprocessed input | `uri` |
+
+Feature S3 prefix (isolated from other features):
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
+
+## Feature contract
+
+Read-only reference: `data_platform/generate_features/is_structurally_complete/generate_feature.py` and `FEATURE_REGISTRY["is_structurally_complete"]`.
+
+Output schema per labeled row:
+
+| Column | Type | Accepted values |
+|--------|------|-----------------|
+| `source_record_id` | string | Must match pinned preprocessed `uri` / `source_record_id` |
+| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
+| `is_structurally_complete` | boolean | `true` or `false` only |
+
+Final consolidated wide-table column name remains `is_structurally_complete`.
+
+Do not run `is_toxic_tiered` (Perspective API) in this step.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope and campaign rules |
+| `/workspace/data_platform/generate_features/run_bluesky_llm_campaign.py` | Campaign CLI from Steps 4–7 |
+| `/workspace/data_platform/generate_features/is_structurally_complete/generate_feature.py` | Prompt and output schema |
+| `/workspace/data_platform/generate_features/registry.py` | `FEATURE_REGISTRY["is_structurally_complete"]` |
+| `/workspace/data_platform/generate_features/metadata.py` | Pinned model and prompt hash behavior on resume |
+| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch resume semantics |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Expected `row_counts.output == 200000` |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export in Cloud Agent |
+
+## Files allowed to change
+
+Run artifacts only:
+
+- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete_REPORT.md` (permanent; keep after merge)
+- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/is_structurally_complete_*` (temporary smoke and resume evidence; commit for review, delete before merge)
+- S3 objects under the feature prefix above
+
+Do not edit the plan package during implementation.
+
+## Files forbidden to change
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
+- `/workspace/data_platform/generate_features/**` except reading
+- `/workspace/data_platform/utils/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/data_platform/models/**`
+- `/workspace/tests/**`
+- `/workspace/CHANGELOG.md`
+- Any other repository file
+
+## Workflow
+
+### Phase A — Ten-post smoke, cost estimate, interrupt/resume proof
+
+1. Export AWS credentials per `AGENTS.md`.
+2. Run smoke with exactly one feature flag.
+3. Commit temporary smoke artifacts listed below so reviewers can inspect cost and resume evidence.
+4. Post the smoke cost estimate to this feature’s GitHub issue.
+5. Perform the deliberate interruption and resume check required by Step 6 on the same campaign prefix.
+6. Wait for parent campaign approval on the aggregate cost estimate before Phase B.
+
+### Phase B — Full 200,000-row generation
+
+1. Run the same command with full-run flags only after parent approval.
+2. Keep one blocking OpenAI Batch job active for this feature.
+3. After each durable 2,000-row shard lands in S3, ensure Step 7 progress records update.
+4. At every 10,000 durable labeled rows, update the rolling GitHub issue comment via the watcher subagent pattern from Step 7.
+5. On failure, resume the failed run with the same campaign prefix and `--resume`; do not start a parallel provider job.
+
+### Phase C — Validation, permanent report, PR cleanup
+
+1. Run runtime validation commands below.
+2. Write the permanent run report.
+3. Remove temporary smoke artifacts from the branch before merge.
+4. Leave S3 final Parquet, manifest, progress history, and permanent report in place.
+
+## Exact commands
+
+From the repo root. Export AWS credentials first:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+```
+
+Install deps if needed:
+
+```bash
+uv sync
+```
+
+### Smoke (ten posts, one feature only)
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --feature is_structurally_complete \
+  --batch-size 2000 \
+  --phase smoke
+```
+
+Expected:
+
+- Stdout reports exactly ten labeled rows.
+- Smoke cost JSON is written under `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/is_structurally_complete_cost.json`.
+- Smoke outputs land under `.../is_structurally_complete/smoke/` on S3.
+- Deliberate interrupt/resume evidence is captured in `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/is_structurally_complete_resume_evidence.md`.
+
+### Full run (after parent approval)
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --feature is_structurally_complete \
+  --batch-size 2000 \
+  --phase full
+```
+
+Expected:
+
+- One OpenAI Batch job chain completes with 100 durable shards of 2,000 rows each (last shard may be shorter only if input count changes; it must not for this campaign).
+- Progress records advance in steps of 2,000 until `labeled == 200000`.
+- Rolling issue comment updates occur at 10000, 20000, …, 200000 durable rows.
+
+### Failed-run resume (same command shape as Step 8–11)
+
+If the run stops after partial progress:
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --feature is_structurally_complete \
+  --batch-size 2000 \
+  --phase full \
+  --resume
+```
+
+Expected:
+
+- The CLI reloads the persisted OpenAI Batch job ID and existing shards.
+- No duplicate provider job is created for rows already durably written.
+- Model ID and prompt hash in campaign metadata remain unchanged.
+
+### Runtime validation (required; not automated tests)
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python - <<'PY'
+import duckdb
+
+final = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/final/is_structurally_complete.parquet"
+posts = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
+
+con = duckdb.connect()
+row = con.execute(f"""
+WITH inp AS (
+  SELECT CAST(source_record_id AS VARCHAR) AS source_record_id
+  FROM read_parquet('{posts}')
+),
+feat AS (
+  SELECT CAST(source_record_id AS VARCHAR) AS source_record_id,
+         is_structurally_complete
+  FROM read_parquet('{final}')
+)
+SELECT
+  (SELECT COUNT(*) FROM inp) AS input_rows,
+  (SELECT COUNT(*) FROM feat) AS feature_rows,
+  (SELECT COUNT(DISTINCT source_record_id) FROM feat) AS unique_ids,
+  (SELECT COUNT(*) FROM feat WHERE is_structurally_complete IS NULL) AS null_labels,
+  (SELECT COUNT(*) FROM inp i LEFT JOIN feat f USING (source_record_id) WHERE f.source_record_id IS NULL) AS missing_labels,
+  (SELECT COUNT(*) FROM feat f LEFT JOIN inp i USING (source_record_id) WHERE i.source_record_id IS NULL) AS extra_labels
+""").fetchone()
+print(row)
+assert row == (200000, 200000, 200000, 0, 0, 0)
+PY
+```
+
+Boolean value check:
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import duckdb
+path = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/final/is_structurally_complete.parquet"
+bad = duckdb.connect().execute(f"""
+SELECT COUNT(*) FROM read_parquet('{path}')
+WHERE is_structurally_complete NOT IN (TRUE, FALSE)
+""").fetchone()[0]
+print("invalid_boolean_rows", bad)
+assert bad == 0
+PY
+```
+
+Manifest check:
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/final/manifest.sha256.json -
+```
+
+Expected: JSON listing SHA-256 for final Parquet and every durable shard, with row counts summing to 200000.
+
+## Required outputs
+
+### S3 (permanent)
+
+| Object | Purpose |
+|--------|---------|
+| `.../is_structurally_complete/shards/shard_*.parquet` | Durable 2,000-row intermediate shards (lifecycle-tagged in Step 16) |
+| `.../is_structurally_complete/final/is_structurally_complete.parquet` | Final deduped feature file |
+| `.../is_structurally_complete/final/manifest.sha256.json` | SHA-256 manifest |
+| `.../is_structurally_complete/progress/` | Structured progress history |
+| `.../is_structurally_complete/metadata.json` | Campaign metadata including OpenAI job ID, model ID, prompt hash, labeled count |
+
+### Repository
+
+| Path | Lifetime |
+|------|----------|
+| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete_REPORT.md` | Permanent |
+| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/is_structurally_complete_cost.json` | Temporary; remove before merge |
+| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/is_structurally_complete_resume_evidence.md` | Temporary; remove before merge |
+
+Permanent report must record: S3 URIs, input preprocessed hash, manifest digest, model ID, prompt hash, smoke and actual token counts, estimated and actual cost, throughput, retry counts, validation command results, and true/false label counts.
+
+## Acceptance and failure
+
+| Check | Pass | Fail |
+|-------|------|------|
+| Dependencies | Steps 3–7 merged | Campaign CLI or S3 backend missing |
+| Single feature command | Every run uses only `--feature is_structurally_complete` | Multiple `--feature` values or full registry run |
+| Batch size | `--batch-size 2000` on smoke and full runs | Any other batch size |
+| Parent approval | Full run starts only after parent issue approval | Full run before approval |
+| Smoke artifacts | Temporary smoke files committed for review, then removed before merge | Smoke artifacts left in repo or never committed for review |
+| Completeness | Exactly 200000 unique `source_record_id` values, zero null labels, zero missing/extra IDs | Any other row count or join mismatch |
+| Accepted values | `is_structurally_complete` is boolean only | String booleans or other types |
+| Resume | Failed run continues with `--resume` on same prefix without duplicate OpenAI job | New provider job for already-labeled rows |
+| Progress | Rolling issue comment updates every 10000 durable rows | Missing updates |
+| Tests | Runtime checks only | New or modified automated tests in this PR |
+| Product code | No Python product code edits | Any change under `data_platform/generate_features/**` or related libraries |
+| Perspective toxicity | `is_toxic_tiered` never invoked | Perspective feature run attempted |
+
+## Done when
+
+1. Smoke, interrupt/resume proof, and cost estimate are posted and parent campaign approval is recorded.
+2. Final S3 Parquet, manifest, and progress history exist for `is_structurally_complete`.
+3. Runtime validation passes with exactly 200000 unique, non-null boolean labels.
+4. Permanent run report is committed; temporary smoke artifacts are removed before merge.
+5. Rolling GitHub issue updates cover 10000-row milestones through 200000.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step12.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step12.md
@@ -1,306 +1,260 @@
-# Step 12: Generate `is_structurally_complete` for 200,000 Bluesky posts
+# Step 12: Generate is_structurally_complete for 200,000 Bluesky posts
 
 ## Goal
 
-Run the approved S3-backed LLM campaign flow for the boolean feature `is_structurally_complete` on the pinned 200,000-post Bluesky preprocessed dataset. Publish the final feature Parquet file, SHA-256 manifest, progress history, runtime validation results, and one permanent run report under campaign prefix `bluesky_2026_09_03_235130_llm_features_v1`.
+Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_structurally_complete` feature only. Publish immutable S3 batches, `final.parquet`, `manifest.json`, `progress.jsonl`, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
 
-This step is one future pull request. It is a run-only PR: no product code changes.
-
-## Caller / unit of work
-
-**Main caller:** `data_platform/generate_features/run_bluesky_llm_campaign.py` (delivered by Steps 4–7).
-
-**Task:** label every pinned input row once with `is_structurally_complete`, using OpenAI Batch at batch size 2000, then verify completeness and publish audit artifacts.
-
-**Out of scope:** Changing feature prompts, registry entries, OpenAI engine code, S3 storage helpers, consolidation logic, curation, automated tests, or any file outside the allowed list below.
+This step is one future pull request and one GitHub feature issue. The issue stays open until the feature run is complete and validated.
 
 ## Dependencies
 
-Merge and verify these plan steps before opening this PR:
+Do not start until Steps 3, 6, and 7 have merged to `main`. Steps 2, 4, and 5 are required transitively through Step 6 and Step 7. See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md`.
 
 | Step | Requirement |
 |------|-------------|
-| Step 3 | S3 is the production pipeline backend; pinned preprocessed Parquet is readable from S3 |
-| Step 4 | OpenAI Batch jobs persist provider job IDs and resume without duplicate jobs |
-| Step 5 | Immutable 2,000-row Parquet shards, final feature Parquet, hash manifest, deterministic order |
-| Step 6 | Deterministic ten-post smoke sample, cost estimate artifact, deliberate interrupt/resume check, parent campaign approval gate |
-| Step 7 | Durable progress records and rolling GitHub issue comment updates every 10,000 durable rows |
+| Step 3 | S3 is the production backend |
+| Step 6 | `smoke_bluesky_campaign.py` and cost aggregation command (single invocation includes deliberate interruption and resume) |
+| Step 7 | `progress.jsonl`, `watcher.json`, and watcher CLI |
 
-Steps 8–11 are not blockers for starting this feature, but this step follows the same run contract as those steps.
+## Main caller and implementation slice
 
-## Pinned identities
+**Main caller (campaign mode; same command resumes automatically):**
 
-Lock every command and artifact to these values. A different dataset, preprocess run, or campaign ID requires a new campaign.
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
-| Field | Value |
-|-------|-------|
-| Dataset ID | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --features is_structurally_complete \
+  --batch-size 2000
+```
+
+**Smoke caller (Phase A only; available after Step 6):**
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_bluesky_campaign.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --feature is_structurally_complete \
+  --output-dir docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_structurally_complete
+```
+
+**Implementation slice for this PR:** documentation and run artifacts only. No product code changes.
+
+## Pinned identity contract
+
+| Field | Pinned value |
+|-------|----------------|
+| Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
 | Preprocessed run | `2026_09_03-23:51:30` |
-| Preprocessed input object | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet` |
-| Expected input row count | `200000` |
-| Campaign prefix | `bluesky_2026_09_03_235130_llm_features_v1` |
-| Feature name | `is_structurally_complete` (exactly one feature per command) |
+| Preprocessed row count | `200000` |
+| Campaign id | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Feature name | `is_structurally_complete` |
+| Run id | `bluesky_2026_09_03_235130_llm_features_v1:is_structurally_complete` |
+| Feature S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/` |
+| Model id | `gpt-5.4-nano` |
 | Batch size | `2000` |
-| Model ID | `gpt-5.4-nano` (`DEFAULT_LLM_MODEL`) |
-| Prompt source | `data_platform/generate_features/is_structurally_complete/generate_feature.py` `SYSTEM_PROMPT` |
-| Join key in feature files | `source_record_id` |
-| Records id column in preprocessed input | `uri` |
-
-Feature S3 prefix (isolated from other features):
-
-`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
-
-## Feature contract
-
-Read-only reference: `data_platform/generate_features/is_structurally_complete/generate_feature.py` and `FEATURE_REGISTRY["is_structurally_complete"]`.
-
-Output schema per labeled row:
-
-| Column | Type | Accepted values |
-|--------|------|-----------------|
-| `source_record_id` | string | Must match pinned preprocessed `uri` / `source_record_id` |
-| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
-| `is_structurally_complete` | boolean | `true` or `false` only |
-
-Final consolidated wide-table column name remains `is_structurally_complete`.
-
-Do not run `is_toxic_tiered` (Perspective API) in this step.
+| Label field | `is_structurally_complete` |
+| Pydantic model | `IsStructurallyCompleteModel` |
+| Accepted label values | boolean `true` or `false` |
+| Prompt source | `data_platform/generate_features/is_structurally_complete/generate_feature.py` → `SYSTEM_PROMPT` |
 
 ## Files to inspect (read-only)
 
 | Path | Why |
 |------|-----|
-| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope and campaign rules |
-| `/workspace/data_platform/generate_features/run_bluesky_llm_campaign.py` | Campaign CLI from Steps 4–7 |
-| `/workspace/data_platform/generate_features/is_structurally_complete/generate_feature.py` | Prompt and output schema |
-| `/workspace/data_platform/generate_features/registry.py` | `FEATURE_REGISTRY["is_structurally_complete"]` |
-| `/workspace/data_platform/generate_features/metadata.py` | Pinned model and prompt hash behavior on resume |
-| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch resume semantics |
-| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Expected `row_counts.output == 200000` |
-| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export in Cloud Agent |
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | Canonical layout and smoke flow |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Campaign CLI |
+| `/workspace/data_platform/generate_features/smoke_bluesky_campaign.py` | Ten-post smoke (Step 6) |
+| `/workspace/data_platform/generate_features/feature_progress_watcher.py` | Progress watcher (Step 7) |
+| `/workspace/data_platform/generate_features/is_structurally_complete/generate_feature.py` | Prompt and schema |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credentials, no automated tests |
 
 ## Files allowed to change
 
-Run artifacts only:
+Documentation artifacts only.
 
-- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete_REPORT.md` (permanent; keep after merge)
-- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/is_structurally_complete_*` (temporary smoke and resume evidence; commit for review, delete before merge)
-- S3 objects under the feature prefix above
+**Temporary smoke artifacts (Phase A; deleted before merge):**
 
-Do not edit the plan package during implementation.
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_structurally_complete/is_structurally_complete_cost_report.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_structurally_complete/is_structurally_complete_resume_evidence.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_structurally_complete/is_structurally_complete_s3_checks.txt`
+
+**Permanent run report (Phase B; kept after merge):**
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_structurally_complete_run_report.md`
 
 ## Files forbidden to change
 
+- Any file under `/workspace/data_platform/`, `/workspace/lib/`, `/workspace/ml_tooling/`, `/workspace/tests/`, `/workspace/pyproject.toml`, `/workspace/CHANGELOG.md`
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
-- `/workspace/data_platform/generate_features/**` except reading
-- `/workspace/data_platform/utils/**`
-- `/workspace/data_platform/curate/**`
-- `/workspace/data_platform/models/**`
-- `/workspace/tests/**`
-- `/workspace/CHANGELOG.md`
-- Any other repository file
+- Any other step file under `steps/`
+- Any path under the S3 prefixes for the other six features:
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_political/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
+- Any committed Parquet, CSV, or JSON label files anywhere in the repository
 
-## Workflow
 
-### Phase A — Ten-post smoke, cost estimate, interrupt/resume proof
+Do not add or run automated tests.
 
-1. Export AWS credentials per `AGENTS.md`.
-2. Run smoke with exactly one feature flag.
-3. Commit temporary smoke artifacts listed below so reviewers can inspect cost and resume evidence.
-4. Post the smoke cost estimate to this feature’s GitHub issue.
-5. Perform the deliberate interruption and resume check required by Step 6 on the same campaign prefix.
-6. Wait for parent campaign approval on the aggregate cost estimate before Phase B.
+## Locked contracts
 
-### Phase B — Full 200,000-row generation
+See `campaign_contract.md`. S3 objects for this feature:
 
-1. Run the same command with full-run flags only after parent approval.
-2. Keep one blocking OpenAI Batch job active for this feature.
-3. After each durable 2,000-row shard lands in S3, ensure Step 7 progress records update.
-4. At every 10,000 durable labeled rows, update the rolling GitHub issue comment via the watcher subagent pattern from Step 7.
-5. On failure, resume the failed run with the same campaign prefix and `--resume`; do not start a parallel provider job.
+| Object | Path |
+|--------|------|
+| Smoke input | `.../is_structurally_complete/smoke/input.parquet` |
+| Smoke output | `.../is_structurally_complete/smoke/output.parquet` |
+| Smoke cost report | `.../is_structurally_complete/smoke/cost_report.json` |
+| Smoke resume evidence | `.../is_structurally_complete/smoke/resume_evidence.json` |
+| Batches | `.../is_structurally_complete/batches/part-NNNNN.parquet` |
+| Final | `.../is_structurally_complete/final.parquet` |
+| Manifest | `.../is_structurally_complete/manifest.json` |
+| Progress | `.../is_structurally_complete/progress.jsonl` |
+| Errors | `.../is_structurally_complete/errors.jsonl` (when needed) |
+| Watcher | `.../is_structurally_complete/watcher.json` |
 
-### Phase C — Validation, permanent report, PR cleanup
+Q44 columns in `final.parquet`: `source_record_id`, `run_id`, `batch_id`, `request_id`, `attempt_count`, `label_timestamp`, `is_structurally_complete`.
 
-1. Run runtime validation commands below.
-2. Write the permanent run report.
-3. Remove temporary smoke artifacts from the branch before merge.
-4. Leave S3 final Parquet, manifest, progress history, and permanent report in place.
+After parent approval, `part-00000.parquet` must contain ten unchanged smoke labels plus 1,990 new labels (2,000 rows total). The next 99 provider jobs each write `part-00001` through `part-00099` with 2,000 rows each. Total: exactly 100 canonical batch objects and 200,000 rows. Preserve original smoke `batch_id` and `request_id` in the ten rows in `part-00000`. `manifest.json` batch entry for `part_index=0` may list both the smoke provider `batch_id` and the first production provider `batch_id`.
 
-## Exact commands
+## Two-phase pull request flow
 
-From the repo root. Export AWS credentials first:
+### Phase A: smoke, estimate, and review artifacts
 
-```bash
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-```
+1. Confirm Steps 3, 6, and 7 are on `main`.
+2. Run `smoke_bluesky_campaign.py` once for `is_structurally_complete` only. The smoke caller performs one deliberate interruption and resume and writes untagged S3 evidence under `is_structurally_complete/smoke/` including `resume_evidence.json`. Do not repeat the interruption procedure in this step.
+3. Commit temporary Git smoke artifacts under `reports/smoke/is_structurally_complete/` (include a local copy of `resume_evidence.json`).
+4. Post estimated full-run cost to this feature's GitHub issue through authenticated GitHub integration.
+5. Stop. Do not start the 200,000-post run until the parent campaign issue has one aggregate estimate and explicit human approval.
 
-Install deps if needed:
+### Phase B: full run after parent approval
 
-```bash
-uv sync
-```
+1. Confirm parent campaign issue has explicit approval.
+2. Run the campaign CLI command above (same command resumes automatically).
+3. Run the Step 7 watcher at every 10,000 durable rows; post rolling comment through authenticated GitHub integration.
+4. Validate S3 artifacts and row counts.
+5. Write `reports/is_structurally_complete_run_report.md`.
+6. Delete temporary smoke artifacts from Git. S3 smoke evidence remains.
+7. Commit and push only the permanent run report.
 
-### Smoke (ten posts, one feature only)
+## Ordered work
 
-```bash
-PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --preprocessed-run 2026_09_03-23:51:30 \
-  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
-  --feature is_structurally_complete \
-  --batch-size 2000 \
-  --phase smoke
-```
+1. Phase A smoke and cost estimate.
+2. Pause for parent aggregate and human approval.
+3. Phase B full run with watcher.
+4. Runtime validation.
+5. Permanent report and Git cleanup.
 
-Expected:
+## Exact commands and expected output
 
-- Stdout reports exactly ten labeled rows.
-- Smoke cost JSON is written under `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/is_structurally_complete_cost.json`.
-- Smoke outputs land under `.../is_structurally_complete/smoke/` on S3.
-- Deliberate interrupt/resume evidence is captured in `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/is_structurally_complete_resume_evidence.md`.
-
-### Full run (after parent approval)
-
-```bash
-PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --preprocessed-run 2026_09_03-23:51:30 \
-  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
-  --feature is_structurally_complete \
-  --batch-size 2000 \
-  --phase full
-```
-
-Expected:
-
-- One OpenAI Batch job chain completes with 100 durable shards of 2,000 rows each (last shard may be shorter only if input count changes; it must not for this campaign).
-- Progress records advance in steps of 2,000 until `labeled == 200000`.
-- Rolling issue comment updates occur at 10000, 20000, …, 200000 durable rows.
-
-### Failed-run resume (same command shape as Step 8–11)
-
-If the run stops after partial progress:
-
-```bash
-PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --preprocessed-run 2026_09_03-23:51:30 \
-  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
-  --feature is_structurally_complete \
-  --batch-size 2000 \
-  --phase full \
-  --resume
-```
-
-Expected:
-
-- The CLI reloads the persisted OpenAI Batch job ID and existing shards.
-- No duplicate provider job is created for rows already durably written.
-- Model ID and prompt hash in campaign metadata remain unchanged.
-
-### Runtime validation (required; not automated tests)
+### List feature prefix
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
-PYTHONPATH=. uv run python - <<'PY'
-import duckdb
-
-final = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/final/is_structurally_complete.parquet"
-posts = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
-
-con = duckdb.connect()
-row = con.execute(f"""
-WITH inp AS (
-  SELECT CAST(source_record_id AS VARCHAR) AS source_record_id
-  FROM read_parquet('{posts}')
-),
-feat AS (
-  SELECT CAST(source_record_id AS VARCHAR) AS source_record_id,
-         is_structurally_complete
-  FROM read_parquet('{final}')
-)
-SELECT
-  (SELECT COUNT(*) FROM inp) AS input_rows,
-  (SELECT COUNT(*) FROM feat) AS feature_rows,
-  (SELECT COUNT(DISTINCT source_record_id) FROM feat) AS unique_ids,
-  (SELECT COUNT(*) FROM feat WHERE is_structurally_complete IS NULL) AS null_labels,
-  (SELECT COUNT(*) FROM inp i LEFT JOIN feat f USING (source_record_id) WHERE f.source_record_id IS NULL) AS missing_labels,
-  (SELECT COUNT(*) FROM feat f LEFT JOIN inp i USING (source_record_id) WHERE i.source_record_id IS NULL) AS extra_labels
-""").fetchone()
-print(row)
-assert row == (200000, 200000, 200000, 0, 0, 0)
-PY
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/ --recursive
 ```
 
-Boolean value check:
+### Download final parquet for validation
+
+```bash
+aws s3 cp \
+  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/final.parquet \
+  /tmp/is_structurally_complete_final.parquet
+```
+
+### Validate row count, Q44 schema, and accepted values
 
 ```bash
 PYTHONPATH=. uv run python - <<'PY'
-import duckdb
-path = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/final/is_structurally_complete.parquet"
-bad = duckdb.connect().execute(f"""
-SELECT COUNT(*) FROM read_parquet('{path}')
-WHERE is_structurally_complete NOT IN (TRUE, FALSE)
-""").fetchone()[0]
-print("invalid_boolean_rows", bad)
-assert bad == 0
+import pandas as pd
+
+Q44_COLS = [
+    "source_record_id", "run_id", "batch_id", "request_id",
+    "attempt_count", "label_timestamp", "is_structurally_complete",
+]
+
+df = pd.read_parquet("/tmp/is_structurally_complete_final.parquet")
+assert list(df.columns) == Q44_COLS, df.columns.tolist()
+assert len(df) == 200_000, len(df)
+assert df["source_record_id"].is_unique
+assert df["run_id"].nunique() == 1
+assert df["run_id"].iloc[0] == "bluesky_2026_09_03_235130_llm_features_v1:is_structurally_complete"
+assert df["is_structurally_complete"].notna().all()
+assert df["is_structurally_complete"].dtype == bool or set(df["is_structurally_complete"].unique()) <= {True, False}
+print("ok", df["is_structurally_complete"].value_counts().to_dict())
 PY
 ```
 
-Manifest check:
+Expected: `ok` plus value counts and exit code 0.
+
+### Verify manifest SHA-256
 
 ```bash
-aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/final/manifest.sha256.json -
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/manifest.json -
 ```
 
-Expected: JSON listing SHA-256 for final Parquet and every durable shard, with row counts summing to 200000.
+Expected: JSON with `final_parquet.sha256` matching downloaded bytes (SHA-256 only, not ETag).
 
-## Required outputs
+### Read progress for watcher
 
-### S3 (permanent)
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/progress.jsonl /tmp/is_structurally_complete_progress.jsonl
+```
 
-| Object | Purpose |
-|--------|---------|
-| `.../is_structurally_complete/shards/shard_*.parquet` | Durable 2,000-row intermediate shards (lifecycle-tagged in Step 16) |
-| `.../is_structurally_complete/final/is_structurally_complete.parquet` | Final deduped feature file |
-| `.../is_structurally_complete/final/manifest.sha256.json` | SHA-256 manifest |
-| `.../is_structurally_complete/progress/` | Structured progress history |
-| `.../is_structurally_complete/metadata.json` | Campaign metadata including OpenAI job ID, model ID, prompt hash, labeled count |
+Confirm watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
 
-### Repository
+## Acceptance criteria
 
-| Path | Lifetime |
-|------|----------|
-| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete_REPORT.md` | Permanent |
-| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/is_structurally_complete_cost.json` | Temporary; remove before merge |
-| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/is_structurally_complete_resume_evidence.md` | Temporary; remove before merge |
+1. Exactly 200,000 unique `source_record_id` values with zero missing outputs.
+2. Q44 columns present with correct `run_id` and accepted `is_structurally_complete` values.
+3. `manifest.json`, `progress.jsonl`, and `final.parquet` present under the feature prefix.
+4. Permanent run report records smoke estimate, actual cost, throughput, retries, error rate, and label counts.
+5. Watcher updated the GitHub comment at every 10,000 durable rows.
+6. Resume reused the same `run_id` with no duplicate OpenAI Batch job.
+7. S3 smoke evidence under `is_structurally_complete/smoke/` includes `resume_evidence.json` from the single smoke invocation.
+8. Temporary Git smoke files removed before merge. S3 smoke evidence remains.
+9. Only `reports/is_structurally_complete_run_report.md` remains from this step in Git.
 
-Permanent report must record: S3 URIs, input preprocessed hash, manifest digest, model ID, prompt hash, smoke and actual token counts, estimated and actual cost, throughput, retry counts, validation command results, and true/false label counts.
+## Failure conditions
 
-## Acceptance and failure
+- Full 200k run starts before parent campaign issue approval.
+- Smoke run twice for the same feature or different ten-post ids than other features.
+- Smoke writes any object under `batches/` (smoke never writes canonical batch objects).
+- `part-00000.parquet` after full run does not contain ten unchanged smoke labels plus 1,990 new labels.
+- Missing Q44 columns or wrong `run_id`.
+- Any non-boolean `is_structurally_complete` value.
+- Using `--checkpoint`, `--resume`, `run_bluesky_llm_campaign.py`, or `APPROVED.txt`.
+- Objects under `campaigns/`, `shards/`, `final/` subdirectory, or per-run timestamp folders.
+- Label files committed to Git.
+- Temporary smoke artifacts left in Git after merge.
+- Any product code change in this PR.
+- Any automated test added or run.
 
-| Check | Pass | Fail |
-|-------|------|------|
-| Dependencies | Steps 3–7 merged | Campaign CLI or S3 backend missing |
-| Single feature command | Every run uses only `--feature is_structurally_complete` | Multiple `--feature` values or full registry run |
-| Batch size | `--batch-size 2000` on smoke and full runs | Any other batch size |
-| Parent approval | Full run starts only after parent issue approval | Full run before approval |
-| Smoke artifacts | Temporary smoke files committed for review, then removed before merge | Smoke artifacts left in repo or never committed for review |
-| Completeness | Exactly 200000 unique `source_record_id` values, zero null labels, zero missing/extra IDs | Any other row count or join mismatch |
-| Accepted values | `is_structurally_complete` is boolean only | String booleans or other types |
-| Resume | Failed run continues with `--resume` on same prefix without duplicate OpenAI job | New provider job for already-labeled rows |
-| Progress | Rolling issue comment updates every 10000 durable rows | Missing updates |
-| Tests | Runtime checks only | New or modified automated tests in this PR |
-| Product code | No Python product code edits | Any change under `data_platform/generate_features/**` or related libraries |
-| Perspective toxicity | `is_toxic_tiered` never invoked | Perspective feature run attempted |
+## PR artifact and commit rules
 
-## Done when
+- Phase A: commit temporary smoke artifacts for review.
+- Phase B: commit only permanent run report; delete temporary smoke files before merge.
+- Do not edit `plan.md` or other step specs.
 
-1. Smoke, interrupt/resume proof, and cost estimate are posted and parent campaign approval is recorded.
-2. Final S3 Parquet, manifest, and progress history exist for `is_structurally_complete`.
-3. Runtime validation passes with exactly 200000 unique, non-null boolean labels.
-4. Permanent run report is committed; temporary smoke artifacts are removed before merge.
-5. Rolling GitHub issue updates cover 10000-row milestones through 200000.
+## Permanent run report contents
+
+`reports/is_structurally_complete_run_report.md` must include:
+
+- Pinned identity table (dataset, preprocessed run, campaign id, run id, model, prompt path, prompt hash)
+- S3 URIs for `final.parquet`, `manifest.json`, and `progress.jsonl`
+- Smoke estimated full-run cost and assumptions
+- Actual cost, tokens, throughput, retry count, error rate
+- Label counts for `is_structurally_complete=true` and `is_structurally_complete=false`
+- Validation command pass/fail summary
+- OpenAI Batch job id(s) from manifest or progress lines

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step13.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step13.md
@@ -1,0 +1,311 @@
+# Step 13: Generate `political_stance` for 200,000 Bluesky posts
+
+## Goal
+
+Run the approved S3-backed LLM campaign flow for the multi-class feature `political_stance` on the pinned 200,000-post Bluesky preprocessed dataset. Publish the final feature Parquet file, SHA-256 manifest, progress history, runtime validation results, and one permanent run report under campaign prefix `bluesky_2026_09_03_235130_llm_features_v1`.
+
+This step is one future pull request. It is a run-only PR: no product code changes.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/generate_features/run_bluesky_llm_campaign.py` (delivered by Steps 4–7).
+
+**Task:** label every pinned input row once with `political_stance`, using OpenAI Batch at batch size 2000, then verify completeness and publish audit artifacts.
+
+**Out of scope:** Changing feature prompts, registry entries, OpenAI engine code, S3 storage helpers, consolidation logic, curation, automated tests, or any file outside the allowed list below.
+
+## Dependencies
+
+Merge and verify these plan steps before opening this PR:
+
+| Step | Requirement |
+|------|-------------|
+| Step 3 | S3 is the production pipeline backend; pinned preprocessed Parquet is readable from S3 |
+| Step 4 | OpenAI Batch jobs persist provider job IDs and resume without duplicate jobs |
+| Step 5 | Immutable 2,000-row Parquet shards, final feature Parquet, hash manifest, deterministic order |
+| Step 6 | Deterministic ten-post smoke sample, cost estimate artifact, deliberate interrupt/resume check, parent campaign approval gate |
+| Step 7 | Durable progress records and rolling GitHub issue comment updates every 10,000 durable rows |
+
+Steps 8–11 are not blockers for starting this feature, but this step follows the same run contract as those steps.
+
+## Pinned identities
+
+Lock every command and artifact to these values. A different dataset, preprocess run, or campaign ID requires a new campaign.
+
+| Field | Value |
+|-------|-------|
+| Dataset ID | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| Preprocessed run | `2026_09_03-23:51:30` |
+| Preprocessed input object | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet` |
+| Expected input row count | `200000` |
+| Campaign prefix | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Feature name | `political_stance` (exactly one feature per command) |
+| Batch size | `2000` |
+| Model ID | `gpt-5.4-nano` (`DEFAULT_LLM_MODEL`) |
+| Prompt source | `data_platform/generate_features/political_stance/generate_feature.py` `SYSTEM_PROMPT` |
+| Join key in feature files | `source_record_id` |
+| Records id column in preprocessed input | `uri` |
+
+Feature S3 prefix (isolated from other features):
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
+
+## Feature contract
+
+Read-only reference: `data_platform/generate_features/political_stance/generate_feature.py` and `FEATURE_REGISTRY["political_stance"]`.
+
+Output schema per labeled row:
+
+| Column | Type | Accepted values |
+|--------|------|-----------------|
+| `source_record_id` | string | Must match pinned preprocessed `uri` / `source_record_id` |
+| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
+| `political_stance` | string | Exactly one of `left`, `right`, `neutral`, `unclear` |
+
+Final consolidated wide-table column name remains `political_stance`.
+
+Do not run `is_toxic_tiered` (Perspective API) in this step.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope and campaign rules |
+| `/workspace/data_platform/generate_features/run_bluesky_llm_campaign.py` | Campaign CLI from Steps 4–7 |
+| `/workspace/data_platform/generate_features/political_stance/generate_feature.py` | Prompt and output schema |
+| `/workspace/data_platform/generate_features/registry.py` | `FEATURE_REGISTRY["political_stance"]` |
+| `/workspace/data_platform/generate_features/metadata.py` | Pinned model and prompt hash behavior on resume |
+| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch resume semantics |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Expected `row_counts.output == 200000` |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export in Cloud Agent |
+
+## Files allowed to change
+
+Run artifacts only:
+
+- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/political_stance_REPORT.md` (permanent; keep after merge)
+- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/political_stance_*` (temporary smoke and resume evidence; commit for review, delete before merge)
+- S3 objects under the feature prefix above
+
+Do not edit the plan package during implementation.
+
+## Files forbidden to change
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
+- `/workspace/data_platform/generate_features/**` except reading
+- `/workspace/data_platform/utils/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/data_platform/models/**`
+- `/workspace/tests/**`
+- `/workspace/CHANGELOG.md`
+- Any other repository file
+
+## Workflow
+
+### Phase A — Ten-post smoke, cost estimate, interrupt/resume proof
+
+1. Export AWS credentials per `AGENTS.md`.
+2. Run smoke with exactly one feature flag.
+3. Commit temporary smoke artifacts listed below so reviewers can inspect cost and resume evidence.
+4. Post the smoke cost estimate to this feature’s GitHub issue.
+5. Perform the deliberate interruption and resume check required by Step 6 on the same campaign prefix.
+6. Wait for parent campaign approval on the aggregate cost estimate before Phase B.
+
+### Phase B — Full 200,000-row generation
+
+1. Run the same command with full-run flags only after parent approval.
+2. Keep one blocking OpenAI Batch job active for this feature.
+3. After each durable 2,000-row shard lands in S3, ensure Step 7 progress records update.
+4. At every 10,000 durable labeled rows, update the rolling GitHub issue comment via the watcher subagent pattern from Step 7.
+5. On failure, resume the failed run with the same campaign prefix and `--resume`; do not start a parallel provider job.
+
+### Phase C — Validation, permanent report, PR cleanup
+
+1. Run runtime validation commands below.
+2. Write the permanent run report including label counts for `left`, `right`, `neutral`, and `unclear`.
+3. Remove temporary smoke artifacts from the branch before merge.
+4. Leave S3 final Parquet, manifest, progress history, and permanent report in place.
+
+## Exact commands
+
+From the repo root. Export AWS credentials first:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+```
+
+Install deps if needed:
+
+```bash
+uv sync
+```
+
+### Smoke (ten posts, one feature only)
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --feature political_stance \
+  --batch-size 2000 \
+  --phase smoke
+```
+
+Expected:
+
+- Stdout reports exactly ten labeled rows.
+- Smoke cost JSON is written under `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/political_stance_cost.json`.
+- Smoke outputs land under `.../political_stance/smoke/` on S3.
+- Deliberate interrupt/resume evidence is captured in `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/political_stance_resume_evidence.md`.
+
+### Full run (after parent approval)
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --feature political_stance \
+  --batch-size 2000 \
+  --phase full
+```
+
+Expected:
+
+- One OpenAI Batch job chain completes with 100 durable shards of 2,000 rows each.
+- Progress records advance in steps of 2,000 until `labeled == 200000`.
+- Rolling issue comment updates occur at 10000, 20000, …, 200000 durable rows.
+
+### Failed-run resume
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --feature political_stance \
+  --batch-size 2000 \
+  --phase full \
+  --resume
+```
+
+Expected:
+
+- The CLI reloads the persisted OpenAI Batch job ID and existing shards.
+- No duplicate provider job is created for rows already durably written.
+- Model ID and prompt hash in campaign metadata remain unchanged.
+
+### Runtime validation (required; not automated tests)
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python - <<'PY'
+import duckdb
+
+final = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/political_stance/final/political_stance.parquet"
+posts = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
+
+con = duckdb.connect()
+row = con.execute(f"""
+WITH inp AS (
+  SELECT CAST(source_record_id AS VARCHAR) AS source_record_id
+  FROM read_parquet('{posts}')
+),
+feat AS (
+  SELECT CAST(source_record_id AS VARCHAR) AS source_record_id,
+         political_stance
+  FROM read_parquet('{final}')
+)
+SELECT
+  (SELECT COUNT(*) FROM inp) AS input_rows,
+  (SELECT COUNT(*) FROM feat) AS feature_rows,
+  (SELECT COUNT(DISTINCT source_record_id) FROM feat) AS unique_ids,
+  (SELECT COUNT(*) FROM feat WHERE political_stance IS NULL) AS null_labels,
+  (SELECT COUNT(*) FROM inp i LEFT JOIN feat f USING (source_record_id) WHERE f.source_record_id IS NULL) AS missing_labels,
+  (SELECT COUNT(*) FROM feat f LEFT JOIN inp i USING (source_record_id) WHERE i.source_record_id IS NULL) AS extra_labels
+""").fetchone()
+print(row)
+assert row == (200000, 200000, 200000, 0, 0, 0)
+PY
+```
+
+Accepted-value check:
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import duckdb
+path = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/political_stance/final/political_stance.parquet"
+allowed = ("left", "right", "neutral", "unclear")
+bad = duckdb.connect().execute(f"""
+SELECT COUNT(*) FROM read_parquet('{path}')
+WHERE political_stance NOT IN {allowed}
+""").fetchone()[0]
+print("invalid_stance_rows", bad)
+assert bad == 0
+counts = duckdb.connect().execute(f"""
+SELECT political_stance, COUNT(*) AS n
+FROM read_parquet('{path}')
+GROUP BY 1 ORDER BY 1
+""").fetchdf()
+print(counts.to_string(index=False))
+PY
+```
+
+Manifest check:
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/political_stance/final/manifest.sha256.json -
+```
+
+Expected: JSON listing SHA-256 for final Parquet and every durable shard, with row counts summing to 200000.
+
+## Required outputs
+
+### S3 (permanent)
+
+| Object | Purpose |
+|--------|---------|
+| `.../political_stance/shards/shard_*.parquet` | Durable 2,000-row intermediate shards |
+| `.../political_stance/final/political_stance.parquet` | Final deduped feature file |
+| `.../political_stance/final/manifest.sha256.json` | SHA-256 manifest |
+| `.../political_stance/progress/` | Structured progress history |
+| `.../political_stance/metadata.json` | Campaign metadata including OpenAI job ID, model ID, prompt hash, labeled count |
+
+### Repository
+
+| Path | Lifetime |
+|------|----------|
+| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/political_stance_REPORT.md` | Permanent |
+| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/political_stance_cost.json` | Temporary; remove before merge |
+| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/political_stance_resume_evidence.md` | Temporary; remove before merge |
+
+Permanent report must record: S3 URIs, input preprocessed hash, manifest digest, model ID, prompt hash, smoke and actual token counts, estimated and actual cost, throughput, retry counts, validation command results, and counts for `left`, `right`, `neutral`, and `unclear`.
+
+## Acceptance and failure
+
+| Check | Pass | Fail |
+|-------|------|------|
+| Dependencies | Steps 3–7 merged | Campaign CLI or S3 backend missing |
+| Single feature command | Every run uses only `--feature political_stance` | Multiple `--feature` values or full registry run |
+| Batch size | `--batch-size 2000` on smoke and full runs | Any other batch size |
+| Parent approval | Full run starts only after parent issue approval | Full run before approval |
+| Smoke artifacts | Temporary smoke files committed for review, then removed before merge | Smoke artifacts left in repo or never committed for review |
+| Completeness | Exactly 200000 unique `source_record_id` values, zero null labels, zero missing/extra IDs | Any other row count or join mismatch |
+| Accepted values | `political_stance` in `{left, right, neutral, unclear}` only | Any other label string |
+| Resume | Failed run continues with `--resume` on same prefix without duplicate OpenAI job | New provider job for already-labeled rows |
+| Progress | Rolling issue comment updates every 10000 durable rows | Missing updates |
+| Tests | Runtime checks only | New or modified automated tests in this PR |
+| Product code | No Python product code edits | Any change under `data_platform/generate_features/**` or related libraries |
+| Perspective toxicity | `is_toxic_tiered` never invoked | Perspective feature run attempted |
+
+## Done when
+
+1. Smoke, interrupt/resume proof, and cost estimate are posted and parent campaign approval is recorded.
+2. Final S3 Parquet, manifest, and progress history exist for `political_stance`.
+3. Runtime validation passes with exactly 200000 unique, non-null stance labels in the accepted set.
+4. Permanent run report is committed; temporary smoke artifacts are removed before merge.
+5. Rolling GitHub issue updates cover 10000-row milestones through 200000.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step13.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step13.md
@@ -1,311 +1,261 @@
-# Step 13: Generate `political_stance` for 200,000 Bluesky posts
+# Step 13: Generate political_stance for 200,000 Bluesky posts
 
 ## Goal
 
-Run the approved S3-backed LLM campaign flow for the multi-class feature `political_stance` on the pinned 200,000-post Bluesky preprocessed dataset. Publish the final feature Parquet file, SHA-256 manifest, progress history, runtime validation results, and one permanent run report under campaign prefix `bluesky_2026_09_03_235130_llm_features_v1`.
+Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `political_stance` feature only. Publish immutable S3 batches, `final.parquet`, `manifest.json`, `progress.jsonl`, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
 
-This step is one future pull request. It is a run-only PR: no product code changes.
-
-## Caller / unit of work
-
-**Main caller:** `data_platform/generate_features/run_bluesky_llm_campaign.py` (delivered by Steps 4–7).
-
-**Task:** label every pinned input row once with `political_stance`, using OpenAI Batch at batch size 2000, then verify completeness and publish audit artifacts.
-
-**Out of scope:** Changing feature prompts, registry entries, OpenAI engine code, S3 storage helpers, consolidation logic, curation, automated tests, or any file outside the allowed list below.
+This step is one future pull request and one GitHub feature issue. The issue stays open until the feature run is complete and validated.
 
 ## Dependencies
 
-Merge and verify these plan steps before opening this PR:
+Do not start until Steps 3, 6, and 7 have merged to `main`. Steps 2, 4, and 5 are required transitively through Step 6 and Step 7. See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md`.
 
 | Step | Requirement |
 |------|-------------|
-| Step 3 | S3 is the production pipeline backend; pinned preprocessed Parquet is readable from S3 |
-| Step 4 | OpenAI Batch jobs persist provider job IDs and resume without duplicate jobs |
-| Step 5 | Immutable 2,000-row Parquet shards, final feature Parquet, hash manifest, deterministic order |
-| Step 6 | Deterministic ten-post smoke sample, cost estimate artifact, deliberate interrupt/resume check, parent campaign approval gate |
-| Step 7 | Durable progress records and rolling GitHub issue comment updates every 10,000 durable rows |
+| Step 3 | S3 is the production backend |
+| Step 6 | `smoke_bluesky_campaign.py` and cost aggregation command (single invocation includes deliberate interruption and resume) |
+| Step 7 | `progress.jsonl`, `watcher.json`, and watcher CLI |
 
-Steps 8–11 are not blockers for starting this feature, but this step follows the same run contract as those steps.
+## Main caller and implementation slice
 
-## Pinned identities
+**Main caller (campaign mode; same command resumes automatically):**
 
-Lock every command and artifact to these values. A different dataset, preprocess run, or campaign ID requires a new campaign.
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
-| Field | Value |
-|-------|-------|
-| Dataset ID | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --features political_stance \
+  --batch-size 2000
+```
+
+**Smoke caller (Phase A only; available after Step 6):**
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_bluesky_campaign.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --feature political_stance \
+  --output-dir docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/political_stance
+```
+
+**Implementation slice for this PR:** documentation and run artifacts only. No product code changes.
+
+## Pinned identity contract
+
+| Field | Pinned value |
+|-------|----------------|
+| Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
 | Preprocessed run | `2026_09_03-23:51:30` |
-| Preprocessed input object | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet` |
-| Expected input row count | `200000` |
-| Campaign prefix | `bluesky_2026_09_03_235130_llm_features_v1` |
-| Feature name | `political_stance` (exactly one feature per command) |
+| Preprocessed row count | `200000` |
+| Campaign id | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Feature name | `political_stance` |
+| Run id | `bluesky_2026_09_03_235130_llm_features_v1:political_stance` |
+| Feature S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/political_stance/` |
+| Model id | `gpt-5.4-nano` |
 | Batch size | `2000` |
-| Model ID | `gpt-5.4-nano` (`DEFAULT_LLM_MODEL`) |
-| Prompt source | `data_platform/generate_features/political_stance/generate_feature.py` `SYSTEM_PROMPT` |
-| Join key in feature files | `source_record_id` |
-| Records id column in preprocessed input | `uri` |
-
-Feature S3 prefix (isolated from other features):
-
-`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
-
-## Feature contract
-
-Read-only reference: `data_platform/generate_features/political_stance/generate_feature.py` and `FEATURE_REGISTRY["political_stance"]`.
-
-Output schema per labeled row:
-
-| Column | Type | Accepted values |
-|--------|------|-----------------|
-| `source_record_id` | string | Must match pinned preprocessed `uri` / `source_record_id` |
-| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
-| `political_stance` | string | Exactly one of `left`, `right`, `neutral`, `unclear` |
-
-Final consolidated wide-table column name remains `political_stance`.
-
-Do not run `is_toxic_tiered` (Perspective API) in this step.
+| Label field | `political_stance` |
+| Pydantic model | `PoliticalStanceModel` |
+| Accepted label values | `left`, `right`, `neutral`, `unclear` |
+| Prompt source | `data_platform/generate_features/political_stance/generate_feature.py` → `SYSTEM_PROMPT` |
 
 ## Files to inspect (read-only)
 
 | Path | Why |
 |------|-----|
-| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope and campaign rules |
-| `/workspace/data_platform/generate_features/run_bluesky_llm_campaign.py` | Campaign CLI from Steps 4–7 |
-| `/workspace/data_platform/generate_features/political_stance/generate_feature.py` | Prompt and output schema |
-| `/workspace/data_platform/generate_features/registry.py` | `FEATURE_REGISTRY["political_stance"]` |
-| `/workspace/data_platform/generate_features/metadata.py` | Pinned model and prompt hash behavior on resume |
-| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch resume semantics |
-| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Expected `row_counts.output == 200000` |
-| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export in Cloud Agent |
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | Canonical layout and smoke flow |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Campaign CLI |
+| `/workspace/data_platform/generate_features/smoke_bluesky_campaign.py` | Ten-post smoke (Step 6) |
+| `/workspace/data_platform/generate_features/feature_progress_watcher.py` | Progress watcher (Step 7) |
+| `/workspace/data_platform/generate_features/political_stance/generate_feature.py` | Prompt and schema |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credentials, no automated tests |
 
 ## Files allowed to change
 
-Run artifacts only:
+Documentation artifacts only.
 
-- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/political_stance_REPORT.md` (permanent; keep after merge)
-- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/political_stance_*` (temporary smoke and resume evidence; commit for review, delete before merge)
-- S3 objects under the feature prefix above
+**Temporary smoke artifacts (Phase A; deleted before merge):**
 
-Do not edit the plan package during implementation.
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/political_stance/political_stance_cost_report.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/political_stance/political_stance_resume_evidence.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/political_stance/political_stance_s3_checks.txt`
+
+**Permanent run report (Phase B; kept after merge):**
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/political_stance_run_report.md`
 
 ## Files forbidden to change
 
+- Any file under `/workspace/data_platform/`, `/workspace/lib/`, `/workspace/ml_tooling/`, `/workspace/tests/`, `/workspace/pyproject.toml`, `/workspace/CHANGELOG.md`
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
-- `/workspace/data_platform/generate_features/**` except reading
-- `/workspace/data_platform/utils/**`
-- `/workspace/data_platform/curate/**`
-- `/workspace/data_platform/models/**`
-- `/workspace/tests/**`
-- `/workspace/CHANGELOG.md`
-- Any other repository file
+- Any other step file under `steps/`
+- Any path under the S3 prefixes for the other six features:
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_political/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
+- Any committed Parquet, CSV, or JSON label files anywhere in the repository
 
-## Workflow
 
-### Phase A — Ten-post smoke, cost estimate, interrupt/resume proof
+Do not add or run automated tests.
 
-1. Export AWS credentials per `AGENTS.md`.
-2. Run smoke with exactly one feature flag.
-3. Commit temporary smoke artifacts listed below so reviewers can inspect cost and resume evidence.
-4. Post the smoke cost estimate to this feature’s GitHub issue.
-5. Perform the deliberate interruption and resume check required by Step 6 on the same campaign prefix.
-6. Wait for parent campaign approval on the aggregate cost estimate before Phase B.
+## Locked contracts
 
-### Phase B — Full 200,000-row generation
+See `campaign_contract.md`. S3 objects for this feature:
 
-1. Run the same command with full-run flags only after parent approval.
-2. Keep one blocking OpenAI Batch job active for this feature.
-3. After each durable 2,000-row shard lands in S3, ensure Step 7 progress records update.
-4. At every 10,000 durable labeled rows, update the rolling GitHub issue comment via the watcher subagent pattern from Step 7.
-5. On failure, resume the failed run with the same campaign prefix and `--resume`; do not start a parallel provider job.
+| Object | Path |
+|--------|------|
+| Smoke input | `.../political_stance/smoke/input.parquet` |
+| Smoke output | `.../political_stance/smoke/output.parquet` |
+| Smoke cost report | `.../political_stance/smoke/cost_report.json` |
+| Smoke resume evidence | `.../political_stance/smoke/resume_evidence.json` |
+| Batches | `.../political_stance/batches/part-NNNNN.parquet` |
+| Final | `.../political_stance/final.parquet` |
+| Manifest | `.../political_stance/manifest.json` |
+| Progress | `.../political_stance/progress.jsonl` |
+| Errors | `.../political_stance/errors.jsonl` (when needed) |
+| Watcher | `.../political_stance/watcher.json` |
 
-### Phase C — Validation, permanent report, PR cleanup
+Q44 columns in `final.parquet`: `source_record_id`, `run_id`, `batch_id`, `request_id`, `attempt_count`, `label_timestamp`, `political_stance`.
 
-1. Run runtime validation commands below.
-2. Write the permanent run report including label counts for `left`, `right`, `neutral`, and `unclear`.
-3. Remove temporary smoke artifacts from the branch before merge.
-4. Leave S3 final Parquet, manifest, progress history, and permanent report in place.
+After parent approval, `part-00000.parquet` must contain ten unchanged smoke labels plus 1,990 new labels (2,000 rows total). The next 99 provider jobs each write `part-00001` through `part-00099` with 2,000 rows each. Total: exactly 100 canonical batch objects and 200,000 rows. Preserve original smoke `batch_id` and `request_id` in the ten rows in `part-00000`. `manifest.json` batch entry for `part_index=0` may list both the smoke provider `batch_id` and the first production provider `batch_id`.
 
-## Exact commands
+## Two-phase pull request flow
 
-From the repo root. Export AWS credentials first:
+### Phase A: smoke, estimate, and review artifacts
 
-```bash
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-```
+1. Confirm Steps 3, 6, and 7 are on `main`.
+2. Run `smoke_bluesky_campaign.py` once for `political_stance` only. The smoke caller performs one deliberate interruption and resume and writes untagged S3 evidence under `political_stance/smoke/` including `resume_evidence.json`. Do not repeat the interruption procedure in this step.
+3. Commit temporary Git smoke artifacts under `reports/smoke/political_stance/` (include a local copy of `resume_evidence.json`).
+4. Post estimated full-run cost to this feature's GitHub issue through authenticated GitHub integration.
+5. Stop. Do not start the 200,000-post run until the parent campaign issue has one aggregate estimate and explicit human approval.
 
-Install deps if needed:
+### Phase B: full run after parent approval
 
-```bash
-uv sync
-```
+1. Confirm parent campaign issue has explicit approval.
+2. Run the campaign CLI command above (same command resumes automatically).
+3. Run the Step 7 watcher at every 10,000 durable rows; post rolling comment through authenticated GitHub integration.
+4. Validate S3 artifacts and row counts.
+5. Write `reports/political_stance_run_report.md`.
+6. Delete temporary smoke artifacts from Git. S3 smoke evidence remains.
+7. Commit and push only the permanent run report.
 
-### Smoke (ten posts, one feature only)
+## Ordered work
 
-```bash
-PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --preprocessed-run 2026_09_03-23:51:30 \
-  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
-  --feature political_stance \
-  --batch-size 2000 \
-  --phase smoke
-```
+1. Phase A smoke and cost estimate.
+2. Pause for parent aggregate and human approval.
+3. Phase B full run with watcher.
+4. Runtime validation.
+5. Permanent report and Git cleanup.
 
-Expected:
+## Exact commands and expected output
 
-- Stdout reports exactly ten labeled rows.
-- Smoke cost JSON is written under `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/political_stance_cost.json`.
-- Smoke outputs land under `.../political_stance/smoke/` on S3.
-- Deliberate interrupt/resume evidence is captured in `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/political_stance_resume_evidence.md`.
-
-### Full run (after parent approval)
-
-```bash
-PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --preprocessed-run 2026_09_03-23:51:30 \
-  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
-  --feature political_stance \
-  --batch-size 2000 \
-  --phase full
-```
-
-Expected:
-
-- One OpenAI Batch job chain completes with 100 durable shards of 2,000 rows each.
-- Progress records advance in steps of 2,000 until `labeled == 200000`.
-- Rolling issue comment updates occur at 10000, 20000, …, 200000 durable rows.
-
-### Failed-run resume
-
-```bash
-PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --preprocessed-run 2026_09_03-23:51:30 \
-  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
-  --feature political_stance \
-  --batch-size 2000 \
-  --phase full \
-  --resume
-```
-
-Expected:
-
-- The CLI reloads the persisted OpenAI Batch job ID and existing shards.
-- No duplicate provider job is created for rows already durably written.
-- Model ID and prompt hash in campaign metadata remain unchanged.
-
-### Runtime validation (required; not automated tests)
+### List feature prefix
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
-PYTHONPATH=. uv run python - <<'PY'
-import duckdb
-
-final = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/political_stance/final/political_stance.parquet"
-posts = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
-
-con = duckdb.connect()
-row = con.execute(f"""
-WITH inp AS (
-  SELECT CAST(source_record_id AS VARCHAR) AS source_record_id
-  FROM read_parquet('{posts}')
-),
-feat AS (
-  SELECT CAST(source_record_id AS VARCHAR) AS source_record_id,
-         political_stance
-  FROM read_parquet('{final}')
-)
-SELECT
-  (SELECT COUNT(*) FROM inp) AS input_rows,
-  (SELECT COUNT(*) FROM feat) AS feature_rows,
-  (SELECT COUNT(DISTINCT source_record_id) FROM feat) AS unique_ids,
-  (SELECT COUNT(*) FROM feat WHERE political_stance IS NULL) AS null_labels,
-  (SELECT COUNT(*) FROM inp i LEFT JOIN feat f USING (source_record_id) WHERE f.source_record_id IS NULL) AS missing_labels,
-  (SELECT COUNT(*) FROM feat f LEFT JOIN inp i USING (source_record_id) WHERE i.source_record_id IS NULL) AS extra_labels
-""").fetchone()
-print(row)
-assert row == (200000, 200000, 200000, 0, 0, 0)
-PY
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/political_stance/ --recursive
 ```
 
-Accepted-value check:
+### Download final parquet for validation
+
+```bash
+aws s3 cp \
+  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/political_stance/final.parquet \
+  /tmp/political_stance_final.parquet
+```
+
+### Validate row count, Q44 schema, and accepted values
 
 ```bash
 PYTHONPATH=. uv run python - <<'PY'
-import duckdb
-path = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/political_stance/final/political_stance.parquet"
-allowed = ("left", "right", "neutral", "unclear")
-bad = duckdb.connect().execute(f"""
-SELECT COUNT(*) FROM read_parquet('{path}')
-WHERE political_stance NOT IN {allowed}
-""").fetchone()[0]
-print("invalid_stance_rows", bad)
-assert bad == 0
-counts = duckdb.connect().execute(f"""
-SELECT political_stance, COUNT(*) AS n
-FROM read_parquet('{path}')
-GROUP BY 1 ORDER BY 1
-""").fetchdf()
-print(counts.to_string(index=False))
+import pandas as pd
+
+Q44_COLS = [
+    "source_record_id", "run_id", "batch_id", "request_id",
+    "attempt_count", "label_timestamp", "political_stance",
+]
+
+df = pd.read_parquet("/tmp/political_stance_final.parquet")
+assert list(df.columns) == Q44_COLS, df.columns.tolist()
+assert len(df) == 200_000, len(df)
+assert df["source_record_id"].is_unique
+assert df["run_id"].nunique() == 1
+assert df["run_id"].iloc[0] == "bluesky_2026_09_03_235130_llm_features_v1:political_stance"
+assert df["political_stance"].notna().all()
+ACCEPTED = {"left", "right", "neutral", "unclear"}
+assert not (set(df["political_stance"].unique()) - ACCEPTED)
+print("ok", df["political_stance"].value_counts().to_dict())
 PY
 ```
 
-Manifest check:
+Expected: `ok` plus value counts and exit code 0.
+
+### Verify manifest SHA-256
 
 ```bash
-aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/political_stance/final/manifest.sha256.json -
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/political_stance/manifest.json -
 ```
 
-Expected: JSON listing SHA-256 for final Parquet and every durable shard, with row counts summing to 200000.
+Expected: JSON with `final_parquet.sha256` matching downloaded bytes (SHA-256 only, not ETag).
 
-## Required outputs
+### Read progress for watcher
 
-### S3 (permanent)
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/political_stance/progress.jsonl /tmp/political_stance_progress.jsonl
+```
 
-| Object | Purpose |
-|--------|---------|
-| `.../political_stance/shards/shard_*.parquet` | Durable 2,000-row intermediate shards |
-| `.../political_stance/final/political_stance.parquet` | Final deduped feature file |
-| `.../political_stance/final/manifest.sha256.json` | SHA-256 manifest |
-| `.../political_stance/progress/` | Structured progress history |
-| `.../political_stance/metadata.json` | Campaign metadata including OpenAI job ID, model ID, prompt hash, labeled count |
+Confirm watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
 
-### Repository
+## Acceptance criteria
 
-| Path | Lifetime |
-|------|----------|
-| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/political_stance_REPORT.md` | Permanent |
-| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/political_stance_cost.json` | Temporary; remove before merge |
-| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/political_stance_resume_evidence.md` | Temporary; remove before merge |
+1. Exactly 200,000 unique `source_record_id` values with zero missing outputs.
+2. Q44 columns present with correct `run_id` and accepted `political_stance` values.
+3. `manifest.json`, `progress.jsonl`, and `final.parquet` present under the feature prefix.
+4. Permanent run report records smoke estimate, actual cost, throughput, retries, error rate, and label counts.
+5. Watcher updated the GitHub comment at every 10,000 durable rows.
+6. Resume reused the same `run_id` with no duplicate OpenAI Batch job.
+7. S3 smoke evidence under `political_stance/smoke/` includes `resume_evidence.json` from the single smoke invocation.
+8. Temporary Git smoke files removed before merge. S3 smoke evidence remains.
+9. Only `reports/political_stance_run_report.md` remains from this step in Git.
 
-Permanent report must record: S3 URIs, input preprocessed hash, manifest digest, model ID, prompt hash, smoke and actual token counts, estimated and actual cost, throughput, retry counts, validation command results, and counts for `left`, `right`, `neutral`, and `unclear`.
+## Failure conditions
 
-## Acceptance and failure
+- Full 200k run starts before parent campaign issue approval.
+- Smoke run twice for the same feature or different ten-post ids than other features.
+- Smoke writes any object under `batches/` (smoke never writes canonical batch objects).
+- `part-00000.parquet` after full run does not contain ten unchanged smoke labels plus 1,990 new labels.
+- Missing Q44 columns or wrong `run_id`.
+- Any `political_stance` value outside `left`, `right`, `neutral`, `unclear`.
+- Using `--checkpoint`, `--resume`, `run_bluesky_llm_campaign.py`, or `APPROVED.txt`.
+- Objects under `campaigns/`, `shards/`, `final/` subdirectory, or per-run timestamp folders.
+- Label files committed to Git.
+- Temporary smoke artifacts left in Git after merge.
+- Any product code change in this PR.
+- Any automated test added or run.
 
-| Check | Pass | Fail |
-|-------|------|------|
-| Dependencies | Steps 3–7 merged | Campaign CLI or S3 backend missing |
-| Single feature command | Every run uses only `--feature political_stance` | Multiple `--feature` values or full registry run |
-| Batch size | `--batch-size 2000` on smoke and full runs | Any other batch size |
-| Parent approval | Full run starts only after parent issue approval | Full run before approval |
-| Smoke artifacts | Temporary smoke files committed for review, then removed before merge | Smoke artifacts left in repo or never committed for review |
-| Completeness | Exactly 200000 unique `source_record_id` values, zero null labels, zero missing/extra IDs | Any other row count or join mismatch |
-| Accepted values | `political_stance` in `{left, right, neutral, unclear}` only | Any other label string |
-| Resume | Failed run continues with `--resume` on same prefix without duplicate OpenAI job | New provider job for already-labeled rows |
-| Progress | Rolling issue comment updates every 10000 durable rows | Missing updates |
-| Tests | Runtime checks only | New or modified automated tests in this PR |
-| Product code | No Python product code edits | Any change under `data_platform/generate_features/**` or related libraries |
-| Perspective toxicity | `is_toxic_tiered` never invoked | Perspective feature run attempted |
+## PR artifact and commit rules
 
-## Done when
+- Phase A: commit temporary smoke artifacts for review.
+- Phase B: commit only permanent run report; delete temporary smoke files before merge.
+- Do not edit `plan.md` or other step specs.
 
-1. Smoke, interrupt/resume proof, and cost estimate are posted and parent campaign approval is recorded.
-2. Final S3 Parquet, manifest, and progress history exist for `political_stance`.
-3. Runtime validation passes with exactly 200000 unique, non-null stance labels in the accepted set.
-4. Permanent run report is committed; temporary smoke artifacts are removed before merge.
-5. Rolling GitHub issue updates cover 10000-row milestones through 200000.
+## Permanent run report contents
+
+`reports/political_stance_run_report.md` must include:
+
+- Pinned identity table (dataset, preprocessed run, campaign id, run id, model, prompt path, prompt hash)
+- S3 URIs for `final.parquet`, `manifest.json`, and `progress.jsonl`
+- Smoke estimated full-run cost and assumptions
+- Actual cost, tokens, throughput, retry count, error rate
+- Label counts for `left`, `right`, `neutral`, and `unclear`
+- Validation command pass/fail summary
+- OpenAI Batch job id(s) from manifest or progress lines

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step14.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step14.md
@@ -1,0 +1,328 @@
+# Step 14: Generate `llm_toxicity_tiered` for 200,000 Bluesky posts
+
+## Goal
+
+Run the approved S3-backed LLM campaign flow for the LLM toxicity feature `llm_toxicity_tiered` on the pinned 200,000-post Bluesky preprocessed dataset. Keep this output distinct from the Perspective API feature `is_toxic_tiered`. Publish the final feature Parquet file, SHA-256 manifest, progress history, runtime validation results, and one permanent run report under campaign prefix `bluesky_2026_09_03_235130_llm_features_v1`.
+
+This step is one future pull request. It is a run-only PR: no product code changes.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/generate_features/run_bluesky_llm_campaign.py` (delivered by Steps 4–7).
+
+**Task:** label every pinned input row once with `toxicity_tier` through the `llm_toxicity_tiered` registry entry, using OpenAI Batch at batch size 2000, then verify completeness and publish audit artifacts.
+
+**Out of scope:** Changing feature prompts, registry entries, OpenAI engine code, S3 storage helpers, consolidation logic, curation, running Perspective `is_toxic_tiered`, automated tests, or any file outside the allowed list below.
+
+## Dependencies
+
+Merge and verify these plan steps before opening this PR:
+
+| Step | Requirement |
+|------|-------------|
+| Step 3 | S3 is the production pipeline backend; pinned preprocessed Parquet is readable from S3 |
+| Step 4 | OpenAI Batch jobs persist provider job IDs and resume without duplicate jobs |
+| Step 5 | Immutable 2,000-row Parquet shards, final feature Parquet, hash manifest, deterministic order |
+| Step 6 | Deterministic ten-post smoke sample, cost estimate artifact, deliberate interrupt/resume check, parent campaign approval gate |
+| Step 7 | Durable progress records and rolling GitHub issue comment updates every 10,000 durable rows |
+
+Steps 8–11 are not blockers for starting this feature, but this step follows the same run contract as those steps.
+
+## Pinned identities
+
+Lock every command and artifact to these values. A different dataset, preprocess run, or campaign ID requires a new campaign.
+
+| Field | Value |
+|-------|-------|
+| Dataset ID | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| Preprocessed run | `2026_09_03-23:51:30` |
+| Preprocessed input object | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet` |
+| Expected input row count | `200000` |
+| Campaign prefix | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Feature name | `llm_toxicity_tiered` (exactly one feature per command) |
+| Batch size | `2000` |
+| Model ID | `gpt-5.4-nano` (`DEFAULT_LLM_MODEL`) |
+| Prompt source | `data_platform/generate_features/llm_toxicity_tiered/generate_feature.py` `SYSTEM_PROMPT` |
+| Join key in feature files | `source_record_id` |
+| Records id column in preprocessed input | `uri` |
+| Forbidden feature | `is_toxic_tiered` must never run in this campaign |
+
+Feature S3 prefix (isolated from other features):
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
+
+There must be no S3 objects under `.../is_toxic_tiered/` for this campaign.
+
+## Feature contract
+
+Read-only reference: `data_platform/generate_features/llm_toxicity_tiered/generate_feature.py` and `FEATURE_REGISTRY["llm_toxicity_tiered"]`.
+
+Output schema per labeled row:
+
+| Column | Type | Accepted values |
+|--------|------|-----------------|
+| `source_record_id` | string | Must match pinned preprocessed `uri` / `source_record_id` |
+| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
+| `toxicity_tier` | string | Exactly one of `low`, `medium`, `high` |
+
+Wide-table rename for Step 15: export column `llm_toxicity_tier` sourced from raw `toxicity_tier`. Do not write `toxicity_prob`. Do not join Perspective columns.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope; LLM toxicity must stay distinct from Perspective |
+| `/workspace/data_platform/generate_features/run_bluesky_llm_campaign.py` | Campaign CLI from Steps 4–7 |
+| `/workspace/data_platform/generate_features/llm_toxicity_tiered/generate_feature.py` | Prompt and output schema |
+| `/workspace/data_platform/generate_features/is_toxic_tiered/generate_feature.py` | Perspective feature to avoid |
+| `/workspace/data_platform/generate_features/registry.py` | `llm_toxicity_tiered` vs `is_toxic_tiered` |
+| `/workspace/data_platform/generate_features/metadata.py` | Pinned model and prompt hash behavior on resume |
+| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch resume semantics |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Expected `row_counts.output == 200000` |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export in Cloud Agent |
+
+## Files allowed to change
+
+Run artifacts only:
+
+- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered_REPORT.md` (permanent; keep after merge)
+- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/llm_toxicity_tiered_*` (temporary smoke and resume evidence; commit for review, delete before merge)
+- S3 objects under the feature prefix above
+
+Do not edit the plan package during implementation.
+
+## Files forbidden to change
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
+- `/workspace/data_platform/generate_features/**` except reading
+- `/workspace/data_platform/utils/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/data_platform/models/**`
+- `/workspace/tests/**`
+- `/workspace/CHANGELOG.md`
+- Any other repository file
+
+Explicit prohibition: never invoke `--feature is_toxic_tiered`, never write Perspective outputs, and never create `.../campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_toxic_tiered/`.
+
+## Workflow
+
+### Phase A — Ten-post smoke, cost estimate, interrupt/resume proof
+
+1. Export AWS credentials per `AGENTS.md`.
+2. Run smoke with exactly one feature flag: `llm_toxicity_tiered`.
+3. Commit temporary smoke artifacts listed below so reviewers can inspect cost and resume evidence.
+4. Post the smoke cost estimate to this feature’s GitHub issue.
+5. Perform the deliberate interruption and resume check required by Step 6 on the same campaign prefix.
+6. Wait for parent campaign approval on the aggregate cost estimate before Phase B.
+
+### Phase B — Full 200,000-row generation
+
+1. Run the same command with full-run flags only after parent approval.
+2. Keep one blocking OpenAI Batch job active for this feature.
+3. After each durable 2,000-row shard lands in S3, ensure Step 7 progress records update.
+4. At every 10,000 durable labeled rows, update the rolling GitHub issue comment via the watcher subagent pattern from Step 7.
+5. On failure, resume the failed run with the same campaign prefix and `--resume`; do not start a parallel provider job.
+
+### Phase C — Validation, permanent report, PR cleanup
+
+1. Run runtime validation commands below.
+2. Confirm no Perspective artifacts exist for this campaign prefix.
+3. Write the permanent run report including label counts for `low`, `medium`, and `high`.
+4. Remove temporary smoke artifacts from the branch before merge.
+5. Leave S3 final Parquet, manifest, progress history, and permanent report in place.
+
+## Exact commands
+
+From the repo root. Export AWS credentials first:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+```
+
+Install deps if needed:
+
+```bash
+uv sync
+```
+
+### Smoke (ten posts, one feature only)
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --feature llm_toxicity_tiered \
+  --batch-size 2000 \
+  --phase smoke
+```
+
+Expected:
+
+- Stdout reports exactly ten labeled rows with `toxicity_tier` values.
+- Smoke cost JSON is written under `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/llm_toxicity_tiered_cost.json`.
+- Smoke outputs land under `.../llm_toxicity_tiered/smoke/` on S3.
+- Deliberate interrupt/resume evidence is captured in `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/llm_toxicity_tiered_resume_evidence.md`.
+
+### Full run (after parent approval)
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --feature llm_toxicity_tiered \
+  --batch-size 2000 \
+  --phase full
+```
+
+Expected:
+
+- One OpenAI Batch job chain completes with 100 durable shards of 2,000 rows each.
+- Progress records advance in steps of 2,000 until `labeled == 200000`.
+- Rolling issue comment updates occur at 10000, 20000, …, 200000 durable rows.
+
+### Failed-run resume
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --feature llm_toxicity_tiered \
+  --batch-size 2000 \
+  --phase full \
+  --resume
+```
+
+Expected:
+
+- The CLI reloads the persisted OpenAI Batch job ID and existing shards.
+- No duplicate provider job is created for rows already durably written.
+- Model ID and prompt hash in campaign metadata remain unchanged.
+
+### Runtime validation (required; not automated tests)
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python - <<'PY'
+import duckdb
+
+final = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/final/llm_toxicity_tiered.parquet"
+posts = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
+
+con = duckdb.connect()
+row = con.execute(f"""
+WITH inp AS (
+  SELECT CAST(source_record_id AS VARCHAR) AS source_record_id
+  FROM read_parquet('{posts}')
+),
+feat AS (
+  SELECT CAST(source_record_id AS VARCHAR) AS source_record_id,
+         toxicity_tier
+  FROM read_parquet('{final}')
+)
+SELECT
+  (SELECT COUNT(*) FROM inp) AS input_rows,
+  (SELECT COUNT(*) FROM feat) AS feature_rows,
+  (SELECT COUNT(DISTINCT source_record_id) FROM feat) AS unique_ids,
+  (SELECT COUNT(*) FROM feat WHERE toxicity_tier IS NULL) AS null_labels,
+  (SELECT COUNT(*) FROM inp i LEFT JOIN feat f USING (source_record_id) WHERE f.source_record_id IS NULL) AS missing_labels,
+  (SELECT COUNT(*) FROM feat f LEFT JOIN inp i USING (source_record_id) WHERE i.source_record_id IS NULL) AS extra_labels
+""").fetchone()
+print(row)
+assert row == (200000, 200000, 200000, 0, 0, 0)
+PY
+```
+
+Accepted-value check:
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import duckdb
+path = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/final/llm_toxicity_tiered.parquet"
+allowed = ("low", "medium", "high")
+con = duckdb.connect()
+bad = con.execute(f"""
+SELECT COUNT(*) FROM read_parquet('{path}')
+WHERE toxicity_tier NOT IN {allowed}
+""").fetchone()[0]
+print("invalid_toxicity_rows", bad)
+assert bad == 0
+cols = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{path}')").fetchall()]
+assert "toxicity_prob" not in cols
+counts = con.execute(f"""
+SELECT toxicity_tier, COUNT(*) AS n
+FROM read_parquet('{path}')
+GROUP BY 1 ORDER BY 1
+""").fetchdf()
+print(counts.to_string(index=False))
+PY
+```
+
+Perspective absence check:
+
+```bash
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_toxic_tiered/ 2>&1 || true
+```
+
+Expected: `An error occurred (NoSuchKey)` or empty listing. Any objects under that prefix fail this step.
+
+Manifest check:
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/final/manifest.sha256.json -
+```
+
+Expected: JSON listing SHA-256 for final Parquet and every durable shard, with row counts summing to 200000.
+
+## Required outputs
+
+### S3 (permanent)
+
+| Object | Purpose |
+|--------|---------|
+| `.../llm_toxicity_tiered/shards/shard_*.parquet` | Durable 2,000-row intermediate shards |
+| `.../llm_toxicity_tiered/final/llm_toxicity_tiered.parquet` | Final deduped feature file with raw column `toxicity_tier` |
+| `.../llm_toxicity_tiered/final/manifest.sha256.json` | SHA-256 manifest |
+| `.../llm_toxicity_tiered/progress/` | Structured progress history |
+| `.../llm_toxicity_tiered/metadata.json` | Campaign metadata including OpenAI job ID, model ID, prompt hash, labeled count |
+
+### Repository
+
+| Path | Lifetime |
+|------|----------|
+| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered_REPORT.md` | Permanent |
+| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/llm_toxicity_tiered_cost.json` | Temporary; remove before merge |
+| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/llm_toxicity_tiered_resume_evidence.md` | Temporary; remove before merge |
+
+Permanent report must record: S3 URIs, input preprocessed hash, manifest digest, model ID, prompt hash, smoke and actual token counts, estimated and actual cost, throughput, retry counts, validation command results, counts for `low`, `medium`, and `high`, and an explicit statement that `is_toxic_tiered` was not run.
+
+## Acceptance and failure
+
+| Check | Pass | Fail |
+|-------|------|------|
+| Dependencies | Steps 3–7 merged | Campaign CLI or S3 backend missing |
+| Single feature command | Every run uses only `--feature llm_toxicity_tiered` | Multiple `--feature` values, full registry run, or `--feature is_toxic_tiered` |
+| Batch size | `--batch-size 2000` on smoke and full runs | Any other batch size |
+| Parent approval | Full run starts only after parent issue approval | Full run before approval |
+| Smoke artifacts | Temporary smoke files committed for review, then removed before merge | Smoke artifacts left in repo or never committed for review |
+| Completeness | Exactly 200000 unique `source_record_id` values, zero null labels, zero missing/extra IDs | Any other row count or join mismatch |
+| Accepted values | `toxicity_tier` in `{low, medium, high}` only | Any other label string or `toxicity_prob` column |
+| Perspective isolation | No `is_toxic_tiered` run and no campaign-prefix objects under `is_toxic_tiered/` | Perspective outputs present |
+| Resume | Failed run continues with `--resume` on same prefix without duplicate OpenAI job | New provider job for already-labeled rows |
+| Progress | Rolling issue comment updates every 10000 durable rows | Missing updates |
+| Tests | Runtime checks only | New or modified automated tests in this PR |
+| Product code | No Python product code edits | Any change under `data_platform/generate_features/**` or related libraries |
+
+## Done when
+
+1. Smoke, interrupt/resume proof, and cost estimate are posted and parent campaign approval is recorded.
+2. Final S3 Parquet, manifest, and progress history exist for `llm_toxicity_tiered` with raw column `toxicity_tier`.
+3. Runtime validation passes with exactly 200000 unique, non-null toxicity tiers in `{low, medium, high}`.
+4. No Perspective campaign artifacts exist.
+5. Permanent run report is committed; temporary smoke artifacts are removed before merge.
+6. Rolling GitHub issue updates cover 10000-row milestones through 200000.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step14.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step14.md
@@ -1,328 +1,270 @@
-# Step 14: Generate `llm_toxicity_tiered` for 200,000 Bluesky posts
+# Step 14: Generate llm_toxicity_tiered for 200,000 Bluesky posts
 
 ## Goal
 
-Run the approved S3-backed LLM campaign flow for the LLM toxicity feature `llm_toxicity_tiered` on the pinned 200,000-post Bluesky preprocessed dataset. Keep this output distinct from the Perspective API feature `is_toxic_tiered`. Publish the final feature Parquet file, SHA-256 manifest, progress history, runtime validation results, and one permanent run report under campaign prefix `bluesky_2026_09_03_235130_llm_features_v1`.
+Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `llm_toxicity_tiered` feature only. Publish immutable S3 batches, `final.parquet`, `manifest.json`, `progress.jsonl`, validation results, and one permanent run report. Keep this output distinct from Perspective API feature `is_toxic_tiered`. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
 
-This step is one future pull request. It is a run-only PR: no product code changes.
-
-## Caller / unit of work
-
-**Main caller:** `data_platform/generate_features/run_bluesky_llm_campaign.py` (delivered by Steps 4–7).
-
-**Task:** label every pinned input row once with `toxicity_tier` through the `llm_toxicity_tiered` registry entry, using OpenAI Batch at batch size 2000, then verify completeness and publish audit artifacts.
-
-**Out of scope:** Changing feature prompts, registry entries, OpenAI engine code, S3 storage helpers, consolidation logic, curation, running Perspective `is_toxic_tiered`, automated tests, or any file outside the allowed list below.
+This step is one future pull request and one GitHub feature issue. The issue stays open until the feature run is complete and validated.
 
 ## Dependencies
 
-Merge and verify these plan steps before opening this PR:
+Do not start until Steps 3, 6, and 7 have merged to `main`. Steps 2, 4, and 5 are required transitively through Step 6 and Step 7. See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md`.
 
 | Step | Requirement |
 |------|-------------|
-| Step 3 | S3 is the production pipeline backend; pinned preprocessed Parquet is readable from S3 |
-| Step 4 | OpenAI Batch jobs persist provider job IDs and resume without duplicate jobs |
-| Step 5 | Immutable 2,000-row Parquet shards, final feature Parquet, hash manifest, deterministic order |
-| Step 6 | Deterministic ten-post smoke sample, cost estimate artifact, deliberate interrupt/resume check, parent campaign approval gate |
-| Step 7 | Durable progress records and rolling GitHub issue comment updates every 10,000 durable rows |
+| Step 3 | S3 is the production backend |
+| Step 6 | `smoke_bluesky_campaign.py` and cost aggregation command (single invocation includes deliberate interruption and resume) |
+| Step 7 | `progress.jsonl`, `watcher.json`, and watcher CLI |
 
-Steps 8–11 are not blockers for starting this feature, but this step follows the same run contract as those steps.
+## Main caller and implementation slice
 
-## Pinned identities
+**Main caller (campaign mode; same command resumes automatically):**
 
-Lock every command and artifact to these values. A different dataset, preprocess run, or campaign ID requires a new campaign.
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
-| Field | Value |
-|-------|-------|
-| Dataset ID | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --features llm_toxicity_tiered \
+  --batch-size 2000
+```
+
+**Smoke caller (Phase A only; available after Step 6):**
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_bluesky_campaign.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --feature llm_toxicity_tiered \
+  --output-dir docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/llm_toxicity_tiered
+```
+
+**Implementation slice for this PR:** documentation and run artifacts only. No product code changes.
+
+## Pinned identity contract
+
+| Field | Pinned value |
+|-------|----------------|
+| Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
 | Preprocessed run | `2026_09_03-23:51:30` |
-| Preprocessed input object | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet` |
-| Expected input row count | `200000` |
-| Campaign prefix | `bluesky_2026_09_03_235130_llm_features_v1` |
-| Feature name | `llm_toxicity_tiered` (exactly one feature per command) |
+| Preprocessed row count | `200000` |
+| Campaign id | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Feature name | `llm_toxicity_tiered` |
+| Run id | `bluesky_2026_09_03_235130_llm_features_v1:llm_toxicity_tiered` |
+| Feature S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/` |
+| Model id | `gpt-5.4-nano` |
 | Batch size | `2000` |
-| Model ID | `gpt-5.4-nano` (`DEFAULT_LLM_MODEL`) |
-| Prompt source | `data_platform/generate_features/llm_toxicity_tiered/generate_feature.py` `SYSTEM_PROMPT` |
-| Join key in feature files | `source_record_id` |
-| Records id column in preprocessed input | `uri` |
-| Forbidden feature | `is_toxic_tiered` must never run in this campaign |
-
-Feature S3 prefix (isolated from other features):
-
-`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
-
-There must be no S3 objects under `.../is_toxic_tiered/` for this campaign.
-
-## Feature contract
-
-Read-only reference: `data_platform/generate_features/llm_toxicity_tiered/generate_feature.py` and `FEATURE_REGISTRY["llm_toxicity_tiered"]`.
-
-Output schema per labeled row:
-
-| Column | Type | Accepted values |
-|--------|------|-----------------|
-| `source_record_id` | string | Must match pinned preprocessed `uri` / `source_record_id` |
-| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
-| `toxicity_tier` | string | Exactly one of `low`, `medium`, `high` |
-
-Wide-table rename for Step 15: export column `llm_toxicity_tier` sourced from raw `toxicity_tier`. Do not write `toxicity_prob`. Do not join Perspective columns.
+| Label field | `toxicity_tier` |
+| Pydantic model | `LlmToxicityTieredModel` |
+| Accepted label values | `low`, `medium`, `high` |
+| Prompt source | `data_platform/generate_features/llm_toxicity_tiered/generate_feature.py` → `SYSTEM_PROMPT` |
 
 ## Files to inspect (read-only)
 
 | Path | Why |
 |------|-----|
-| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope; LLM toxicity must stay distinct from Perspective |
-| `/workspace/data_platform/generate_features/run_bluesky_llm_campaign.py` | Campaign CLI from Steps 4–7 |
-| `/workspace/data_platform/generate_features/llm_toxicity_tiered/generate_feature.py` | Prompt and output schema |
-| `/workspace/data_platform/generate_features/is_toxic_tiered/generate_feature.py` | Perspective feature to avoid |
-| `/workspace/data_platform/generate_features/registry.py` | `llm_toxicity_tiered` vs `is_toxic_tiered` |
-| `/workspace/data_platform/generate_features/metadata.py` | Pinned model and prompt hash behavior on resume |
-| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch resume semantics |
-| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Expected `row_counts.output == 200000` |
-| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export in Cloud Agent |
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | Canonical layout and smoke flow |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Campaign CLI |
+| `/workspace/data_platform/generate_features/smoke_bluesky_campaign.py` | Ten-post smoke (Step 6) |
+| `/workspace/data_platform/generate_features/feature_progress_watcher.py` | Progress watcher (Step 7) |
+| `/workspace/data_platform/generate_features/llm_toxicity_tiered/generate_feature.py` | Prompt and schema |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credentials, no automated tests |
 
 ## Files allowed to change
 
-Run artifacts only:
+Documentation artifacts only.
 
-- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered_REPORT.md` (permanent; keep after merge)
-- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/llm_toxicity_tiered_*` (temporary smoke and resume evidence; commit for review, delete before merge)
-- S3 objects under the feature prefix above
+**Temporary smoke artifacts (Phase A; deleted before merge):**
 
-Do not edit the plan package during implementation.
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/llm_toxicity_tiered/llm_toxicity_tiered_cost_report.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/llm_toxicity_tiered/llm_toxicity_tiered_resume_evidence.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/llm_toxicity_tiered/llm_toxicity_tiered_s3_checks.txt`
+
+**Permanent run report (Phase B; kept after merge):**
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/llm_toxicity_tiered_run_report.md`
 
 ## Files forbidden to change
 
+- Any file under `/workspace/data_platform/`, `/workspace/lib/`, `/workspace/ml_tooling/`, `/workspace/tests/`, `/workspace/pyproject.toml`, `/workspace/CHANGELOG.md`
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
-- `/workspace/data_platform/generate_features/**` except reading
-- `/workspace/data_platform/utils/**`
-- `/workspace/data_platform/curate/**`
-- `/workspace/data_platform/models/**`
-- `/workspace/tests/**`
-- `/workspace/CHANGELOG.md`
-- Any other repository file
+- Any other step file under `steps/`
+- Any path under the S3 prefixes for the other six features:
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_political/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
+- Any committed Parquet, CSV, or JSON label files anywhere in the repository
+- Running `is_toxic_tiered` or creating objects under `.../is_toxic_tiered/`
 
-Explicit prohibition: never invoke `--feature is_toxic_tiered`, never write Perspective outputs, and never create `.../campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_toxic_tiered/`.
+Do not add or run automated tests.
 
-## Workflow
+## Locked contracts
 
-### Phase A — Ten-post smoke, cost estimate, interrupt/resume proof
+See `campaign_contract.md`. S3 objects for this feature:
 
-1. Export AWS credentials per `AGENTS.md`.
-2. Run smoke with exactly one feature flag: `llm_toxicity_tiered`.
-3. Commit temporary smoke artifacts listed below so reviewers can inspect cost and resume evidence.
-4. Post the smoke cost estimate to this feature’s GitHub issue.
-5. Perform the deliberate interruption and resume check required by Step 6 on the same campaign prefix.
-6. Wait for parent campaign approval on the aggregate cost estimate before Phase B.
+| Object | Path |
+|--------|------|
+| Smoke input | `.../llm_toxicity_tiered/smoke/input.parquet` |
+| Smoke output | `.../llm_toxicity_tiered/smoke/output.parquet` |
+| Smoke cost report | `.../llm_toxicity_tiered/smoke/cost_report.json` |
+| Smoke resume evidence | `.../llm_toxicity_tiered/smoke/resume_evidence.json` |
+| Batches | `.../llm_toxicity_tiered/batches/part-NNNNN.parquet` |
+| Final | `.../llm_toxicity_tiered/final.parquet` |
+| Manifest | `.../llm_toxicity_tiered/manifest.json` |
+| Progress | `.../llm_toxicity_tiered/progress.jsonl` |
+| Errors | `.../llm_toxicity_tiered/errors.jsonl` (when needed) |
+| Watcher | `.../llm_toxicity_tiered/watcher.json` |
 
-### Phase B — Full 200,000-row generation
+Q44 columns in `final.parquet`: `source_record_id`, `run_id`, `batch_id`, `request_id`, `attempt_count`, `label_timestamp`, `toxicity_tier`.
 
-1. Run the same command with full-run flags only after parent approval.
-2. Keep one blocking OpenAI Batch job active for this feature.
-3. After each durable 2,000-row shard lands in S3, ensure Step 7 progress records update.
-4. At every 10,000 durable labeled rows, update the rolling GitHub issue comment via the watcher subagent pattern from Step 7.
-5. On failure, resume the failed run with the same campaign prefix and `--resume`; do not start a parallel provider job.
+After parent approval, `part-00000.parquet` must contain ten unchanged smoke labels plus 1,990 new labels (2,000 rows total). The next 99 provider jobs each write `part-00001` through `part-00099` with 2,000 rows each. Total: exactly 100 canonical batch objects and 200,000 rows. Preserve original smoke `batch_id` and `request_id` in the ten rows in `part-00000`. `manifest.json` batch entry for `part_index=0` may list both the smoke provider `batch_id` and the first production provider `batch_id`.
 
-### Phase C — Validation, permanent report, PR cleanup
+## Two-phase pull request flow
 
-1. Run runtime validation commands below.
-2. Confirm no Perspective artifacts exist for this campaign prefix.
-3. Write the permanent run report including label counts for `low`, `medium`, and `high`.
-4. Remove temporary smoke artifacts from the branch before merge.
-5. Leave S3 final Parquet, manifest, progress history, and permanent report in place.
+### Phase A: smoke, estimate, and review artifacts
 
-## Exact commands
+1. Confirm Steps 3, 6, and 7 are on `main`.
+2. Run `smoke_bluesky_campaign.py` once for `llm_toxicity_tiered` only. The smoke caller performs one deliberate interruption and resume and writes untagged S3 evidence under `llm_toxicity_tiered/smoke/` including `resume_evidence.json`. Do not repeat the interruption procedure in this step.
+3. Commit temporary Git smoke artifacts under `reports/smoke/llm_toxicity_tiered/` (include a local copy of `resume_evidence.json`).
+4. Post estimated full-run cost to this feature's GitHub issue through authenticated GitHub integration.
+5. Stop. Do not start the 200,000-post run until the parent campaign issue has one aggregate estimate and explicit human approval.
 
-From the repo root. Export AWS credentials first:
+### Phase B: full run after parent approval
 
-```bash
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-```
+1. Confirm parent campaign issue has explicit approval.
+2. Run the campaign CLI command above (same command resumes automatically).
+3. Run the Step 7 watcher at every 10,000 durable rows; post rolling comment through authenticated GitHub integration.
+4. Validate S3 artifacts and row counts.
+5. Write `reports/llm_toxicity_tiered_run_report.md`.
+6. Delete temporary smoke artifacts from Git. S3 smoke evidence remains.
+7. Commit and push only the permanent run report.
 
-Install deps if needed:
+## Ordered work
 
-```bash
-uv sync
-```
+1. Phase A smoke and cost estimate.
+2. Pause for parent aggregate and human approval.
+3. Phase B full run with watcher.
+4. Runtime validation.
+5. Permanent report and Git cleanup.
 
-### Smoke (ten posts, one feature only)
+## Exact commands and expected output
 
-```bash
-PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --preprocessed-run 2026_09_03-23:51:30 \
-  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
-  --feature llm_toxicity_tiered \
-  --batch-size 2000 \
-  --phase smoke
-```
-
-Expected:
-
-- Stdout reports exactly ten labeled rows with `toxicity_tier` values.
-- Smoke cost JSON is written under `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/llm_toxicity_tiered_cost.json`.
-- Smoke outputs land under `.../llm_toxicity_tiered/smoke/` on S3.
-- Deliberate interrupt/resume evidence is captured in `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/llm_toxicity_tiered_resume_evidence.md`.
-
-### Full run (after parent approval)
-
-```bash
-PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --preprocessed-run 2026_09_03-23:51:30 \
-  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
-  --feature llm_toxicity_tiered \
-  --batch-size 2000 \
-  --phase full
-```
-
-Expected:
-
-- One OpenAI Batch job chain completes with 100 durable shards of 2,000 rows each.
-- Progress records advance in steps of 2,000 until `labeled == 200000`.
-- Rolling issue comment updates occur at 10000, 20000, …, 200000 durable rows.
-
-### Failed-run resume
-
-```bash
-PYTHONPATH=. uv run python data_platform/generate_features/run_bluesky_llm_campaign.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --preprocessed-run 2026_09_03-23:51:30 \
-  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
-  --feature llm_toxicity_tiered \
-  --batch-size 2000 \
-  --phase full \
-  --resume
-```
-
-Expected:
-
-- The CLI reloads the persisted OpenAI Batch job ID and existing shards.
-- No duplicate provider job is created for rows already durably written.
-- Model ID and prompt hash in campaign metadata remain unchanged.
-
-### Runtime validation (required; not automated tests)
+### List feature prefix
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
-PYTHONPATH=. uv run python - <<'PY'
-import duckdb
-
-final = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/final/llm_toxicity_tiered.parquet"
-posts = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
-
-con = duckdb.connect()
-row = con.execute(f"""
-WITH inp AS (
-  SELECT CAST(source_record_id AS VARCHAR) AS source_record_id
-  FROM read_parquet('{posts}')
-),
-feat AS (
-  SELECT CAST(source_record_id AS VARCHAR) AS source_record_id,
-         toxicity_tier
-  FROM read_parquet('{final}')
-)
-SELECT
-  (SELECT COUNT(*) FROM inp) AS input_rows,
-  (SELECT COUNT(*) FROM feat) AS feature_rows,
-  (SELECT COUNT(DISTINCT source_record_id) FROM feat) AS unique_ids,
-  (SELECT COUNT(*) FROM feat WHERE toxicity_tier IS NULL) AS null_labels,
-  (SELECT COUNT(*) FROM inp i LEFT JOIN feat f USING (source_record_id) WHERE f.source_record_id IS NULL) AS missing_labels,
-  (SELECT COUNT(*) FROM feat f LEFT JOIN inp i USING (source_record_id) WHERE i.source_record_id IS NULL) AS extra_labels
-""").fetchone()
-print(row)
-assert row == (200000, 200000, 200000, 0, 0, 0)
-PY
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/ --recursive
 ```
 
-Accepted-value check:
+### Download final parquet for validation
+
+```bash
+aws s3 cp \
+  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/final.parquet \
+  /tmp/llm_toxicity_tiered_final.parquet
+```
+
+### Validate row count, Q44 schema, and accepted values
 
 ```bash
 PYTHONPATH=. uv run python - <<'PY'
-import duckdb
-path = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/final/llm_toxicity_tiered.parquet"
-allowed = ("low", "medium", "high")
-con = duckdb.connect()
-bad = con.execute(f"""
-SELECT COUNT(*) FROM read_parquet('{path}')
-WHERE toxicity_tier NOT IN {allowed}
-""").fetchone()[0]
-print("invalid_toxicity_rows", bad)
-assert bad == 0
-cols = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{path}')").fetchall()]
-assert "toxicity_prob" not in cols
-counts = con.execute(f"""
-SELECT toxicity_tier, COUNT(*) AS n
-FROM read_parquet('{path}')
-GROUP BY 1 ORDER BY 1
-""").fetchdf()
-print(counts.to_string(index=False))
+import pandas as pd
+
+Q44_COLS = [
+    "source_record_id", "run_id", "batch_id", "request_id",
+    "attempt_count", "label_timestamp", "toxicity_tier",
+]
+
+df = pd.read_parquet("/tmp/llm_toxicity_tiered_final.parquet")
+assert list(df.columns) == Q44_COLS, df.columns.tolist()
+assert len(df) == 200_000, len(df)
+assert df["source_record_id"].is_unique
+assert df["run_id"].nunique() == 1
+assert df["run_id"].iloc[0] == "bluesky_2026_09_03_235130_llm_features_v1:llm_toxicity_tiered"
+assert df["toxicity_tier"].notna().all()
+ACCEPTED = {"low", "medium", "high"}
+assert not (set(df["toxicity_tier"].unique()) - ACCEPTED)
+assert "toxicity_prob" not in df.columns
+print("ok", df["toxicity_tier"].value_counts().to_dict())
 PY
 ```
 
-Perspective absence check:
+Expected: `ok` plus value counts and exit code 0.
+
+### Verify manifest SHA-256
 
 ```bash
-aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_toxic_tiered/ 2>&1 || true
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/manifest.json -
 ```
 
-Expected: `An error occurred (NoSuchKey)` or empty listing. Any objects under that prefix fail this step.
+Expected: JSON with `final_parquet.sha256` matching downloaded bytes (SHA-256 only, not ETag).
 
-Manifest check:
+### Perspective absence check
 
 ```bash
-aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/final/manifest.sha256.json -
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_toxic_tiered/ 2>&1 || true
 ```
 
-Expected: JSON listing SHA-256 for final Parquet and every durable shard, with row counts summing to 200000.
+Expected: no objects under that prefix.
 
-## Required outputs
+### Read progress for watcher
 
-### S3 (permanent)
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/progress.jsonl /tmp/llm_toxicity_tiered_progress.jsonl
+```
 
-| Object | Purpose |
-|--------|---------|
-| `.../llm_toxicity_tiered/shards/shard_*.parquet` | Durable 2,000-row intermediate shards |
-| `.../llm_toxicity_tiered/final/llm_toxicity_tiered.parquet` | Final deduped feature file with raw column `toxicity_tier` |
-| `.../llm_toxicity_tiered/final/manifest.sha256.json` | SHA-256 manifest |
-| `.../llm_toxicity_tiered/progress/` | Structured progress history |
-| `.../llm_toxicity_tiered/metadata.json` | Campaign metadata including OpenAI job ID, model ID, prompt hash, labeled count |
+Confirm watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
 
-### Repository
+## Acceptance criteria
 
-| Path | Lifetime |
-|------|----------|
-| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered_REPORT.md` | Permanent |
-| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/llm_toxicity_tiered_cost.json` | Temporary; remove before merge |
-| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/smoke/llm_toxicity_tiered_resume_evidence.md` | Temporary; remove before merge |
+1. Exactly 200,000 unique `source_record_id` values with zero missing outputs.
+2. Q44 columns present with correct `run_id` and accepted `toxicity_tier` values.
+3. `manifest.json`, `progress.jsonl`, and `final.parquet` present under the feature prefix.
+4. Permanent run report records smoke estimate, actual cost, throughput, retries, error rate, and label counts.
+5. Watcher updated the GitHub comment at every 10,000 durable rows.
+6. Resume reused the same `run_id` with no duplicate OpenAI Batch job.
+7. S3 smoke evidence under `llm_toxicity_tiered/smoke/` includes `resume_evidence.json` from the single smoke invocation.
+8. Temporary Git smoke files removed before merge. S3 smoke evidence remains.
+9. Only `reports/llm_toxicity_tiered_run_report.md` remains from this step in Git.
 
-Permanent report must record: S3 URIs, input preprocessed hash, manifest digest, model ID, prompt hash, smoke and actual token counts, estimated and actual cost, throughput, retry counts, validation command results, counts for `low`, `medium`, and `high`, and an explicit statement that `is_toxic_tiered` was not run.
+## Failure conditions
 
-## Acceptance and failure
+- Full 200k run starts before parent campaign issue approval.
+- Smoke run twice for the same feature or different ten-post ids than other features.
+- Smoke writes any object under `batches/` (smoke never writes canonical batch objects).
+- `part-00000.parquet` after full run does not contain ten unchanged smoke labels plus 1,990 new labels.
+- Missing Q44 columns or wrong `run_id`.
+- Any `toxicity_tier` value outside `low`, `medium`, `high`, or any Perspective run.
+- Using `--checkpoint`, `--resume`, `run_bluesky_llm_campaign.py`, or `APPROVED.txt`.
+- Objects under `campaigns/`, `shards/`, `final/` subdirectory, or per-run timestamp folders.
+- Label files committed to Git.
+- Temporary smoke artifacts left in Git after merge.
+- Any product code change in this PR.
+- Any automated test added or run.
 
-| Check | Pass | Fail |
-|-------|------|------|
-| Dependencies | Steps 3–7 merged | Campaign CLI or S3 backend missing |
-| Single feature command | Every run uses only `--feature llm_toxicity_tiered` | Multiple `--feature` values, full registry run, or `--feature is_toxic_tiered` |
-| Batch size | `--batch-size 2000` on smoke and full runs | Any other batch size |
-| Parent approval | Full run starts only after parent issue approval | Full run before approval |
-| Smoke artifacts | Temporary smoke files committed for review, then removed before merge | Smoke artifacts left in repo or never committed for review |
-| Completeness | Exactly 200000 unique `source_record_id` values, zero null labels, zero missing/extra IDs | Any other row count or join mismatch |
-| Accepted values | `toxicity_tier` in `{low, medium, high}` only | Any other label string or `toxicity_prob` column |
-| Perspective isolation | No `is_toxic_tiered` run and no campaign-prefix objects under `is_toxic_tiered/` | Perspective outputs present |
-| Resume | Failed run continues with `--resume` on same prefix without duplicate OpenAI job | New provider job for already-labeled rows |
-| Progress | Rolling issue comment updates every 10000 durable rows | Missing updates |
-| Tests | Runtime checks only | New or modified automated tests in this PR |
-| Product code | No Python product code edits | Any change under `data_platform/generate_features/**` or related libraries |
+## PR artifact and commit rules
 
-## Done when
+- Phase A: commit temporary smoke artifacts for review.
+- Phase B: commit only permanent run report; delete temporary smoke files before merge.
+- Do not edit `plan.md` or other step specs.
 
-1. Smoke, interrupt/resume proof, and cost estimate are posted and parent campaign approval is recorded.
-2. Final S3 Parquet, manifest, and progress history exist for `llm_toxicity_tiered` with raw column `toxicity_tier`.
-3. Runtime validation passes with exactly 200000 unique, non-null toxicity tiers in `{low, medium, high}`.
-4. No Perspective campaign artifacts exist.
-5. Permanent run report is committed; temporary smoke artifacts are removed before merge.
-6. Rolling GitHub issue updates cover 10000-row milestones through 200000.
+## Permanent run report contents
+
+`reports/llm_toxicity_tiered_run_report.md` must include:
+
+- Pinned identity table (dataset, preprocessed run, campaign id, run id, model, prompt path, prompt hash)
+- S3 URIs for `final.parquet`, `manifest.json`, and `progress.jsonl`
+- Smoke estimated full-run cost and assumptions
+- Actual cost, tokens, throughput, retry count, error rate
+- Label counts for `low`, `medium`, and `high`, plus explicit statement that `is_toxic_tiered` was not run
+- Validation command pass/fail summary
+- OpenAI Batch job id(s) from manifest or progress lines

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step15.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step15.md
@@ -4,100 +4,86 @@
 
 Join the seven verified S3-backed LLM feature outputs to all twelve pinned preprocessed post columns by `source_record_id`. Write one deterministic wide Parquet file with exactly 200,000 unique rows and no missing feature values, plus a SHA-256 manifest and one permanent consolidation report. Exclude all Perspective API columns.
 
-This step is one future pull request. Unlike Steps 8–14, this PR may change consolidation code. It does not run LLM labeling and does not add temporary smoke artifacts.
-
-## Caller / unit of work
-
-**Main caller:** `data_platform/curate/consolidate_bluesky_llm_campaign.py` (new CLI introduced in this step).
-
-**Task:** read pinned preprocessed Parquet and seven final campaign feature Parquet files from S3, build the wide table, validate row completeness, upload the wide artifact and manifest, and commit the permanent report.
-
-**Out of scope:** Re-running any feature campaign, changing feature prompts or engines, curation rule application, automated tests, temporary smoke artifacts, or edits to completed feature run reports.
+This step is one future pull request. Unlike Steps 8 through 14, this PR may change consolidation code. It does not run LLM labeling and does not add temporary smoke artifacts.
 
 ## Dependencies
 
-Do not start this PR until all of the following are merged:
+Do not start until all of the following are merged. See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md`.
 
 | Dependency | Requirement |
 |------------|-------------|
-| Steps 3–7 | S3 backend, campaign layout, manifests, and progress conventions |
-| Step 8 PR + merged `is_news_or_opinion_REPORT.md` | Final feature Parquet verified at 200000 rows |
-| Step 9 PR + merged `is_political_REPORT.md` | Final feature Parquet verified at 200000 rows |
-| Step 10 PR + merged `is_likely_spam_REPORT.md` | Final feature Parquet verified at 200000 rows |
-| Step 11 PR + merged `is_self_contained_REPORT.md` | Final feature Parquet verified at 200000 rows |
-| Step 12 PR + merged `is_structurally_complete_REPORT.md` | Final feature Parquet verified at 200000 rows |
-| Step 13 PR + merged `political_stance_REPORT.md` | Final feature Parquet verified at 200000 rows |
-| Step 14 PR + merged `llm_toxicity_tiered_REPORT.md` | Final feature Parquet verified at 200000 rows; no Perspective run |
+| Step 8 + `reports/is_news_or_opinion_run_report.md` | Final `is_news_or_opinion/final.parquet` verified at 200000 rows |
+| Step 9 + `reports/is_political_run_report.md` | Final `is_political/final.parquet` verified at 200000 rows |
+| Step 10 + `reports/is_likely_spam_run_report.md` | Final `is_likely_spam/final.parquet` verified at 200000 rows |
+| Step 11 + `reports/is_self_contained_run_report.md` | Final `is_self_contained/final.parquet` verified at 200000 rows |
+| Step 12 + `reports/is_structurally_complete_run_report.md` | Final `is_structurally_complete/final.parquet` verified at 200000 rows |
+| Step 13 + `reports/political_stance_run_report.md` | Final `political_stance/final.parquet` verified at 200000 rows |
+| Step 14 + `reports/llm_toxicity_tiered_run_report.md` | Final `llm_toxicity_tiered/final.parquet` verified; no Perspective run |
 
 Each merged feature report must list the final S3 URI and manifest digest used as inputs here.
+
+## Main caller and implementation slice
+
+**Main caller:** `data_platform/curate/consolidate_bluesky_llm_campaign.py` (new CLI introduced in this step).
+
+**Task:** read pinned preprocessed Parquet and seven `final.parquet` files from S3, build the wide table, validate row completeness, upload `wide/features.parquet` and `wide/manifest.json`, and commit `reports/wide_run_report.md`.
+
+**Out of scope:** Re-running any feature campaign, changing feature prompts or engines, curation rule application, automated tests, temporary smoke artifacts, or edits to completed feature run reports.
 
 ## Pinned identities
 
 | Field | Value |
 |-------|-------|
-| Dataset ID | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
 | Preprocessed run | `2026_09_03-23:51:30` |
-| Campaign prefix | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Campaign id | `bluesky_2026_09_03_235130_llm_features_v1` |
 | Join key | `source_record_id` |
 | Expected row count | `200000` |
 | Deterministic sort | `ORDER BY source_record_id ASC` |
 
-Campaign root:
+Feature root:
 
-`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/`
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/`
 
 Preprocessed input:
 
 `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet`
 
-Feature inputs (final Parquet only):
+Feature inputs (`final.parquet` only):
 
-| Feature | S3 final object |
-|---------|-----------------|
-| `is_news_or_opinion` | `.../is_news_or_opinion/final/is_news_or_opinion.parquet` |
-| `is_political` | `.../is_political/final/is_political.parquet` |
-| `is_likely_spam` | `.../is_likely_spam/final/is_likely_spam.parquet` |
-| `is_self_contained` | `.../is_self_contained/final/is_self_contained.parquet` |
-| `is_structurally_complete` | `.../is_structurally_complete/final/is_structurally_complete.parquet` |
-| `political_stance` | `.../political_stance/final/political_stance.parquet` |
-| `llm_toxicity_tiered` | `.../llm_toxicity_tiered/final/llm_toxicity_tiered.parquet` |
+| Feature | S3 object |
+|---------|-----------|
+| `is_news_or_opinion` | `.../is_news_or_opinion/final.parquet` |
+| `is_political` | `.../is_political/final.parquet` |
+| `is_likely_spam` | `.../is_likely_spam/final.parquet` |
+| `is_self_contained` | `.../is_self_contained/final.parquet` |
+| `is_structurally_complete` | `.../is_structurally_complete/final.parquet` |
+| `political_stance` | `.../political_stance/final.parquet` |
+| `llm_toxicity_tiered` | `.../llm_toxicity_tiered/final.parquet` |
 
 Wide outputs:
 
 | Object | Path |
 |--------|------|
-| Wide Parquet | `.../wide/bluesky_llm_features_wide.parquet` |
-| SHA-256 manifest | `.../wide/manifest.sha256.json` |
+| Wide parquet | `.../wide/features.parquet` |
+| Wide manifest | `.../wide/manifest.json` |
 
 Repository permanent report:
 
-`/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/WIDE_CONSOLIDATION_REPORT.md`
+`/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/wide_run_report.md`
 
 ## Wide-table schema
 
-The wide file must contain exactly these nineteen columns in this order:
+The wide file must contain exactly nineteen columns in this order.
 
-### Twelve preprocessed columns (exact names, no extras)
+### Twelve preprocessed columns
 
-From `PreprocessedBlueskyPostModel` / pinned preprocessed Parquet:
+`uri`, `record_id`, `url`, `author_handle`, `text`, `created_at`, `like_count`, `repost_count`, `reply_count`, `quote_count`, `sync_timestamp`, `source_record_id`
 
-1. `uri`
-2. `record_id`
-3. `url`
-4. `author_handle`
-5. `text`
-6. `created_at`
-7. `like_count`
-8. `repost_count`
-9. `reply_count`
-10. `quote_count`
-11. `sync_timestamp`
-12. `source_record_id`
+### Seven aliased label columns
 
-### Seven LLM feature columns
-
-| Wide column | Source feature file | Source column | Accepted values |
-|-------------|--------------------|--------------|-----------------|
+| Wide column | Source feature | Source column | Accepted values |
+|-------------|----------------|---------------|-----------------|
 | `news_or_opinion_category` | `is_news_or_opinion` | `category` | `news`, `opinion`, `neither` |
 | `is_political` | `is_political` | `is_political` | boolean |
 | `is_likely_spam` | `is_likely_spam` | `is_likely_spam` | boolean |
@@ -106,58 +92,54 @@ From `PreprocessedBlueskyPostModel` / pinned preprocessed Parquet:
 | `political_stance` | `political_stance` | `political_stance` | `left`, `right`, `neutral`, `unclear` |
 | `llm_toxicity_tier` | `llm_toxicity_tiered` | `toxicity_tier` | `low`, `medium`, `high` |
 
-Forbidden wide columns: `toxicity_prob`, `toxicity_tier` as a standalone wide name, any `is_toxic_tiered` field, `label_timestamp`, or duplicate feature-id columns.
+Forbidden wide columns: `toxicity_prob`, `toxicity_tier`, any `is_toxic_tiered` field, `label_timestamp`, `run_id`, or duplicate feature-id columns.
 
-Join rule: inner join preprocessed posts to each feature file on `CAST(source_record_id AS VARCHAR)`. Deduplicate feature rows by latest `label_timestamp` per `source_record_id` before joining, matching the dedupe semantics in `data_platform/curate/consolidate.py`.
+Join rule: inner join preprocessed posts to each feature file on `CAST(source_record_id AS VARCHAR)`. Deduplicate feature rows by latest `label_timestamp` per `source_record_id` before joining.
 
 ## Files to inspect (read-only)
 
 | Path | Why |
 |------|-----|
-| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Step 15 scope |
-| `/workspace/data_platform/curate/consolidate.py` | Existing DuckDB join and `FEATURE_WIDE_COLUMNS` pattern |
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | Wide schema and input paths |
+| `/workspace/data_platform/curate/consolidate.py` | Existing DuckDB join pattern |
 | `/workspace/data_platform/curate/runner.py` | Metadata and hash patterns |
 | `/workspace/data_platform/models/sync.py` | Twelve preprocessed column names |
 | `/workspace/data_platform/generate_features/registry.py` | Raw feature output schemas |
-| `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/*_REPORT.md` | Input URIs and manifest digests from Steps 8–14 |
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/*_run_report.md` | Input URIs and manifest digests from Steps 8 through 14 |
 | `/workspace/AGENTS.md` | AWS credential export, `PYTHONPATH=.` |
 
 ## Files allowed to change
 
-- `/workspace/data_platform/curate/consolidate.py` (add campaign-wide column map including `llm_toxicity_tiered -> llm_toxicity_tier`; keep `is_toxic_tiered` out of the Bluesky campaign map)
-- `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py` (new CLI: read S3 campaign inputs, write wide Parquet + manifest, print validation summary)
-- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/WIDE_CONSOLIDATION_REPORT.md` (permanent report only)
+- `/workspace/data_platform/curate/consolidate.py` (add campaign-wide column map including `llm_toxicity_tiered` → `llm_toxicity_tier`)
+- `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py` (new CLI)
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/wide_run_report.md` (permanent report only)
 - S3 objects under `.../wide/`
-
-Optional README note in `/workspace/data_platform/README.md` only if needed to document the new CLI; keep the diff minimal.
-
-Do not edit the plan package during implementation.
 
 ## Files forbidden to change
 
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
 - `/workspace/data_platform/generate_features/**`
-- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/*_REPORT.md` except adding cross-links inside the new wide report
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/*_run_report.md` except cross-links inside the wide report
 - `/workspace/tests/**`
 - `/workspace/CHANGELOG.md`
-- Feature S3 prefixes under the seven feature folders (read-only inputs)
-- Any temporary smoke paths under `docs/reports/.../smoke/`
+- Feature S3 prefixes (read-only inputs)
+- Any temporary smoke paths under `reports/smoke/`
 
-## Consolidation behavior
+## Locked contracts
 
-1. Verify each of the seven feature manifests matches its final Parquet SHA-256 and row count 200000 before joining.
-2. Load only the pinned preprocessed run, not every preprocess directory on the dataset.
-3. Build the wide dataframe with exactly the nineteen columns listed above.
-4. Sort rows by `source_record_id` ascending before writing Parquet.
-5. Write `bluesky_llm_features_wide.parquet` to the wide S3 prefix.
-6. Write `manifest.sha256.json` covering the wide Parquet bytes and listing constituent input object hashes copied from the seven feature manifests plus the preprocessed input hash.
-7. Fail the CLI with non-zero exit if any validation check below fails.
+See `campaign_contract.md`. `wide/manifest.json` must link all seven per-feature `manifest.json` provenance manifests plus preprocessed input hash. Use SHA-256 only; never ETag.
 
-No LLM calls. No batch jobs. No temporary artifacts committed to the repo beyond the permanent report.
+## Ordered implementation work
 
-## Exact commands
+1. Verify each of the seven feature manifests matches its `final.parquet` SHA-256 and row count 200000.
+2. Load only pinned preprocessed run `2026_09_03-23:51:30`.
+3. Build wide dataframe with exactly nineteen columns.
+4. Sort by `source_record_id` ascending before writing Parquet.
+5. Write `wide/features.parquet` and `wide/manifest.json`.
+6. Write `reports/wide_run_report.md`.
+7. Run runtime validation commands below.
 
-From the repo root:
+## Exact commands and expected output
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
@@ -165,14 +147,14 @@ export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 uv sync
 ```
 
-### Build and upload wide artifact
+### Build and upload wide artifact (available after this step's implementation)
 
 ```bash
 PYTHONPATH=. uv run python data_platform/curate/consolidate_bluesky_llm_campaign.py \
   --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
   --preprocessed-run 2026_09_03-23:51:30 \
   --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
-  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/wide/bluesky_llm_features_wide.parquet
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/wide/features.parquet
 ```
 
 Expected stdout includes:
@@ -180,12 +162,10 @@ Expected stdout includes:
 - Seven input manifest digests accepted
 - `wide_rows=200000`
 - `wide_columns=19`
-- `manifest=s3://.../wide/manifest.sha256.json`
+- `manifest=s3://.../wide/manifest.json`
 - `sort_key=source_record_id ASC`
 
-### Runtime validation (required; not automated tests)
-
-Row and column contract:
+### Runtime validation
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
@@ -194,7 +174,7 @@ export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 PYTHONPATH=. uv run python - <<'PY'
 import duckdb
 
-wide = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/wide/bluesky_llm_features_wide.parquet"
+wide = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/wide/features.parquet"
 posts = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
 
 expected_cols = [
@@ -213,18 +193,11 @@ stats = con.execute(f"""
 SELECT
   COUNT(*) AS n,
   COUNT(DISTINCT source_record_id) AS uniq,
-  SUM(CASE WHEN source_record_id IS NULL THEN 1 ELSE 0 END) AS null_id,
-  SUM(CASE WHEN news_or_opinion_category IS NULL THEN 1 ELSE 0 END) AS null_news,
-  SUM(CASE WHEN is_political IS NULL THEN 1 ELSE 0 END) AS null_pol,
-  SUM(CASE WHEN is_likely_spam IS NULL THEN 1 ELSE 0 END) AS null_spam,
-  SUM(CASE WHEN is_self_contained IS NULL THEN 1 ELSE 0 END) AS null_self,
-  SUM(CASE WHEN is_structurally_complete IS NULL THEN 1 ELSE 0 END) AS null_struct,
-  SUM(CASE WHEN political_stance IS NULL THEN 1 ELSE 0 END) AS null_stance,
   SUM(CASE WHEN llm_toxicity_tier IS NULL THEN 1 ELSE 0 END) AS null_tox
 FROM read_parquet('{wide}')
 """).fetchone()
 print(stats)
-assert stats == (200000, 200000, 0, 0, 0, 0, 0, 0, 0, 0)
+assert stats[0] == 200000 and stats[1] == 200000 and stats[2] == 0
 
 missing = con.execute(f"""
 SELECT COUNT(*)
@@ -232,117 +205,46 @@ FROM read_parquet('{posts}') p
 LEFT JOIN read_parquet('{wide}') w USING (source_record_id)
 WHERE w.source_record_id IS NULL
 """).fetchone()[0]
-extra = con.execute(f"""
-SELECT COUNT(*)
-FROM read_parquet('{wide}') w
-LEFT JOIN read_parquet('{posts}') p USING (source_record_id)
-WHERE p.source_record_id IS NULL
-""").fetchone()[0]
-print("missing", missing, "extra", extra)
-assert missing == 0 and extra == 0
+assert missing == 0
+print("validation ok")
 PY
 ```
 
-Deterministic order check:
+Expected: `validation ok` and exit code 0.
+
+### Manifest check
 
 ```bash
-PYTHONPATH=. uv run python - <<'PY'
-import duckdb
-wide = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/wide/bluesky_llm_features_wide.parquet"
-con = duckdb.connect()
-ordered = con.execute(f"""
-SELECT source_record_id
-FROM read_parquet('{wide}')
-""").fetchdf()["source_record_id"].tolist()
-sorted_ids = sorted(ordered)
-assert ordered == sorted_ids
-assert len(ordered) == len(set(ordered))
-print("deterministic_order_ok", len(ordered))
-PY
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/wide/manifest.json -
 ```
 
-Accepted-value checks:
+Expected: JSON with wide parquet SHA-256, row count 200000, column list, and links to all seven feature manifests.
 
-```bash
-PYTHONPATH=. uv run python - <<'PY'
-import duckdb
-wide = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/wide/bluesky_llm_features_wide.parquet"
-con = duckdb.connect()
-assert con.execute(f"SELECT COUNT(*) FROM read_parquet('{wide}') WHERE news_or_opinion_category NOT IN ('news','opinion','neither')").fetchone()[0] == 0
-assert con.execute(f"SELECT COUNT(*) FROM read_parquet('{wide}') WHERE political_stance NOT IN ('left','right','neutral','unclear')").fetchone()[0] == 0
-assert con.execute(f"SELECT COUNT(*) FROM read_parquet('{wide}') WHERE llm_toxicity_tier NOT IN ('low','medium','high')").fetchone()[0] == 0
-for col in ["is_political", "is_likely_spam", "is_self_contained", "is_structurally_complete"]:
-    assert con.execute(f"SELECT COUNT(*) FROM read_parquet('{wide}') WHERE {col} IS NULL").fetchone()[0] == 0
-print("accepted_values_ok")
-PY
-```
+## Acceptance criteria
 
-Forbidden-column check:
+- Wide Parquet and manifest exist at `wide/features.parquet` and `wide/manifest.json`.
+- Exactly 200000 unique rows, nineteen exact columns, no null feature values.
+- Rows sorted by `source_record_id` ascending.
+- No Perspective columns or artifacts.
+- `reports/wide_run_report.md` committed with input hashes, output hash, and validation evidence.
+- No automated tests added or run.
 
-```bash
-PYTHONPATH=. uv run python - <<'PY'
-import duckdb
-wide = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/wide/bluesky_llm_features_wide.parquet"
-cols = {r[0] for r in duckdb.connect().execute(f"DESCRIBE SELECT * FROM read_parquet('{wide}')").fetchall()}
-for forbidden in ["toxicity_prob", "toxicity_tier", "label_timestamp"]:
-    assert forbidden not in cols
-print("forbidden_columns_absent")
-PY
-```
+## Failure conditions
 
-Manifest check:
+- Any missing or unverified feature `final.parquet` input.
+- Join on `uri` without aligning `source_record_id`, or outer join leaving null features.
+- Row count other than 200000 or duplicate `source_record_id` values.
+- Missing, renamed, or extra columns in the wide output.
+- Raw `toxicity_tier` wide column instead of `llm_toxicity_tier`.
+- Manifest missing links to all seven feature provenance manifests.
+- Using `campaigns/` prefix, `bluesky_llm_features_wide.parquet`, or `manifest.sha256.json`.
+- Accepting ETag instead of SHA-256 for manifest verification.
+- Temporary smoke artifacts added to this PR.
+- Any LLM or OpenAI Batch call in this PR.
+- Any automated test added or run.
 
-```bash
-aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/wide/manifest.sha256.json -
-```
+## PR artifact and commit rules
 
-Expected: JSON with `wide_parquet` SHA-256, byte size, row count 200000, column list, deterministic sort key, and nested hashes for preprocessed input plus all seven feature finals.
-
-Perspective absence check:
-
-```bash
-aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_toxic_tiered/ 2>&1 || true
-```
-
-Expected: no objects. Any Perspective campaign prefix fails this step.
-
-## Required outputs
-
-### S3 (permanent)
-
-| Object | Purpose |
-|--------|---------|
-| `.../wide/bluesky_llm_features_wide.parquet` | Final nineteen-column wide artifact |
-| `.../wide/manifest.sha256.json` | SHA-256 manifest for wide file and recorded inputs |
-
-### Repository (permanent only)
-
-| Path | Purpose |
-|------|---------|
-| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/WIDE_CONSOLIDATION_REPORT.md` | Input URIs, manifest digests, validation command output, column list, row count, value distributions, explicit statement that Perspective columns are excluded |
-
-No temporary smoke artifacts belong in this PR.
-
-## Acceptance and failure
-
-| Check | Pass | Fail |
-|-------|------|------|
-| Feature dependencies | All seven feature PRs merged with permanent reports | Any missing or unverified feature final |
-| Join key | Inner join on `source_record_id` only | Join on `uri` without aligning `source_record_id`, or outer join leaving null features |
-| Row count | Exactly 200000 unique rows, zero nulls in any of the nineteen columns | Any other count, duplicate IDs, or null feature values |
-| Preprocessed columns | All twelve exact preprocessed columns present | Missing, renamed, or extra post columns |
-| Feature columns | Seven LLM columns with exact wide names listed above | Missing column, Perspective column, or raw `toxicity_tier` wide name |
-| Deterministic order | Rows sorted by `source_record_id` ascending in written Parquet | Unsorted or unstable order |
-| Manifest | `manifest.sha256.json` matches wide bytes and lists input hashes | Missing or mismatched digest |
-| S3 wide path | Written under campaign `.../wide/` prefix | Local-only output or wrong bucket/key |
-| Report | Only permanent wide consolidation report committed | Temporary smoke artifacts added |
-| Tests | Runtime checks only | New automated tests in this PR |
-| Labeling | No LLM or OpenAI Batch calls | Any feature generation rerun |
-
-## Done when
-
-1. Wide Parquet and manifest exist at the pinned S3 wide paths.
-2. Runtime validation confirms 200000 unique rows, nineteen exact columns, no null feature values, deterministic `source_record_id` order, and accepted value sets.
-3. No Perspective columns or campaign artifacts are present.
-4. `WIDE_CONSOLIDATION_REPORT.md` is committed with input hashes, output hash, and validation evidence.
-5. Consolidation code changes are merged and documented sufficiently for a repeat run on the same campaign prefix to be reproducible.
+- Commit consolidation code and `reports/wide_run_report.md` only.
+- PR title: `Consolidate seven Bluesky LLM features into wide Parquet artifact`
+- Do not edit `plan.md` or other step specs.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step15.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step15.md
@@ -1,0 +1,348 @@
+# Step 15: Consolidate seven Bluesky LLM features into one wide Parquet artifact
+
+## Goal
+
+Join the seven verified S3-backed LLM feature outputs to all twelve pinned preprocessed post columns by `source_record_id`. Write one deterministic wide Parquet file with exactly 200,000 unique rows and no missing feature values, plus a SHA-256 manifest and one permanent consolidation report. Exclude all Perspective API columns.
+
+This step is one future pull request. Unlike Steps 8–14, this PR may change consolidation code. It does not run LLM labeling and does not add temporary smoke artifacts.
+
+## Caller / unit of work
+
+**Main caller:** `data_platform/curate/consolidate_bluesky_llm_campaign.py` (new CLI introduced in this step).
+
+**Task:** read pinned preprocessed Parquet and seven final campaign feature Parquet files from S3, build the wide table, validate row completeness, upload the wide artifact and manifest, and commit the permanent report.
+
+**Out of scope:** Re-running any feature campaign, changing feature prompts or engines, curation rule application, automated tests, temporary smoke artifacts, or edits to completed feature run reports.
+
+## Dependencies
+
+Do not start this PR until all of the following are merged:
+
+| Dependency | Requirement |
+|------------|-------------|
+| Steps 3–7 | S3 backend, campaign layout, manifests, and progress conventions |
+| Step 8 PR + merged `is_news_or_opinion_REPORT.md` | Final feature Parquet verified at 200000 rows |
+| Step 9 PR + merged `is_political_REPORT.md` | Final feature Parquet verified at 200000 rows |
+| Step 10 PR + merged `is_likely_spam_REPORT.md` | Final feature Parquet verified at 200000 rows |
+| Step 11 PR + merged `is_self_contained_REPORT.md` | Final feature Parquet verified at 200000 rows |
+| Step 12 PR + merged `is_structurally_complete_REPORT.md` | Final feature Parquet verified at 200000 rows |
+| Step 13 PR + merged `political_stance_REPORT.md` | Final feature Parquet verified at 200000 rows |
+| Step 14 PR + merged `llm_toxicity_tiered_REPORT.md` | Final feature Parquet verified at 200000 rows; no Perspective run |
+
+Each merged feature report must list the final S3 URI and manifest digest used as inputs here.
+
+## Pinned identities
+
+| Field | Value |
+|-------|-------|
+| Dataset ID | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| Preprocessed run | `2026_09_03-23:51:30` |
+| Campaign prefix | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Join key | `source_record_id` |
+| Expected row count | `200000` |
+| Deterministic sort | `ORDER BY source_record_id ASC` |
+
+Campaign root:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/`
+
+Preprocessed input:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet`
+
+Feature inputs (final Parquet only):
+
+| Feature | S3 final object |
+|---------|-----------------|
+| `is_news_or_opinion` | `.../is_news_or_opinion/final/is_news_or_opinion.parquet` |
+| `is_political` | `.../is_political/final/is_political.parquet` |
+| `is_likely_spam` | `.../is_likely_spam/final/is_likely_spam.parquet` |
+| `is_self_contained` | `.../is_self_contained/final/is_self_contained.parquet` |
+| `is_structurally_complete` | `.../is_structurally_complete/final/is_structurally_complete.parquet` |
+| `political_stance` | `.../political_stance/final/political_stance.parquet` |
+| `llm_toxicity_tiered` | `.../llm_toxicity_tiered/final/llm_toxicity_tiered.parquet` |
+
+Wide outputs:
+
+| Object | Path |
+|--------|------|
+| Wide Parquet | `.../wide/bluesky_llm_features_wide.parquet` |
+| SHA-256 manifest | `.../wide/manifest.sha256.json` |
+
+Repository permanent report:
+
+`/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/WIDE_CONSOLIDATION_REPORT.md`
+
+## Wide-table schema
+
+The wide file must contain exactly these nineteen columns in this order:
+
+### Twelve preprocessed columns (exact names, no extras)
+
+From `PreprocessedBlueskyPostModel` / pinned preprocessed Parquet:
+
+1. `uri`
+2. `record_id`
+3. `url`
+4. `author_handle`
+5. `text`
+6. `created_at`
+7. `like_count`
+8. `repost_count`
+9. `reply_count`
+10. `quote_count`
+11. `sync_timestamp`
+12. `source_record_id`
+
+### Seven LLM feature columns
+
+| Wide column | Source feature file | Source column | Accepted values |
+|-------------|--------------------|--------------|-----------------|
+| `news_or_opinion_category` | `is_news_or_opinion` | `category` | `news`, `opinion`, `neither` |
+| `is_political` | `is_political` | `is_political` | boolean |
+| `is_likely_spam` | `is_likely_spam` | `is_likely_spam` | boolean |
+| `is_self_contained` | `is_self_contained` | `is_self_contained` | boolean |
+| `is_structurally_complete` | `is_structurally_complete` | `is_structurally_complete` | boolean |
+| `political_stance` | `political_stance` | `political_stance` | `left`, `right`, `neutral`, `unclear` |
+| `llm_toxicity_tier` | `llm_toxicity_tiered` | `toxicity_tier` | `low`, `medium`, `high` |
+
+Forbidden wide columns: `toxicity_prob`, `toxicity_tier` as a standalone wide name, any `is_toxic_tiered` field, `label_timestamp`, or duplicate feature-id columns.
+
+Join rule: inner join preprocessed posts to each feature file on `CAST(source_record_id AS VARCHAR)`. Deduplicate feature rows by latest `label_timestamp` per `source_record_id` before joining, matching the dedupe semantics in `data_platform/curate/consolidate.py`.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Step 15 scope |
+| `/workspace/data_platform/curate/consolidate.py` | Existing DuckDB join and `FEATURE_WIDE_COLUMNS` pattern |
+| `/workspace/data_platform/curate/runner.py` | Metadata and hash patterns |
+| `/workspace/data_platform/models/sync.py` | Twelve preprocessed column names |
+| `/workspace/data_platform/generate_features/registry.py` | Raw feature output schemas |
+| `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/*_REPORT.md` | Input URIs and manifest digests from Steps 8–14 |
+| `/workspace/AGENTS.md` | AWS credential export, `PYTHONPATH=.` |
+
+## Files allowed to change
+
+- `/workspace/data_platform/curate/consolidate.py` (add campaign-wide column map including `llm_toxicity_tiered -> llm_toxicity_tier`; keep `is_toxic_tiered` out of the Bluesky campaign map)
+- `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py` (new CLI: read S3 campaign inputs, write wide Parquet + manifest, print validation summary)
+- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/WIDE_CONSOLIDATION_REPORT.md` (permanent report only)
+- S3 objects under `.../wide/`
+
+Optional README note in `/workspace/data_platform/README.md` only if needed to document the new CLI; keep the diff minimal.
+
+Do not edit the plan package during implementation.
+
+## Files forbidden to change
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/docs/reports/bluesky_2026_09_03_235130_llm_features_v1/*_REPORT.md` except adding cross-links inside the new wide report
+- `/workspace/tests/**`
+- `/workspace/CHANGELOG.md`
+- Feature S3 prefixes under the seven feature folders (read-only inputs)
+- Any temporary smoke paths under `docs/reports/.../smoke/`
+
+## Consolidation behavior
+
+1. Verify each of the seven feature manifests matches its final Parquet SHA-256 and row count 200000 before joining.
+2. Load only the pinned preprocessed run, not every preprocess directory on the dataset.
+3. Build the wide dataframe with exactly the nineteen columns listed above.
+4. Sort rows by `source_record_id` ascending before writing Parquet.
+5. Write `bluesky_llm_features_wide.parquet` to the wide S3 prefix.
+6. Write `manifest.sha256.json` covering the wide Parquet bytes and listing constituent input object hashes copied from the seven feature manifests plus the preprocessed input hash.
+7. Fail the CLI with non-zero exit if any validation check below fails.
+
+No LLM calls. No batch jobs. No temporary artifacts committed to the repo beyond the permanent report.
+
+## Exact commands
+
+From the repo root:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+uv sync
+```
+
+### Build and upload wide artifact
+
+```bash
+PYTHONPATH=. uv run python data_platform/curate/consolidate_bluesky_llm_campaign.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/wide/bluesky_llm_features_wide.parquet
+```
+
+Expected stdout includes:
+
+- Seven input manifest digests accepted
+- `wide_rows=200000`
+- `wide_columns=19`
+- `manifest=s3://.../wide/manifest.sha256.json`
+- `sort_key=source_record_id ASC`
+
+### Runtime validation (required; not automated tests)
+
+Row and column contract:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python - <<'PY'
+import duckdb
+
+wide = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/wide/bluesky_llm_features_wide.parquet"
+posts = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
+
+expected_cols = [
+    "uri", "record_id", "url", "author_handle", "text", "created_at",
+    "like_count", "repost_count", "reply_count", "quote_count",
+    "sync_timestamp", "source_record_id",
+    "news_or_opinion_category", "is_political", "is_likely_spam",
+    "is_self_contained", "is_structurally_complete", "political_stance",
+    "llm_toxicity_tier",
+]
+con = duckdb.connect()
+cols = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{wide}')").fetchall()]
+assert cols == expected_cols, cols
+
+stats = con.execute(f"""
+SELECT
+  COUNT(*) AS n,
+  COUNT(DISTINCT source_record_id) AS uniq,
+  SUM(CASE WHEN source_record_id IS NULL THEN 1 ELSE 0 END) AS null_id,
+  SUM(CASE WHEN news_or_opinion_category IS NULL THEN 1 ELSE 0 END) AS null_news,
+  SUM(CASE WHEN is_political IS NULL THEN 1 ELSE 0 END) AS null_pol,
+  SUM(CASE WHEN is_likely_spam IS NULL THEN 1 ELSE 0 END) AS null_spam,
+  SUM(CASE WHEN is_self_contained IS NULL THEN 1 ELSE 0 END) AS null_self,
+  SUM(CASE WHEN is_structurally_complete IS NULL THEN 1 ELSE 0 END) AS null_struct,
+  SUM(CASE WHEN political_stance IS NULL THEN 1 ELSE 0 END) AS null_stance,
+  SUM(CASE WHEN llm_toxicity_tier IS NULL THEN 1 ELSE 0 END) AS null_tox
+FROM read_parquet('{wide}')
+""").fetchone()
+print(stats)
+assert stats == (200000, 200000, 0, 0, 0, 0, 0, 0, 0, 0)
+
+missing = con.execute(f"""
+SELECT COUNT(*)
+FROM read_parquet('{posts}') p
+LEFT JOIN read_parquet('{wide}') w USING (source_record_id)
+WHERE w.source_record_id IS NULL
+""").fetchone()[0]
+extra = con.execute(f"""
+SELECT COUNT(*)
+FROM read_parquet('{wide}') w
+LEFT JOIN read_parquet('{posts}') p USING (source_record_id)
+WHERE p.source_record_id IS NULL
+""").fetchone()[0]
+print("missing", missing, "extra", extra)
+assert missing == 0 and extra == 0
+PY
+```
+
+Deterministic order check:
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import duckdb
+wide = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/wide/bluesky_llm_features_wide.parquet"
+con = duckdb.connect()
+ordered = con.execute(f"""
+SELECT source_record_id
+FROM read_parquet('{wide}')
+""").fetchdf()["source_record_id"].tolist()
+sorted_ids = sorted(ordered)
+assert ordered == sorted_ids
+assert len(ordered) == len(set(ordered))
+print("deterministic_order_ok", len(ordered))
+PY
+```
+
+Accepted-value checks:
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import duckdb
+wide = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/wide/bluesky_llm_features_wide.parquet"
+con = duckdb.connect()
+assert con.execute(f"SELECT COUNT(*) FROM read_parquet('{wide}') WHERE news_or_opinion_category NOT IN ('news','opinion','neither')").fetchone()[0] == 0
+assert con.execute(f"SELECT COUNT(*) FROM read_parquet('{wide}') WHERE political_stance NOT IN ('left','right','neutral','unclear')").fetchone()[0] == 0
+assert con.execute(f"SELECT COUNT(*) FROM read_parquet('{wide}') WHERE llm_toxicity_tier NOT IN ('low','medium','high')").fetchone()[0] == 0
+for col in ["is_political", "is_likely_spam", "is_self_contained", "is_structurally_complete"]:
+    assert con.execute(f"SELECT COUNT(*) FROM read_parquet('{wide}') WHERE {col} IS NULL").fetchone()[0] == 0
+print("accepted_values_ok")
+PY
+```
+
+Forbidden-column check:
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import duckdb
+wide = "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/wide/bluesky_llm_features_wide.parquet"
+cols = {r[0] for r in duckdb.connect().execute(f"DESCRIBE SELECT * FROM read_parquet('{wide}')").fetchall()}
+for forbidden in ["toxicity_prob", "toxicity_tier", "label_timestamp"]:
+    assert forbidden not in cols
+print("forbidden_columns_absent")
+PY
+```
+
+Manifest check:
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/wide/manifest.sha256.json -
+```
+
+Expected: JSON with `wide_parquet` SHA-256, byte size, row count 200000, column list, deterministic sort key, and nested hashes for preprocessed input plus all seven feature finals.
+
+Perspective absence check:
+
+```bash
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/campaigns/bluesky_2026_09_03_235130_llm_features_v1/is_toxic_tiered/ 2>&1 || true
+```
+
+Expected: no objects. Any Perspective campaign prefix fails this step.
+
+## Required outputs
+
+### S3 (permanent)
+
+| Object | Purpose |
+|--------|---------|
+| `.../wide/bluesky_llm_features_wide.parquet` | Final nineteen-column wide artifact |
+| `.../wide/manifest.sha256.json` | SHA-256 manifest for wide file and recorded inputs |
+
+### Repository (permanent only)
+
+| Path | Purpose |
+|------|---------|
+| `docs/reports/bluesky_2026_09_03_235130_llm_features_v1/WIDE_CONSOLIDATION_REPORT.md` | Input URIs, manifest digests, validation command output, column list, row count, value distributions, explicit statement that Perspective columns are excluded |
+
+No temporary smoke artifacts belong in this PR.
+
+## Acceptance and failure
+
+| Check | Pass | Fail |
+|-------|------|------|
+| Feature dependencies | All seven feature PRs merged with permanent reports | Any missing or unverified feature final |
+| Join key | Inner join on `source_record_id` only | Join on `uri` without aligning `source_record_id`, or outer join leaving null features |
+| Row count | Exactly 200000 unique rows, zero nulls in any of the nineteen columns | Any other count, duplicate IDs, or null feature values |
+| Preprocessed columns | All twelve exact preprocessed columns present | Missing, renamed, or extra post columns |
+| Feature columns | Seven LLM columns with exact wide names listed above | Missing column, Perspective column, or raw `toxicity_tier` wide name |
+| Deterministic order | Rows sorted by `source_record_id` ascending in written Parquet | Unsorted or unstable order |
+| Manifest | `manifest.sha256.json` matches wide bytes and lists input hashes | Missing or mismatched digest |
+| S3 wide path | Written under campaign `.../wide/` prefix | Local-only output or wrong bucket/key |
+| Report | Only permanent wide consolidation report committed | Temporary smoke artifacts added |
+| Tests | Runtime checks only | New automated tests in this PR |
+| Labeling | No LLM or OpenAI Batch calls | Any feature generation rerun |
+
+## Done when
+
+1. Wide Parquet and manifest exist at the pinned S3 wide paths.
+2. Runtime validation confirms 200000 unique rows, nineteen exact columns, no null feature values, deterministic `source_record_id` order, and accepted value sets.
+3. No Perspective columns or campaign artifacts are present.
+4. `WIDE_CONSOLIDATION_REPORT.md` is committed with input hashes, output hash, and validation evidence.
+5. Consolidation code changes are merged and documented sufficiently for a repeat run on the same campaign prefix to be reproducible.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step16.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step16.md
@@ -1,0 +1,230 @@
+# Step 16: Expire intermediate data platform S3 shards after 30 days
+
+## Goal
+
+Add an S3 bucket lifecycle rule on `mirrorview-experimental-artifacts` that expires only intermediate batch shards: objects under the `data_platform/data/` prefix that carry the object tag `intermediate-artifact=true`. Final Parquet feature files, hash manifests, progress records, and permanent run reports must not match the rule and must remain until deleted by other processes.
+
+## Dependencies
+
+- **Step 1 merged:** bucket and `data_platform/data/` prefix are in use.
+- **Step 2 and Step 3 merged:** production pipeline writes go to S3 under `data_platform/data/`.
+- **Step 5 merged (technical dependency):** feature shard writes apply `Tagging` `intermediate-artifact=true` on 2,000-row batch parquet objects only. Step 16 is intentionally last in the epic schedule, but the lifecycle rule is inert for correctly tagged shards until Step 5 lands.
+
+No IAM policy changes and no bucket versioning changes in this step.
+
+## Main caller and implementation slice
+
+**Main caller:** `data_platform/infra/apply_data_platform_s3_lifecycle.py` `main`.
+
+**Implementation slice for this PR:** commit a version-controlled lifecycle configuration JSON and a small Python script that calls `put_bucket_lifecycle_configuration` to install one rule with AND filter (prefix + tag), 30-day expiration, and no effect on untagged or final artifacts.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Locked prefix, tag, and retention intent |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json` | Example long-lived objects without the intermediate tag |
+| `/workspace/lib/aws/s3.py` | Region default `us-east-2` |
+| `/workspace/experiments/finetune_qwen_model_2026_08_08/infra/main.tf` | Prior lab use of `mirrorview-experimental-artifacts` (read only; do not edit) |
+| `/workspace/AGENTS.md` | AWS credential export pattern |
+
+## Files allowed to change
+
+- `/workspace/data_platform/infra/data_platform_s3_lifecycle.json` (new, permanent config)
+- `/workspace/data_platform/infra/apply_data_platform_s3_lifecycle.py` (new)
+- `/workspace/data_platform/infra/verify_data_platform_s3_lifecycle.py` (new, read-only verifier)
+
+Temporary smoke objects under `data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/` may be uploaded and committed as manifest-only evidence for review; delete smoke objects from S3 and remove the manifest from git before merge.
+
+Do not edit plan package files during implementation.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/utils/storage.py`
+- `/workspace/data_platform/utils/object_store.py`
+- `/workspace/data_platform/generate_features/**` (tagging is Step 5)
+- `/workspace/lib/aws/s3.py` unless a one-line helper is absolutely required — prefer boto3 calls inside the infra script
+- Any IAM policy, role, or Terraform file
+- Bucket versioning settings
+- `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json`
+- `/workspace/CHANGELOG.md`
+- Any file under `/workspace/tests/`
+- Any file outside the allowed list
+
+## Locked contracts
+
+| Item | Value |
+|------|-------|
+| Bucket | `mirrorview-experimental-artifacts` |
+| Region | `us-east-2` |
+| Rule id | `expire-data-platform-intermediate-artifacts` |
+| Prefix filter | `data_platform/data/` |
+| Tag filter | Key `intermediate-artifact`, value `true` |
+| Filter composition | AWS lifecycle AND of prefix and tag (both required) |
+| Expiration | 30 days after object creation |
+| Non-expiring objects | Final feature parquet, hash manifests, progress JSON, permanent run reports, pinned preprocessed input, and any object without the tag |
+| Tag application | Only Step 5 shard writes set `intermediate-artifact=true`; this step does not retroactively tag objects |
+| IAM | No new policies or role changes |
+| Versioning | No enable/disable/versioning configuration changes |
+| Config file | `data_platform/infra/data_platform_s3_lifecycle.json` documents the rule verbatim for review |
+| Apply script idempotency | Re-running apply replaces the named rule without duplicating rules |
+
+`data_platform_s3_lifecycle.json` must contain exactly one rule matching:
+
+```json
+{
+  "Rules": [
+    {
+      "ID": "expire-data-platform-intermediate-artifacts",
+      "Status": "Enabled",
+      "Filter": {
+        "And": {
+          "Prefix": "data_platform/data/",
+          "Tags": [
+            {
+              "Key": "intermediate-artifact",
+              "Value": "true"
+            }
+          ]
+        }
+      },
+      "Expiration": {
+        "Days": 30
+      }
+    }
+  ]
+}
+```
+
+## Ordered implementation work
+
+1. Add the lifecycle JSON with the locked rule shape.
+2. Add `apply_data_platform_s3_lifecycle.py` that loads the JSON, merges or replaces the rule by `ID`, and calls `put_bucket_lifecycle_configuration`.
+3. Add `verify_data_platform_s3_lifecycle.py` that calls `get_bucket_lifecycle_configuration` and asserts the rule id, prefix, tag, and 30-day expiration.
+4. Export AWS credentials and apply the rule in the lab bucket.
+5. Upload one temporary tagged smoke object under `data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/tagged_shard.parquet` with `intermediate-artifact=true` and confirm lifecycle configuration lists the rule (do not wait 30 days).
+6. Upload one untagged smoke object beside it and confirm the rule filter would not target it (manual reasoning plus tag listing).
+7. Delete smoke S3 objects and any temporary manifest before merge.
+
+## Live smoke and basic check commands
+
+Export AWS credentials:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+aws sts get-caller-identity --region us-east-2
+```
+
+Expected: exit code 0 with caller ARN JSON.
+
+Apply lifecycle configuration:
+
+```bash
+PYTHONPATH=. uv run python data_platform/infra/apply_data_platform_s3_lifecycle.py
+```
+
+Expected stdout: `applied lifecycle rule expire-data-platform-intermediate-artifacts on mirrorview-experimental-artifacts` and exit code 0.
+
+Verify installed rule:
+
+```bash
+PYTHONPATH=. uv run python data_platform/infra/verify_data_platform_s3_lifecycle.py
+```
+
+Expected stdout: `OK: rule expire-data-platform-intermediate-artifacts prefix=data_platform/data/ tag=intermediate-artifact=true expiration_days=30` and exit code 0.
+
+Cross-check with AWS CLI:
+
+```bash
+aws s3api get-bucket-lifecycle-configuration \
+  --bucket mirrorview-experimental-artifacts \
+  --region us-east-2 \
+  --query 'Rules[?ID==`expire-data-platform-intermediate-artifacts`]' \
+  --output json
+```
+
+Expected JSON array with one element whose `Filter.And.Prefix` is `data_platform/data/`, whose `Filter.And.Tags` contains `Key=intermediate-artifact,Value=true`, and whose `Expiration.Days` is `30`.
+
+**Tagged smoke object** (delete after verification):
+
+```bash
+echo 'smoke' > /tmp/lifecycle_smoke.parquet
+aws s3api put-object \
+  --bucket mirrorview-experimental-artifacts \
+  --key data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/tagged_shard.parquet \
+  --body /tmp/lifecycle_smoke.parquet \
+  --tagging "TagSet=[{Key=intermediate-artifact,Value=true}]" \
+  --region us-east-2
+
+aws s3api get-object-tagging \
+  --bucket mirrorview-experimental-artifacts \
+  --key data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/tagged_shard.parquet \
+  --region us-east-2
+```
+
+Expected tagging output includes `intermediate-artifact` = `true`.
+
+**Untagged control object** (delete after verification):
+
+```bash
+aws s3api put-object \
+  --bucket mirrorview-experimental-artifacts \
+  --key data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/final_feature.parquet \
+  --body /tmp/lifecycle_smoke.parquet \
+  --region us-east-2
+
+aws s3api get-object-tagging \
+  --bucket mirrorview-experimental-artifacts \
+  --key data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/final_feature.parquet \
+  --region us-east-2
+```
+
+Expected: empty `TagSet` or no `intermediate-artifact` tag.
+
+Clean up smoke objects:
+
+```bash
+aws s3 rm s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/ --recursive --region us-east-2
+```
+
+Expected: two deleted keys, exit code 0.
+
+Confirm pinned inventory object is not tagged as intermediate:
+
+```bash
+aws s3api get-object-tagging \
+  --bucket mirrorview-experimental-artifacts \
+  --key data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet \
+  --region us-east-2
+```
+
+Expected: no `intermediate-artifact=true` tag (empty tag set is fine).
+
+## Acceptance criteria
+
+- Lifecycle rule `expire-data-platform-intermediate-artifacts` is enabled on `mirrorview-experimental-artifacts`.
+- Rule uses AND of prefix `data_platform/data/` and tag `intermediate-artifact=true`.
+- Expiration is 30 days.
+- Apply and verify scripts are committed under `data_platform/infra/`.
+- Smoke demonstrates tagged vs untagged objects under the prefix.
+- No IAM or versioning changes.
+- Pinned preprocessed input and migration inventory objects are not tagged as intermediate.
+
+## Failure conditions
+
+- Rule expires all objects under `data_platform/data/` without requiring the tag.
+- Rule targets a different prefix (for example `data_platform/` only or a duplicated `data_platform/data_platform/`).
+- Expiration is not 30 days.
+- IAM policies or bucket versioning are modified.
+- Feature final artifacts or manifests are tagged `intermediate-artifact=true` in this PR (tagging belongs to Step 5).
+- Automated tests are added or run.
+
+## PR artifact and commit rules
+
+- One independently mergeable PR, intended to merge after Step 5 tagging is live even though it is numbered last in the plan.
+- Commit JSON config and scripts together; apply output may be noted in PR description but need not commit secrets.
+- Temporary smoke paths under `data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/` must be removed from S3 and not remain in git after merge.
+- Do not add pytest files or run pytest.
+- Do not edit `plan.md` or other step specs.
+- PR title suggestion: `Add 30-day S3 lifecycle for tagged data platform intermediate shards`.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step16.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step16.md
@@ -1,16 +1,15 @@
-# Step 16: Expire intermediate data platform S3 shards after 30 days
+# Step 16: Expire intermediate data platform S3 batches after 30 days
 
 ## Goal
 
-Add an S3 bucket lifecycle rule on `mirrorview-experimental-artifacts` that expires only intermediate batch shards: objects under the `data_platform/data/` prefix that carry the object tag `intermediate-artifact=true`. Final Parquet feature files, hash manifests, progress records, and permanent run reports must not match the rule and must remain until deleted by other processes.
+Add an S3 bucket lifecycle rule on `mirrorview-experimental-artifacts` that expires only intermediate batches: objects under the `data_platform/data/` prefix that carry the object tag `intermediate-artifact=true`. Final Parquet feature files, hash manifests, progress records, and permanent run reports must not match the rule and must remain until deleted by other processes.
 
 ## Dependencies
 
-- **Step 1 merged:** bucket and `data_platform/data/` prefix are in use.
-- **Step 2 and Step 3 merged:** production pipeline writes go to S3 under `data_platform/data/`.
-- **Step 5 merged (technical dependency):** feature shard writes apply `Tagging` `intermediate-artifact=true` on 2,000-row batch parquet objects only. Step 16 is intentionally last in the epic schedule, but the lifecycle rule is inert for correctly tagged shards until Step 5 lands.
+- **Step 5 merged (only technical prerequisite):** feature batch writes apply `Tagging` `intermediate-artifact=true` on `batches/part-*.parquet` objects only. The lifecycle rule is inert for correctly tagged batches until Step 5 lands.
+- See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` for tagging rules.
 
-No IAM policy changes and no bucket versioning changes in this step.
+Step 16 is listed last in the epic schedule. It does not depend on Steps 8 through 15. No IAM policy changes and no bucket versioning changes in this step.
 
 ## Main caller and implementation slice
 
@@ -43,7 +42,7 @@ Do not edit plan package files during implementation.
 - `/workspace/data_platform/utils/storage.py`
 - `/workspace/data_platform/utils/object_store.py`
 - `/workspace/data_platform/generate_features/**` (tagging is Step 5)
-- `/workspace/lib/aws/s3.py` unless a one-line helper is absolutely required — prefer boto3 calls inside the infra script
+- `/workspace/lib/aws/s3.py` unless a one-line helper is absolutely required; prefer boto3 calls inside the infra script
 - Any IAM policy, role, or Terraform file
 - Bucket versioning settings
 - `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json`
@@ -63,7 +62,7 @@ Do not edit plan package files during implementation.
 | Filter composition | AWS lifecycle AND of prefix and tag (both required) |
 | Expiration | 30 days after object creation |
 | Non-expiring objects | Final feature parquet, hash manifests, progress JSON, permanent run reports, pinned preprocessed input, and any object without the tag |
-| Tag application | Only Step 5 shard writes set `intermediate-artifact=true`; this step does not retroactively tag objects |
+| Tag application | Only Step 5 batch writes under `batches/` set `intermediate-artifact=true`; this step does not retroactively tag objects |
 | IAM | No new policies or role changes |
 | Versioning | No enable/disable/versioning configuration changes |
 | Config file | `data_platform/infra/data_platform_s3_lifecycle.json` documents the rule verbatim for review |
@@ -102,7 +101,7 @@ Do not edit plan package files during implementation.
 2. Add `apply_data_platform_s3_lifecycle.py` that loads the JSON, merges or replaces the rule by `ID`, and calls `put_bucket_lifecycle_configuration`.
 3. Add `verify_data_platform_s3_lifecycle.py` that calls `get_bucket_lifecycle_configuration` and asserts the rule id, prefix, tag, and 30-day expiration.
 4. Export AWS credentials and apply the rule in the lab bucket.
-5. Upload one temporary tagged smoke object under `data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/tagged_shard.parquet` with `intermediate-artifact=true` and confirm lifecycle configuration lists the rule (do not wait 30 days).
+5. Upload one temporary tagged smoke object under `data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/tagged_batch.parquet` with `intermediate-artifact=true` and confirm lifecycle configuration lists the rule (do not wait 30 days).
 6. Upload one untagged smoke object beside it and confirm the rule filter would not target it (manual reasoning plus tag listing).
 7. Delete smoke S3 objects and any temporary manifest before merge.
 
@@ -152,14 +151,14 @@ Expected JSON array with one element whose `Filter.And.Prefix` is `data_platform
 echo 'smoke' > /tmp/lifecycle_smoke.parquet
 aws s3api put-object \
   --bucket mirrorview-experimental-artifacts \
-  --key data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/tagged_shard.parquet \
+  --key data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/tagged_batch.parquet \
   --body /tmp/lifecycle_smoke.parquet \
   --tagging "TagSet=[{Key=intermediate-artifact,Value=true}]" \
   --region us-east-2
 
 aws s3api get-object-tagging \
   --bucket mirrorview-experimental-artifacts \
-  --key data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/tagged_shard.parquet \
+  --key data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/tagged_batch.parquet \
   --region us-east-2
 ```
 
@@ -227,4 +226,4 @@ Expected: no `intermediate-artifact=true` tag (empty tag set is fine).
 - Temporary smoke paths under `data_platform/data/bluesky/_lifecycle_smoke_2026_09_05/` must be removed from S3 and not remain in git after merge.
 - Do not add pytest files or run pytest.
 - Do not edit `plan.md` or other step specs.
-- PR title suggestion: `Add 30-day S3 lifecycle for tagged data platform intermediate shards`.
+- PR title suggestion: `Add 30-day S3 lifecycle for tagged data platform intermediate batches`.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step2.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step2.md
@@ -1,0 +1,203 @@
+# Step 2: Add first-class S3 storage support to the data pipeline
+
+## Goal
+
+Introduce a configurable object-store backend for pipeline data so callers can read and write through either local disk or S3. Preserve today's local-disk behavior as the explicit development default. Reject Git LFS pointer text, path traversal, missing content hashes on S3 writes, and accidental overwrites of existing S3 objects.
+
+## Dependencies
+
+- **Step 1 merged:** pinned Bluesky objects exist in `s3://mirrorview-experimental-artifacts/` and `s3_migration_inventory.json` lists their keys and SHA-256 values.
+- AWS credentials available the same way as Step 1.
+- `uv sync` for boto3 and pandas.
+
+This step does not remove Git LFS, does not change the production default backend (that is Step 3), and does not tag intermediate shards (that is Step 5).
+
+## Main caller and implementation slice
+
+**Main caller:** `data_platform/utils/storage.py` `StorageManager.load_records`.
+
+**Implementation slice for this PR:** add `data_platform/utils/object_store.py` with `LocalObjectStore` and `S3ObjectStore`, wire `StorageManager` to resolve paths through the selected backend, and make `load_records(..., latest=True)` read the pinned preprocessed `posts.parquet` from S3 when `DATA_PLATFORM_STORAGE_BACKEND=s3`. Local backend remains the default when the env var is unset.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/data_platform/utils/storage.py` | Current `StorageManager`, `DATA_ROOT`, read/write helpers |
+| `/workspace/data_platform/utils/dataset.py` | `dataset_root`, manifest loading |
+| `/workspace/lib/aws/s3.py` | Existing boto3 wrapper |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json` | Verified S3 keys and hashes from Step 1 |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Pinned run for smoke read |
+| `/workspace/data_platform/generate_features/platform_cli.py` | How feature CLIs construct `StorageManager` |
+| `/workspace/data_platform/preprocessing/preprocess_bluesky.py` | Preprocess write path still local in this step |
+| `/workspace/data_platform/ingestion/sync_bluesky.py` | Raw sync still local in this step |
+| `/workspace/tests/data_platform/utils/test_storage.py` | Existing local storage expectations (read only; do not add tests in this PR) |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.` convention |
+
+## Files allowed to change
+
+- `/workspace/data_platform/utils/object_store.py` (new)
+- `/workspace/data_platform/utils/storage.py`
+- `/workspace/lib/aws/s3.py` (only if required for conditional PUT, ranged read, or tagging hooks used by `S3ObjectStore`; keep changes minimal)
+
+Temporary smoke artifacts under `experiments/bluesky_s3_storage_smoke_2026_09_05/` may be committed for review and must be deleted before merge.
+
+Do not edit plan package files during implementation.
+
+## Files forbidden to change
+
+- `/workspace/.gitattributes`
+- `/workspace/.gitignore`
+- `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json` (read for verification only)
+- `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**/*.parquet` (git-tracked LFS)
+- `/workspace/data_platform/scripts/migrate_bluesky_lfs_to_s3.py`
+- `/workspace/data_platform/generate_features/**` (beyond what storage imports require — prefer zero feature changes)
+- `/workspace/data_platform/preprocessing/**`
+- `/workspace/data_platform/ingestion/**`
+- `/workspace/data_platform/data/reddit/**`
+- `/workspace/CHANGELOG.md`
+- Any file under `/workspace/tests/`
+- Any file outside the allowed list
+
+## Locked contracts
+
+| Item | Value |
+|------|-------|
+| Bucket | `mirrorview-experimental-artifacts` |
+| Region | `us-east-2` |
+| Pipeline key prefix | `data_platform/data/` |
+| Backend env var | `DATA_PLATFORM_STORAGE_BACKEND` with allowed values `local` (default) and `s3` |
+| Bucket env var | `DATA_PLATFORM_S3_BUCKET` defaulting to `mirrorview-experimental-artifacts` |
+| Key construction | `data_platform/data/{platform}/{dataset_id}/{stage}/{run_name}/{filename}` mirrors `StorageManager.root_dir` layout |
+| Path safety | Reject `..`, absolute paths, backslashes, and keys outside `data_platform/data/` |
+| LFS pointer detection | First line exactly `version https://git-lfs.github.com/spec/v1` → raise `ValueError` with message containing `git-lfs pointer` |
+| S3 overwrite policy | `put_bytes` and `put_file` require `allow_overwrite=False` by default; existing object with same key raises `FileExistsError` |
+| S3 write metadata | Every S3 upload must include `sha256` in a sidecar field recorded in memory and returned to callers; use SHA-256 of body bytes |
+| Hash on read | After S3 download, verify bytes against inventory or caller-supplied expected hash when provided |
+| Default backend | `local` when env var unset — production default flip happens in Step 3 |
+| Public API stability | `BlueskyStorageManager`, `StorageStage`, and existing method names remain; backend selection is internal or env-driven |
+| Pinned smoke dataset | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` preprocessed run `2026_09_03-23:51:30` |
+
+`object_store.py` must expose at minimum:
+
+- `class LocalObjectStore` — filesystem operations under `DATA_ROOT`
+- `class S3ObjectStore` — wraps `lib.aws.s3.S3` with the locked policies above
+- `def resolve_object_store() -> ObjectStore` — reads env vars and returns the backend
+
+## Ordered implementation work
+
+1. Add `object_store.py` with the locked interfaces and safety checks.
+2. Extend `lib/aws/s3.py` only if `S3ObjectStore` needs `head_object`, conditional `put_object`, or `delete_object` helpers not already present.
+3. Refactor `StorageManager` path helpers to build repo-relative keys without duplicating `data_platform`.
+4. Route `load_records`, `write_records`, `append_records`, `write_dataframe`, `write_run_metadata`, and `load_run_metadata` through the object store while keeping local semantics unchanged when backend is `local`.
+5. Add a small smoke entry point or `if __name__ == "__main__"` block in `object_store.py` is forbidden; use the live command below instead.
+6. Run live smoke commands with `DATA_PLATFORM_STORAGE_BACKEND=s3` and confirm row count 200000 for the pinned preprocessed parquet.
+7. Run the same smoke with backend unset and confirm local reads still work.
+8. Delete temporary smoke artifacts before merge.
+
+## Live smoke and basic check commands
+
+Export AWS credentials:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+```
+
+**S3 read smoke** — load pinned preprocessed posts from S3:
+
+```bash
+DATA_PLATFORM_STORAGE_BACKEND=s3 \
+DATA_PLATFORM_S3_BUCKET=mirrorview-experimental-artifacts \
+PYTHONPATH=. uv run python - <<'PY'
+from data_platform.utils.storage import BlueskyStorageManager, StorageStage
+storage = BlueskyStorageManager(StorageStage.PREPROCESSED, "bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73")
+run_dir = storage.root_dir / "2026_09_03-23:51:30"
+df = storage.load_records(run_dir)
+assert len(df) == 200000
+assert "source_record_id" in df.columns
+print("s3 load ok", len(df))
+PY
+```
+
+Expected stdout: `s3 load ok 200000` and exit code 0.
+
+**Local read smoke** — default backend still uses disk:
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+from data_platform.utils.storage import BlueskyStorageManager, StorageStage
+storage = BlueskyStorageManager(StorageStage.PREPROCESSED, "bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73")
+df = storage.load_records(latest=True)
+print("local load ok", len(df))
+PY
+```
+
+Expected stdout: `local load ok 200000` when LFS blobs are present locally; if only pointers exist locally, the command may fail until `git lfs pull`, which is acceptable for local dev and does not block the S3 smoke above.
+
+**LFS pointer rejection smoke** — write attempt on pointer bytes must fail fast:
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+from pathlib import Path
+from data_platform.utils.object_store import S3ObjectStore
+store = S3ObjectStore(bucket="mirrorview-experimental-artifacts", prefix="data_platform/data")
+pointer = Path("data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=00/87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef.parquet")
+raw = pointer.read_bytes()
+try:
+    store.put_bytes("bluesky/smoke/pointer.parquet", raw)
+except ValueError as e:
+    assert "git-lfs pointer" in str(e)
+    print("pointer rejected ok")
+else:
+    raise SystemExit("expected ValueError")
+PY
+```
+
+Expected stdout: `pointer rejected ok`. Run only when the hour-00 file is still a pointer (before `git lfs pull` on that path).
+
+**Overwrite rejection smoke** — re-upload pinned preprocessed key without `allow_overwrite`:
+
+```bash
+DATA_PLATFORM_STORAGE_BACKEND=s3 \
+PYTHONPATH=. uv run python - <<'PY'
+from data_platform.utils.object_store import S3ObjectStore
+store = S3ObjectStore(bucket="mirrorview-experimental-artifacts", prefix="data_platform/data")
+key = "bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
+body = store.get_bytes(key)
+try:
+    store.put_bytes(key, body, allow_overwrite=False)
+except FileExistsError:
+    print("overwrite rejected ok")
+else:
+    raise SystemExit("expected FileExistsError")
+PY
+```
+
+Expected stdout: `overwrite rejected ok`.
+
+## Acceptance criteria
+
+- `StorageManager.load_records` reads the pinned 200,000-row preprocessed parquet from S3 when `DATA_PLATFORM_STORAGE_BACKEND=s3`.
+- Default backend without env var remains local and does not change existing local path layout.
+- S3 writes reject overwrites by default and record SHA-256 for uploaded bytes.
+- LFS pointer bytes are rejected on S3 upload.
+- No Git LFS or `.gitattributes` changes.
+- No automated tests added or run.
+
+## Failure conditions
+
+- S3 keys include a duplicated `data_platform` segment.
+- Backend defaults to `s3` in this PR (that belongs to Step 3).
+- Reading S3 returns LFS pointer text or wrong row count for the pinned preprocessed file.
+- Overwrite of an existing production object succeeds without an explicit `allow_overwrite=True`.
+- Reddit storage paths or unrelated buckets are referenced.
+- Feature-generation behavior changes beyond using the shared storage layer.
+
+## PR artifact and commit rules
+
+- One independently mergeable PR.
+- Commit `object_store.py` and `storage.py` changes together; keep `lib/aws/s3.py` edits in a separate commit only if they are non-trivial.
+- Temporary smoke outputs under `experiments/bluesky_s3_storage_smoke_2026_09_05/` may be committed for review; remove before merge.
+- Do not add pytest files or run pytest.
+- Do not edit other step specs or `plan.md`.
+- PR title suggestion: `Add configurable S3 object store for data platform storage`.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step2.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step2.md
@@ -6,11 +6,12 @@ Introduce a configurable object-store backend for pipeline data so callers can r
 
 ## Dependencies
 
-- **Step 1 merged:** pinned Bluesky objects exist in `s3://mirrorview-experimental-artifacts/` and `s3_migration_inventory.json` lists their keys and SHA-256 values.
+- **None** on other epic steps. May run in parallel with Steps 1 and 4.
+- See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` for bucket and prefix conventions used by later steps.
 - AWS credentials available the same way as Step 1.
 - `uv sync` for boto3 and pandas.
 
-This step does not remove Git LFS, does not change the production default backend (that is Step 3), and does not tag intermediate shards (that is Step 5).
+Step 1 S3 objects are useful for end-to-end S3 read smoke in this step but are not a merge-order prerequisite. This step does not remove Git LFS, does not change the production default backend (that is Step 3), and does not tag intermediate batches (that is Step 5).
 
 ## Main caller and implementation slice
 
@@ -50,7 +51,7 @@ Do not edit plan package files during implementation.
 - `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json` (read for verification only)
 - `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**/*.parquet` (git-tracked LFS)
 - `/workspace/data_platform/scripts/migrate_bluesky_lfs_to_s3.py`
-- `/workspace/data_platform/generate_features/**` (beyond what storage imports require — prefer zero feature changes)
+- `/workspace/data_platform/generate_features/**` (beyond what storage imports require . prefer zero feature changes)
 - `/workspace/data_platform/preprocessing/**`
 - `/workspace/data_platform/ingestion/**`
 - `/workspace/data_platform/data/reddit/**`
@@ -71,17 +72,17 @@ Do not edit plan package files during implementation.
 | Path safety | Reject `..`, absolute paths, backslashes, and keys outside `data_platform/data/` |
 | LFS pointer detection | First line exactly `version https://git-lfs.github.com/spec/v1` → raise `ValueError` with message containing `git-lfs pointer` |
 | S3 overwrite policy | `put_bytes` and `put_file` require `allow_overwrite=False` by default; existing object with same key raises `FileExistsError` |
-| S3 write metadata | Every S3 upload must include `sha256` in a sidecar field recorded in memory and returned to callers; use SHA-256 of body bytes |
+| S3 write metadata | Every S3 upload must record SHA-256 of body bytes. Never use ETag as a content hash. |
 | Hash on read | After S3 download, verify bytes against inventory or caller-supplied expected hash when provided |
-| Default backend | `local` when env var unset — production default flip happens in Step 3 |
+| Default backend | `local` when env var unset . production default flip happens in Step 3 |
 | Public API stability | `BlueskyStorageManager`, `StorageStage`, and existing method names remain; backend selection is internal or env-driven |
 | Pinned smoke dataset | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` preprocessed run `2026_09_03-23:51:30` |
 
 `object_store.py` must expose at minimum:
 
-- `class LocalObjectStore` — filesystem operations under `DATA_ROOT`
-- `class S3ObjectStore` — wraps `lib.aws.s3.S3` with the locked policies above
-- `def resolve_object_store() -> ObjectStore` — reads env vars and returns the backend
+- `class LocalObjectStore` . filesystem operations under `DATA_ROOT`
+- `class S3ObjectStore` . wraps `lib.aws.s3.S3` with the locked policies above
+- `def resolve_object_store() -> ObjectStore` . reads env vars and returns the backend
 
 ## Ordered implementation work
 
@@ -103,7 +104,7 @@ export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 ```
 
-**S3 read smoke** — load pinned preprocessed posts from S3:
+**S3 read smoke**: load pinned preprocessed posts from S3:
 
 ```bash
 DATA_PLATFORM_STORAGE_BACKEND=s3 \
@@ -121,7 +122,7 @@ PY
 
 Expected stdout: `s3 load ok 200000` and exit code 0.
 
-**Local read smoke** — default backend still uses disk:
+**Local read smoke**: default backend still uses disk:
 
 ```bash
 PYTHONPATH=. uv run python - <<'PY'
@@ -134,7 +135,7 @@ PY
 
 Expected stdout: `local load ok 200000` when LFS blobs are present locally; if only pointers exist locally, the command may fail until `git lfs pull`, which is acceptable for local dev and does not block the S3 smoke above.
 
-**LFS pointer rejection smoke** — write attempt on pointer bytes must fail fast:
+**LFS pointer rejection smoke**: write attempt on pointer bytes must fail fast:
 
 ```bash
 PYTHONPATH=. uv run python - <<'PY'
@@ -155,7 +156,7 @@ PY
 
 Expected stdout: `pointer rejected ok`. Run only when the hour-00 file is still a pointer (before `git lfs pull` on that path).
 
-**Overwrite rejection smoke** — re-upload pinned preprocessed key without `allow_overwrite`:
+**Overwrite rejection smoke**: re-upload pinned preprocessed key without `allow_overwrite`:
 
 ```bash
 DATA_PLATFORM_STORAGE_BACKEND=s3 \

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step3.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step3.md
@@ -1,4 +1,4 @@
-# Step 3: Make S3 the default pipeline backend and remove current Bluesky LFS artifacts
+# Step 3: Make S3 the default pipeline backend and remove current LFS artifacts
 
 ## Goal
 
@@ -8,6 +8,7 @@ After Step 1 objects and Step 2 S3 reads are verified, make S3 the production st
 
 - **Step 1 merged:** `s3_migration_inventory.json` exists and all 53 objects are in S3.
 - **Step 2 merged:** `StorageManager` can read and write through `S3ObjectStore` with env-driven backend selection.
+- See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` for bucket and prefix conventions.
 - AWS credentials for verification smokes.
 
 This step does not run feature generation, does not add lifecycle rules (Step 16), and does not touch Reddit LFS.
@@ -16,7 +17,7 @@ This step does not run feature generation, does not add lifecycle rules (Step 16
 
 **Main caller:** `data_platform/utils/object_store.py` `resolve_object_store`.
 
-**Implementation slice for this PR:** change the default backend from `local` to `s3` when `DATA_PLATFORM_STORAGE_BACKEND` is unset; update `.gitattributes` and `.gitignore` so only the pinned Bluesky JSON manifests stay tracked; `git rm --cached` the 25 Bluesky parquet blobs (24 raw + 1 preprocessed) while leaving historical commits untouched; add `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/.gitkeep` or equivalent documentation in `dataset.json` comments is not allowed — use a short `README` only if needed under the allowed list.
+**Implementation slice for this PR:** change the default backend from `local` to `s3` when `DATA_PLATFORM_STORAGE_BACKEND` is unset; update `.gitattributes` and `.gitignore` so only the pinned Bluesky JSON manifests stay tracked; `git rm --cached` the 25 Bluesky parquet blobs (24 raw + 1 preprocessed) while leaving historical commits untouched; add `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/.gitkeep` or equivalent. Do not add comments to `dataset.json`. Use a short `README` only if needed under the allowed list.
 
 ## Files to inspect (read-only)
 
@@ -28,7 +29,7 @@ This step does not run feature generation, does not add lifecycle rules (Step 16
 | `/workspace/.gitattributes` | Bluesky and Reddit LFS rules |
 | `/workspace/.gitignore` | Pinned dataset un-ignore exceptions |
 | `/workspace/data_platform/scripts/verify_bluesky_s3_migration.py` | Reuse for post-cutover check |
-| `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md` | Document that production reads S3 (optional one-line note only if this file is explicitly added to allowed list — otherwise skip) |
+| `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md` | Document that production reads S3 (optional one-line note only if this file is explicitly added to allowed list; otherwise skip) |
 
 ## Files allowed to change
 
@@ -36,13 +37,13 @@ This step does not run feature generation, does not add lifecycle rules (Step 16
 - `/workspace/.gitattributes` (remove Bluesky pinned-dataset parquet LFS rule only)
 - `/workspace/.gitignore` (stop un-ignoring Bluesky parquet paths; keep JSON manifest exceptions)
 - Git index only for:
-  - removal from tracking of `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/**/*.parquet`
-  - removal from tracking of `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/**/*.parquet`
+ - removal from tracking of `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/**/*.parquet`
+ - removal from tracking of `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/**/*.parquet`
 - Retain in git as normal files:
-  - `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json`
-  - `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/metadata.json`
-  - `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json`
-  - `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json`
+ - `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json`
+ - `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/metadata.json`
+ - `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json`
+ - `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json`
 
 Temporary smoke evidence under `experiments/bluesky_s3_default_backend_smoke_2026_09_05/` may be committed for review and must be deleted before merge.
 
@@ -97,7 +98,7 @@ export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 ```
 
-**Default backend is S3** — unset env var:
+**Default backend is S3**: unset env var:
 
 ```bash
 unset DATA_PLATFORM_STORAGE_BACKEND

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step3.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step3.md
@@ -1,0 +1,190 @@
+# Step 3: Make S3 the default pipeline backend and remove current Bluesky LFS artifacts
+
+## Goal
+
+After Step 1 objects and Step 2 S3 reads are verified, make S3 the production storage backend for the data platform. Remove the pinned Bluesky parquet files from Git LFS tracking without rewriting repository history. Keep JSON manifests (`dataset.json`, run `metadata.json`, and the Step 1 migration inventory) in git as ordinary text files.
+
+## Dependencies
+
+- **Step 1 merged:** `s3_migration_inventory.json` exists and all 53 objects are in S3.
+- **Step 2 merged:** `StorageManager` can read and write through `S3ObjectStore` with env-driven backend selection.
+- AWS credentials for verification smokes.
+
+This step does not run feature generation, does not add lifecycle rules (Step 16), and does not touch Reddit LFS.
+
+## Main caller and implementation slice
+
+**Main caller:** `data_platform/utils/object_store.py` `resolve_object_store`.
+
+**Implementation slice for this PR:** change the default backend from `local` to `s3` when `DATA_PLATFORM_STORAGE_BACKEND` is unset; update `.gitattributes` and `.gitignore` so only the pinned Bluesky JSON manifests stay tracked; `git rm --cached` the 25 Bluesky parquet blobs (24 raw + 1 preprocessed) while leaving historical commits untouched; add `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/.gitkeep` or equivalent documentation in `dataset.json` comments is not allowed — use a short `README` only if needed under the allowed list.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/data_platform/utils/object_store.py` | Backend resolution from Step 2 |
+| `/workspace/data_platform/utils/storage.py` | `DATA_ROOT` and manager entry points |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json` | Post-removal verification source of truth |
+| `/workspace/.gitattributes` | Bluesky and Reddit LFS rules |
+| `/workspace/.gitignore` | Pinned dataset un-ignore exceptions |
+| `/workspace/data_platform/scripts/verify_bluesky_s3_migration.py` | Reuse for post-cutover check |
+| `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md` | Document that production reads S3 (optional one-line note only if this file is explicitly added to allowed list — otherwise skip) |
+
+## Files allowed to change
+
+- `/workspace/data_platform/utils/object_store.py` (default backend flip only)
+- `/workspace/.gitattributes` (remove Bluesky pinned-dataset parquet LFS rule only)
+- `/workspace/.gitignore` (stop un-ignoring Bluesky parquet paths; keep JSON manifest exceptions)
+- Git index only for:
+  - removal from tracking of `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/**/*.parquet`
+  - removal from tracking of `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/**/*.parquet`
+- Retain in git as normal files:
+  - `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json`
+  - `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/metadata.json`
+  - `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json`
+  - `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json`
+
+Temporary smoke evidence under `experiments/bluesky_s3_default_backend_smoke_2026_09_05/` may be committed for review and must be deleted before merge.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/scripts/migrate_bluesky_lfs_to_s3.py`
+- `/workspace/data_platform/ingestion/data_dumps/bluesky/data/**` (dump LFS stays)
+- `/workspace/data_platform/data/reddit/**`
+- `/workspace/.gitattributes` lines for Reddit or dump parquet (only remove the Bluesky pipeline rule)
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/data_platform/preprocessing/**`
+- `/workspace/data_platform/ingestion/sync_bluesky.py`
+- `/workspace/CHANGELOG.md`
+- Any file under `/workspace/tests/`
+- Any git history rewrite (`git filter-repo`, `git lfs migrate export`, force push)
+- Any file outside the allowed list
+
+## Locked contracts
+
+| Item | Value |
+|------|-------|
+| Production default backend | `s3` when `DATA_PLATFORM_STORAGE_BACKEND` is unset |
+| Local override | `DATA_PLATFORM_STORAGE_BACKEND=local` for development |
+| Bucket | `mirrorview-experimental-artifacts` |
+| Region | `us-east-2` |
+| S3 key prefix | `data_platform/data/` |
+| Parquet removed from git | Only under `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/` (25 parquet files) |
+| JSON kept in git | `dataset.json`, both `metadata.json` files, `s3_migration_inventory.json` |
+| Dump LFS untouched | `data_platform/ingestion/data_dumps/bluesky/data/parquet/**` remains LFS |
+| Reddit LFS untouched | All `data_platform/data/reddit/**` rules and files unchanged |
+| History | No force push, no LFS history rewrite, no `git filter-repo` |
+| Removal mechanism | `git rm --cached` on parquet paths only; working-tree copies may remain ignored locally |
+| `.gitattributes` change | Delete line `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**/*.parquet filter=lfs diff=lfs merge=lfs -text` |
+| Verification | `git lfs ls-files` must not list any path under the pinned Bluesky dataset after this PR |
+
+## Ordered implementation work
+
+1. Flip `resolve_object_store()` default to `s3` while preserving explicit `local` override.
+2. Update `.gitignore` so JSON manifests under the pinned dataset remain tracked but parquet paths are ignored.
+3. Remove the Bluesky pipeline LFS rule from `.gitattributes`.
+4. Run `git rm --cached` for all 25 parquet files under the pinned dataset.
+5. Confirm JSON manifests and inventory remain staged as normal git files.
+6. Run live smokes: default-backend S3 read, migration inventory verification, and `git lfs ls-files` grep returns empty for pinned dataset.
+7. Delete temporary smoke directory before merge.
+
+## Live smoke and basic check commands
+
+Export AWS credentials:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+```
+
+**Default backend is S3** — unset env var:
+
+```bash
+unset DATA_PLATFORM_STORAGE_BACKEND
+PYTHONPATH=. uv run python - <<'PY'
+from data_platform.utils.storage import BlueskyStorageManager, StorageStage
+storage = BlueskyStorageManager(StorageStage.PREPROCESSED, "bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73")
+df = storage.load_records(latest=True)
+assert len(df) == 200000
+print("default s3 backend ok", len(df))
+PY
+```
+
+Expected stdout: `default s3 backend ok 200000` and exit code 0.
+
+**Local override still works** for developers with LFS blobs pulled:
+
+```bash
+DATA_PLATFORM_STORAGE_BACKEND=local \
+PYTHONPATH=. uv run python - <<'PY'
+from data_platform.utils.storage import BlueskyStorageManager, StorageStage
+from data_platform.utils.object_store import resolve_object_store
+assert resolve_object_store().__class__.__name__ == "LocalObjectStore"
+print("local override ok")
+PY
+```
+
+Expected stdout: `local override ok`.
+
+**Migration inventory still valid:**
+
+```bash
+PYTHONPATH=. uv run python data_platform/scripts/verify_bluesky_s3_migration.py
+```
+
+Expected stdout: `OK: 53/53 objects present with matching sha256`.
+
+**No Bluesky pipeline parquet in LFS index:**
+
+```bash
+git lfs ls-files | grep "data_platform/data/bluesky/bluesky_7e2c4a91" || echo "no bluesky pipeline lfs"
+```
+
+Expected stdout: `no bluesky pipeline lfs`.
+
+**JSON manifests still tracked:**
+
+```bash
+git ls-files "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/*.json"
+git ls-files "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**/metadata.json"
+git ls-files "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json"
+```
+
+Expected: paths printed for `dataset.json`, both `metadata.json` files, and `s3_migration_inventory.json`.
+
+**Dump and Reddit LFS unchanged:**
+
+```bash
+git lfs ls-files | grep -E "data_dumps/bluesky|data/reddit" | wc -l
+```
+
+Expected: a positive count (currently 27: 24 dump parquet + 3 Reddit parquet). Exact number may vary if Reddit changes elsewhere; fail only if this count drops.
+
+## Acceptance criteria
+
+- Unset `DATA_PLATFORM_STORAGE_BACKEND` reads pinned preprocessed data from S3 successfully.
+- Twenty-five Bluesky pipeline parquet files are no longer tracked by git or Git LFS.
+- JSON manifests and `s3_migration_inventory.json` remain committed as normal files.
+- Reddit LFS and Bluesky dump LFS rules are untouched.
+- No git history rewrite.
+- `verify_bluesky_s3_migration.py` still passes.
+
+## Failure conditions
+
+- Any pinned Bluesky parquet remains in `git lfs ls-files`.
+- `dataset.json` or run `metadata.json` files are removed from git.
+- Reddit or dump LFS rules are deleted or modified incorrectly.
+- Default backend remains `local`.
+- S3 keys or bucket change from locked values.
+- Git history is rewritten or force-pushed.
+- Pipeline code starts requiring local parquet copies in CI without documenting `DATA_PLATFORM_STORAGE_BACKEND=local` override.
+
+## PR artifact and commit rules
+
+- One independently mergeable PR.
+- Separate commits recommended: (1) default backend flip, (2) gitignore/gitattributes and `git rm --cached`.
+- Include in the PR description the explicit list of 25 removed parquet paths and confirmation that dump LFS is unchanged.
+- Temporary smoke artifacts under `experiments/bluesky_s3_default_backend_smoke_2026_09_05/` may be committed for review; delete before merge.
+- Do not add or run automated tests.
+- Do not edit `plan.md` or other step specs.
+- PR title suggestion: `Default data platform storage to S3 and drop Bluesky pipeline LFS`.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md
@@ -2,11 +2,14 @@
 
 ## Goal
 
-Make OpenAI Batch labeling resumable across process crashes without creating duplicate provider jobs or duplicate charges. Persist `input_file_id` and `batch_id` before polling begins, reattach to the same in-flight batch after interruption, keep successful rows from partly failed batches, retry only transient failures up to four attempts per record, and mark a feature complete only when every pinned input id has exactly one valid output row.
+Make OpenAI Batch labeling resumable across process crashes without creating duplicate provider jobs or duplicate charges. Persist `input_file_id` and `batch_id` before polling begins. Reattach to the same in-flight batch after interruption and keep successful rows from partly failed batches. Retry only transient failures up to four attempts per record. Mark a feature complete only when every pinned input id has exactly one valid output row.
 
-## Real dependencies
+## Dependencies
 
-Steps 1 through 3 from `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` must be merged first. Production reads and writes must go through the S3-backed pipeline storage added in Step 2 and defaulted in Step 3. This step does not add S3 shard layout or Parquet shard writers; Step 5 owns durable shard files. This step only hardens the OpenAI Batch engine and the orchestrator hooks it needs for crash-safe provider job identity.
+- **None.** This step may run in parallel with Steps 1 and 2.
+- See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` for pinned campaign constants and the `active_openai_batch.json` state contract.
+
+This step hardens the OpenAI Batch engine only. It defines provider state independent of storage backend. Step 5 persists campaign state in S3. This step does not add campaign S3 layout, smoke tooling, or watcher comments.
 
 Pinned campaign inputs used in smoke and later steps:
 
@@ -15,9 +18,9 @@ Pinned campaign inputs used in smoke and later steps:
 - Preprocessed run: `2026_09_03-23:51:30`
 - Expected unique input ids: `200000`
 
-## Main caller and one implementation slice
+## Main caller and implementation slice
 
-**Main caller after this PR merges:**
+**Main caller after this PR merges (legacy mode smoke; campaign flags arrive in Step 5):**
 
 ```bash
 cd /workspace
@@ -27,29 +30,29 @@ export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
   --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
   --features is_news_or_opinion \
-  --batch-size 2000 \
-  --checkpoint <FEATURE_RUN_TIMESTAMP>
+  --batch-size 2000
 ```
 
-**One implementation slice for this PR:** split `_submit_and_wait_for_batch` in `data_platform/generate_features/engines/openai_engine.py` into explicit submit, durable state write, poll-or-resume, and partial-result parse paths. Add one small state module that atomically writes and reloads `{input_file_id, batch_id, task_uris, feature_name, campaign_id}` before the first poll call.
+**One implementation slice for this PR:** split `_submit_and_wait_for_batch` in `data_platform/generate_features/engines/openai_engine.py` into explicit submit, durable state write, poll-or-resume, and partial-result parse paths. Add one small state module that defines the `active_openai_batch.json` contract and writes or reloads state before the first poll call. Storage backend is pluggable; Step 5 maps this contract to S3.
 
-**Out of scope for this PR:** immutable 2000-row S3 Parquet shards, `manifest.json`, `progress.jsonl`, ten-post smoke cost reports, campaign approval gate, watcher comments, lifecycle tagging, and any change to feature prompt text or registry membership.
+**Out of scope for this PR:** campaign S3 prefix layout, `manifest.json`, `progress.jsonl`, Q44 provenance columns on rows, ten-post smoke cost reports, watcher comments, lifecycle tagging, `--campaign-id`, `--preprocessed-run`, and any change to feature prompt text or registry membership.
 
 ## Files to inspect (read-only)
 
 | Path | Why |
 |------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | Locked campaign constants |
 | `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Parent plan Step 4 scope |
-| `/workspace/data_platform/generate_features/engines/openai_engine.py` | Current submit-and-wait flow; no persisted provider ids |
-| `/workspace/data_platform/generate_features/engines/base.py` | Blocking batch loop, deadletter on whole-batch failure |
-| `/workspace/data_platform/generate_features/generate_features.py` | Feature completion gate and metadata flush |
+| `/workspace/data_platform/generate_features/engines/openai_engine.py` | Current submit-and-wait flow |
+| `/workspace/data_platform/generate_features/engines/base.py` | Blocking batch loop |
+| `/workspace/data_platform/generate_features/generate_features.py` | Feature completion gate |
 | `/workspace/data_platform/generate_features/metadata.py` | Run metadata shape |
-| `/workspace/data_platform/generate_features/models.py` | `FeatureRunConfig.max_label_retries` default |
-| `/workspace/data_platform/generate_features/llm_retry.py` | Current retry decorator retries all exceptions |
+| `/workspace/data_platform/generate_features/models.py` | `FeatureRunConfig.max_label_retries` |
+| `/workspace/data_platform/generate_features/llm_retry.py` | Current retry decorator |
 | `/workspace/data_platform/generate_features/deadletter.py` | Deadletter record shape |
-| `/workspace/data_platform/generate_features/platform_cli.py` | Checkpoint resume entry |
+| `/workspace/data_platform/generate_features/platform_cli.py` | CLI entry |
 | `/workspace/data_platform/generate_features/registry.py` | Seven OpenAI LLM features |
-| `/workspace/data_platform/utils/storage.py` | Append and resume reads after Step 3 S3 backend |
+| `/workspace/data_platform/utils/storage.py` | Append and resume reads |
 | `/workspace/lib/load_env_vars.py` | `OPENAI_API_KEY` loading |
 | `/workspace/lib/constants.py` | `DEFAULT_LLM_MODEL` (`gpt-5.4-nano`) |
 
@@ -58,51 +61,51 @@ PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_feat
 - `/workspace/data_platform/generate_features/engines/openai_engine.py`
 - `/workspace/data_platform/generate_features/engines/base.py` (only hooks needed for partial batch success and per-record retry accounting)
 - `/workspace/data_platform/generate_features/openai_batch_state.py` (new)
-- `/workspace/data_platform/generate_features/generate_features.py` (completion rule: complete when every pinned id has a label, not when `failed_batches > 0` from an earlier transient streak)
-- `/workspace/data_platform/generate_features/metadata.py` (optional fields for active provider job identity; do not break existing local metadata readers)
-- `/workspace/data_platform/generate_features/models.py` (raise default `max_label_retries` to `4` for campaign runs only if needed; keep backward-compatible default for non-campaign CLI use)
-- `/workspace/data_platform/generate_features/smoke_resume_openai_batch.py` (new temporary smoke helper for this PR; see commands below)
+- `/workspace/data_platform/generate_features/generate_features.py` (completion rule: complete when every pinned id has a label)
+- `/workspace/data_platform/generate_features/metadata.py` (optional fields for active provider job identity)
+- `/workspace/data_platform/generate_features/models.py` (raise default `max_label_retries` to `4` for campaign runs if needed)
+- `/workspace/data_platform/generate_features/smoke_resume_openai_batch.py` (new temporary smoke helper)
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md` (this file only if correcting the spec during implementation)
 
 ## Files forbidden to change
 
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step6.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step7.md`
-- `/workspace/tests/**` (do not add, edit, or run automated tests)
-- `/workspace/data_platform/generate_features/is_*/*.py` feature prompt modules
-- `/workspace/data_platform/generate_features/political_stance/generate_feature.py`
-- `/workspace/data_platform/generate_features/llm_toxicity_tiered/generate_feature.py`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md` through `step7.md`
+- `/workspace/tests/**`
+- Feature prompt modules under `/workspace/data_platform/generate_features/is_*`, `political_stance`, and `llm_toxicity_tiered`
 - `/workspace/webapp/**`
 - `/workspace/experiments/**`
 - Any repository code that launches Cursor agents or other autonomous agent runners
 
 ## Locked contracts
 
+See `campaign_contract.md`. This step owns engine behavior only.
+
 ### Blocking engine and one active OpenAI Batch job
 
 Keep the blocking engine model. For one feature run at a time, at most one OpenAI Batch job may be in flight. Do not submit a second batch for the same feature until the current batch reaches a terminal provider status or is explicitly abandoned in deadletter after four failed attempts per remaining record.
 
-### Provider identity persistence
+### `active_openai_batch.json` state contract (storage agnostic)
 
-Before the first `batches.retrieve` poll call, atomically persist a JSON state file next to the active feature run with at least:
+Before the first `batches.retrieve` poll call, persist state with at least:
 
-```json
-{
-  "campaign_id": "bluesky_2026_09_03_235130_llm_features_v1",
-  "feature_name": "is_news_or_opinion",
-  "input_file_id": "file-...",
-  "batch_id": "batch_...",
-  "task_uris": ["at://...", "..."],
-  "submitted_at": "2026-09-05T18:30:00Z",
-  "status": "polling"
-}
-```
+| Field | Meaning |
+|-------|---------|
+| `input_file_id` | OpenAI files id for the submitted batch input |
+| `batch_id` | OpenAI Batch provider id |
+| `logical_batch_index` | Zero-based canonical part index this job will populate |
+| `pending_source_record_ids` | Ordered ids still expected from this provider job |
+| `attempt_count` | Per-job attempt counter |
+| `state` | `polling`, `writing`, or `terminal` |
+| `campaign_id` | `bluesky_2026_09_03_235130_llm_features_v1` when in campaign mode |
+| `feature_name` | Feature being labeled |
+| `submitted_at` | UTC timestamp |
 
-On resume, if this state file exists and provider status is non-terminal, reload it and continue polling the same `batch_id`. Never call `files.create` or `batches.create` again for that in-flight job.
+On resume, if state exists and provider status is non-terminal, reload it and continue polling the same `batch_id`. Never call `files.create` or `batches.create` again for that in-flight job.
 
-Clear the state file only after all successful rows from that batch are durably written and every still-missing id in the batch has either succeeded on retry or landed in deadletter with four attempts recorded.
+Clear state only after all successful rows from that provider job are durably written to an immutable batch object and recorded in `manifest.json`, and every still-missing id has either succeeded on retry or landed in deadletter with four attempts recorded.
+
+Step 5 stores this contract at `{feature}/active_openai_batch.json` in S3 with conditional atomic replace.
 
 ### Partial batch success
 
@@ -120,10 +123,6 @@ Per-record attempt budget: four attempts total, including the first try.
 
 Completion for a feature requires exactly one valid output row per pinned input id from the campaign input set. Duplicate outputs for the same `source_record_id` are forbidden. Missing ids keep the feature `in_progress`.
 
-### Retry count alignment
-
-Campaign runs use `max_label_retries=4`, which means four attempts per record under the locked contract above. Do not introduce a second retry counter with a different meaning.
-
 ## Ordered implementation work
 
 1. Add `openai_batch_state.py` with atomic write, load, and clear helpers keyed by feature run directory and feature name.
@@ -134,7 +133,7 @@ Campaign runs use `max_label_retries=4`, which means four attempts per record un
 6. Add `smoke_resume_openai_batch.py` that submits a tiny live batch, writes state, sleeps, exits, and documents the exact resume command.
 7. Run the live smoke commands in this spec. Commit temporary smoke evidence. Delete temporary smoke helper and evidence before merge.
 
-## Exact live smoke/basic check commands with expected output
+## Exact live smoke and basic check commands with expected output
 
 ### Offline wiring check (no OpenAI call)
 
@@ -151,9 +150,11 @@ state = {
     'feature_name': 'is_news_or_opinion',
     'input_file_id': 'file-test',
     'batch_id': 'batch_test',
-    'task_uris': ['at://example/1'],
+    'logical_batch_index': 0,
+    'pending_source_record_ids': ['at://example/1'],
+    'attempt_count': 1,
+    'state': 'polling',
     'submitted_at': '2026-09-05T18:30:00Z',
-    'status': 'polling',
 }
 s.write_active_batch_state(d, 'is_news_or_opinion', state)
 loaded = s.load_active_batch_state(d, 'is_news_or_opinion')
@@ -170,8 +171,6 @@ openai_batch_state wiring OK
 
 ### Live partial-success check (requires `OPENAI_API_KEY`)
 
-Use the temporary helper added in this PR with exactly three posts, one intentionally empty-text post that will fail validation, and two valid posts:
-
 ```bash
 cd /workspace
 
@@ -187,8 +186,6 @@ Expected stdout includes both of the following lines:
 partial_success_rows=2
 partial_failure_rows=1
 ```
-
-Expected filesystem effect: two valid label rows are written; one failed id is queued for retry rather than losing the successful rows.
 
 ### Live interrupt-and-resume check (requires `OPENAI_API_KEY`)
 
@@ -216,8 +213,6 @@ completed_without_resubmit=true
 labeled_count=5
 ```
 
-Expected provider behavior: exactly one `batches.create` call for the interrupted job across both commands.
-
 ## Acceptance criteria
 
 - A crash after submit and before poll resumes the same `batch_id` without a second `batches.create` for that job.
@@ -236,13 +231,12 @@ Expected provider behavior: exactly one `batches.create` call for the interrupte
 - Feature completion depends on stale `failed_batches` counters while unlabeled ids still exist.
 - Any edit under `/workspace/tests/**`.
 - Any code path that launches Cursor agents or other autonomous agent runners.
-- Changes to feature prompts, registry membership, S3 shard layout, smoke cost gate, or watcher comments.
+- Changes to feature prompts, registry membership, campaign S3 layout, smoke cost gate, or watcher comments in this PR.
 
-## PR artifact/commit rules
+## PR artifact and commit rules
 
-- Branch name: `cursor/harden-openai-batch-resume-86b0`
-- One focused commit series inside the PR; prefer separate commits for engine refactor, orchestrator completion rule, and temporary smoke helper.
+- One focused PR for engine hardening only.
 - Commit the temporary smoke helper and a short `RESUME_SMOKE_EVIDENCE.md` under `data_platform/generate_features/` during review.
-- Before merge, delete `smoke_resume_openai_batch.py` and `RESUME_SMOKE_EVIDENCE.md`, and squash or add a final cleanup commit that removes them.
+- Before merge, delete `smoke_resume_openai_batch.py` and `RESUME_SMOKE_EVIDENCE.md`.
 - PR title: `Harden OpenAI Batch feature generation and resume`
 - PR body must state: no pytest added, live smoke commands run, and temporary smoke files removed before merge.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md
@@ -1,0 +1,248 @@
+# Step 4: Harden OpenAI Batch feature generation and resume
+
+## Goal
+
+Make OpenAI Batch labeling resumable across process crashes without creating duplicate provider jobs or duplicate charges. Persist `input_file_id` and `batch_id` before polling begins, reattach to the same in-flight batch after interruption, keep successful rows from partly failed batches, retry only transient failures up to four attempts per record, and mark a feature complete only when every pinned input id has exactly one valid output row.
+
+## Real dependencies
+
+Steps 1 through 3 from `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` must be merged first. Production reads and writes must go through the S3-backed pipeline storage added in Step 2 and defaulted in Step 3. This step does not add S3 shard layout or Parquet shard writers; Step 5 owns durable shard files. This step only hardens the OpenAI Batch engine and the orchestrator hooks it needs for crash-safe provider job identity.
+
+Pinned campaign inputs used in smoke and later steps:
+
+- Campaign id: `bluesky_2026_09_03_235130_llm_features_v1`
+- Dataset id: `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73`
+- Preprocessed run: `2026_09_03-23:51:30`
+- Expected unique input ids: `200000`
+
+## Main caller and one implementation slice
+
+**Main caller after this PR merges:**
+
+```bash
+cd /workspace
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --features is_news_or_opinion \
+  --batch-size 2000 \
+  --checkpoint <FEATURE_RUN_TIMESTAMP>
+```
+
+**One implementation slice for this PR:** split `_submit_and_wait_for_batch` in `data_platform/generate_features/engines/openai_engine.py` into explicit submit, durable state write, poll-or-resume, and partial-result parse paths. Add one small state module that atomically writes and reloads `{input_file_id, batch_id, task_uris, feature_name, campaign_id}` before the first poll call.
+
+**Out of scope for this PR:** immutable 2000-row S3 Parquet shards, `manifest.json`, `progress.jsonl`, ten-post smoke cost reports, campaign approval gate, watcher comments, lifecycle tagging, and any change to feature prompt text or registry membership.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Parent plan Step 4 scope |
+| `/workspace/data_platform/generate_features/engines/openai_engine.py` | Current submit-and-wait flow; no persisted provider ids |
+| `/workspace/data_platform/generate_features/engines/base.py` | Blocking batch loop, deadletter on whole-batch failure |
+| `/workspace/data_platform/generate_features/generate_features.py` | Feature completion gate and metadata flush |
+| `/workspace/data_platform/generate_features/metadata.py` | Run metadata shape |
+| `/workspace/data_platform/generate_features/models.py` | `FeatureRunConfig.max_label_retries` default |
+| `/workspace/data_platform/generate_features/llm_retry.py` | Current retry decorator retries all exceptions |
+| `/workspace/data_platform/generate_features/deadletter.py` | Deadletter record shape |
+| `/workspace/data_platform/generate_features/platform_cli.py` | Checkpoint resume entry |
+| `/workspace/data_platform/generate_features/registry.py` | Seven OpenAI LLM features |
+| `/workspace/data_platform/utils/storage.py` | Append and resume reads after Step 3 S3 backend |
+| `/workspace/lib/load_env_vars.py` | `OPENAI_API_KEY` loading |
+| `/workspace/lib/constants.py` | `DEFAULT_LLM_MODEL` (`gpt-5.4-nano`) |
+
+## Files allowed to change
+
+- `/workspace/data_platform/generate_features/engines/openai_engine.py`
+- `/workspace/data_platform/generate_features/engines/base.py` (only hooks needed for partial batch success and per-record retry accounting)
+- `/workspace/data_platform/generate_features/openai_batch_state.py` (new)
+- `/workspace/data_platform/generate_features/generate_features.py` (completion rule: complete when every pinned id has a label, not when `failed_batches > 0` from an earlier transient streak)
+- `/workspace/data_platform/generate_features/metadata.py` (optional fields for active provider job identity; do not break existing local metadata readers)
+- `/workspace/data_platform/generate_features/models.py` (raise default `max_label_retries` to `4` for campaign runs only if needed; keep backward-compatible default for non-campaign CLI use)
+- `/workspace/data_platform/generate_features/smoke_resume_openai_batch.py` (new temporary smoke helper for this PR; see commands below)
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md` (this file only if correcting the spec during implementation)
+
+## Files forbidden to change
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step6.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step7.md`
+- `/workspace/tests/**` (do not add, edit, or run automated tests)
+- `/workspace/data_platform/generate_features/is_*/*.py` feature prompt modules
+- `/workspace/data_platform/generate_features/political_stance/generate_feature.py`
+- `/workspace/data_platform/generate_features/llm_toxicity_tiered/generate_feature.py`
+- `/workspace/webapp/**`
+- `/workspace/experiments/**`
+- Any repository code that launches Cursor agents or other autonomous agent runners
+
+## Locked contracts
+
+### Blocking engine and one active OpenAI Batch job
+
+Keep the blocking engine model. For one feature run at a time, at most one OpenAI Batch job may be in flight. Do not submit a second batch for the same feature until the current batch reaches a terminal provider status or is explicitly abandoned in deadletter after four failed attempts per remaining record.
+
+### Provider identity persistence
+
+Before the first `batches.retrieve` poll call, atomically persist a JSON state file next to the active feature run with at least:
+
+```json
+{
+  "campaign_id": "bluesky_2026_09_03_235130_llm_features_v1",
+  "feature_name": "is_news_or_opinion",
+  "input_file_id": "file-...",
+  "batch_id": "batch_...",
+  "task_uris": ["at://...", "..."],
+  "submitted_at": "2026-09-05T18:30:00Z",
+  "status": "polling"
+}
+```
+
+On resume, if this state file exists and provider status is non-terminal, reload it and continue polling the same `batch_id`. Never call `files.create` or `batches.create` again for that in-flight job.
+
+Clear the state file only after all successful rows from that batch are durably written and every still-missing id in the batch has either succeeded on retry or landed in deadletter with four attempts recorded.
+
+### Partial batch success
+
+Replace whole-batch failure when OpenAI returns mixed success and error lines. Parse output and error files separately. Write every successful structured row immediately. Retry only the failed custom ids, up to four attempts per record, using the same blocking one-batch-at-a-time rule for each retry batch.
+
+Do not discard successful rows because another row in the same provider batch failed.
+
+### Transient failure policy
+
+Retry only transient provider and transport failures: `APIConnectionError`, `InternalServerError`, `RateLimitError`, HTTP 429, and HTTP 5xx. Non-transient schema, auth, and validation failures go straight to deadletter for that record after one non-retryable failure.
+
+Per-record attempt budget: four attempts total, including the first try.
+
+### Exact input id completeness
+
+Completion for a feature requires exactly one valid output row per pinned input id from the campaign input set. Duplicate outputs for the same `source_record_id` are forbidden. Missing ids keep the feature `in_progress`.
+
+### Retry count alignment
+
+Campaign runs use `max_label_retries=4`, which means four attempts per record under the locked contract above. Do not introduce a second retry counter with a different meaning.
+
+## Ordered implementation work
+
+1. Add `openai_batch_state.py` with atomic write, load, and clear helpers keyed by feature run directory and feature name.
+2. Refactor `openai_engine.py` so submit persists `input_file_id` and `batch_id` before polling, and poll uses `wait_for_completed_batch(batch_id)` on resume instead of creating a new batch.
+3. Change output parsing so successful lines become rows even when the error file is non-empty; collect failed custom ids for targeted retry batches instead of raising on the first error line.
+4. Restrict `retry_llm_completion` for OpenAI Batch paths to transient exception types only, or add an OpenAI-specific retry wrapper used by the engine.
+5. Update `generate_features.py` completion logic so a feature can finish when every pinned id is labeled, even if earlier batches logged transient failures that later retries cleared.
+6. Add `smoke_resume_openai_batch.py` that submits a tiny live batch, writes state, sleeps, exits, and documents the exact resume command.
+7. Run the live smoke commands in this spec. Commit temporary smoke evidence. Delete temporary smoke helper and evidence before merge.
+
+## Exact live smoke/basic check commands with expected output
+
+### Offline wiring check (no OpenAI call)
+
+```bash
+cd /workspace
+
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features import openai_batch_state as s
+from pathlib import Path
+import tempfile
+d = Path(tempfile.mkdtemp())
+state = {
+    'campaign_id': 'bluesky_2026_09_03_235130_llm_features_v1',
+    'feature_name': 'is_news_or_opinion',
+    'input_file_id': 'file-test',
+    'batch_id': 'batch_test',
+    'task_uris': ['at://example/1'],
+    'submitted_at': '2026-09-05T18:30:00Z',
+    'status': 'polling',
+}
+s.write_active_batch_state(d, 'is_news_or_opinion', state)
+loaded = s.load_active_batch_state(d, 'is_news_or_opinion')
+assert loaded['batch_id'] == 'batch_test'
+print('openai_batch_state wiring OK')
+"
+```
+
+Expected stdout:
+
+```text
+openai_batch_state wiring OK
+```
+
+### Live partial-success check (requires `OPENAI_API_KEY`)
+
+Use the temporary helper added in this PR with exactly three posts, one intentionally empty-text post that will fail validation, and two valid posts:
+
+```bash
+cd /workspace
+
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_resume_openai_batch.py \
+  --mode partial-success \
+  --feature is_news_or_opinion \
+  --post-count 3
+```
+
+Expected stdout includes both of the following lines:
+
+```text
+partial_success_rows=2
+partial_failure_rows=1
+```
+
+Expected filesystem effect: two valid label rows are written; one failed id is queued for retry rather than losing the successful rows.
+
+### Live interrupt-and-resume check (requires `OPENAI_API_KEY`)
+
+```bash
+cd /workspace
+
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_resume_openai_batch.py \
+  --mode interrupt \
+  --feature is_news_or_opinion \
+  --post-count 5 \
+  --stop-after-submit
+
+# In a second shell, resume the same run directory printed by the command above:
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_resume_openai_batch.py \
+  --mode resume \
+  --feature is_news_or_opinion \
+  --run-dir /tmp/<printed-run-dir>
+```
+
+Expected stdout on resume:
+
+```text
+reattached_batch_id=batch_...
+completed_without_resubmit=true
+labeled_count=5
+```
+
+Expected provider behavior: exactly one `batches.create` call for the interrupted job across both commands.
+
+## Acceptance criteria
+
+- A crash after submit and before poll resumes the same `batch_id` without a second `batches.create` for that job.
+- Mixed success and failure within one provider batch keeps successful rows and retries only failed ids.
+- Each record gets at most four attempts for transient failures.
+- A feature is marked complete only when all pinned input ids have exactly one valid output row.
+- Blocking semantics remain: one active OpenAI Batch job per feature run at a time.
+- Temporary smoke helper and smoke evidence are committed for review during the PR and removed before merge.
+- No automated tests were added or run.
+
+## Failure conditions
+
+- A resume path creates a second OpenAI Batch job for the same in-flight work.
+- A partly successful provider batch throws away successful rows.
+- Non-transient failures retry four times instead of failing fast.
+- Feature completion depends on stale `failed_batches` counters while unlabeled ids still exist.
+- Any edit under `/workspace/tests/**`.
+- Any code path that launches Cursor agents or other autonomous agent runners.
+- Changes to feature prompts, registry membership, S3 shard layout, smoke cost gate, or watcher comments.
+
+## PR artifact/commit rules
+
+- Branch name: `cursor/harden-openai-batch-resume-86b0`
+- One focused commit series inside the PR; prefer separate commits for engine refactor, orchestrator completion rule, and temporary smoke helper.
+- Commit the temporary smoke helper and a short `RESUME_SMOKE_EVIDENCE.md` under `data_platform/generate_features/` during review.
+- Before merge, delete `smoke_resume_openai_batch.py` and `RESUME_SMOKE_EVIDENCE.md`, and squash or add a final cleanup commit that removes them.
+- PR title: `Harden OpenAI Batch feature generation and resume`
+- PR body must state: no pytest added, live smoke commands run, and temporary smoke files removed before merge.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md
@@ -1,16 +1,18 @@
-# Step 5: Write resumable 2,000-row Parquet feature shards
+# Step 5: Write resumable 2,000-row Parquet feature batches
 
 ## Goal
 
-Write immutable S3-backed feature artifacts for the Bluesky LLM campaign: 2,000-row Parquet batch shards, one consolidated `final.parquet`, a SHA-256 `manifest.json`, append-only `progress.jsonl`, and error records. Preserve deterministic record order across resume and consolidation. Keep one blocking OpenAI Batch job per feature and reuse the hardened resume behavior from Step 4.
+Write immutable S3-backed feature artifacts for the Bluesky LLM campaign: 2,000-row Parquet batch objects, one consolidated `final.parquet`, a SHA-256 `manifest.json`, append-only `progress.jsonl`, and error records. Preserve deterministic record order across resume and consolidation. Keep one blocking OpenAI Batch job per feature and reuse the hardened resume behavior from Step 4.
 
-## Real dependencies
+## Dependencies
 
-- Step 4 merged: persisted `input_file_id` and `batch_id`, partial success retention, four-attempt transient retry, exact input id completeness.
-- Steps 1 through 3 merged: S3 production backend under `s3://mirrorview-experimental-artifacts/data_platform/data/`.
-- Pinned campaign constants from the parent plan.
+- **Step 2 merged:** S3 object store with conditional put support.
+- **Step 4 merged:** `active_openai_batch.json` state contract, partial success retention, four-attempt transient retry, exact input id completeness.
+- See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` for the full layout and Q44 schema.
 
-## Main caller and one implementation slice
+This step may start after Steps 2 and 4 merge. It does not require Steps 1 or 3.
+
+## Main caller and implementation slice
 
 **Main caller after this PR merges:**
 
@@ -21,147 +23,165 @@ export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
 PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
   --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
   --features is_news_or_opinion \
-  --batch-size 2000 \
-  --campaign-id bluesky_2026_09_03_235130_llm_features_v1
+  --batch-size 2000
 ```
 
-**One implementation slice for this PR:** add an S3 shard writer that, after each completed OpenAI Batch of up to 2000 records, writes one immutable Parquet object under `batches/`, appends one `progress.jsonl` line, updates `manifest.json` with SHA-256 only, and never mutates an existing shard object.
+**One implementation slice for this PR:** add campaign mode flags (`--campaign-id`, `--preprocessed-run`) to `generate_bluesky_features.py`, persist `active_openai_batch.json` in S3, write immutable batch objects under `batches/part-NNNNN.parquet`, implement logical append for `progress.jsonl` and `errors.jsonl`, conditionally replace `manifest.json`, and never mutate an existing batch object.
 
-**Out of scope for this PR:** ten-post smoke cost gate, parent-issue cost aggregation, deliberate interrupt smoke beyond one shard write/resume proof, watcher GitHub comments, Step 16 lifecycle rule infrastructure, and joining seven features into one wide artifact.
+**Out of scope for this PR:** ten-post smoke cost tooling (Step 6), watcher GitHub comments (Step 7), Step 16 lifecycle rule infrastructure, and joining seven features into one wide artifact.
 
 ## Files to inspect (read-only)
 
 | Path | Why |
 |------|-----|
-| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Parent plan Step 5 scope |
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | Canonical S3 layout and Q44 schema |
 | `/workspace/data_platform/generate_features/engines/openai_engine.py` | Batch completion hook point after Step 4 |
-| `/workspace/data_platform/generate_features/engines/base.py` | Batch loop and write callback |
 | `/workspace/data_platform/generate_features/generate_features.py` | Orchestrator and completion checks |
-| `/workspace/data_platform/generate_features/metadata.py` | Existing local metadata; do not break resume |
-| `/workspace/data_platform/generate_features/models.py` | Label row models and run config |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Bluesky CLI wrapper |
+| `/workspace/data_platform/generate_features/platform_cli.py` | CLI flags |
 | `/workspace/data_platform/generate_features/registry.py` | Seven LLM features |
-| `/workspace/data_platform/generate_features/platform_cli.py` | CLI flags for campaign id and batch size |
-| `/workspace/data_platform/utils/storage.py` | Post-Step-3 storage abstraction |
+| `/workspace/data_platform/utils/storage.py` | Post-Step-2 S3 storage abstraction; Step 3 default-backend flip is not required for this step |
 | `/workspace/lib/aws/s3.py` | Low-level S3 upload and list helpers |
-| `/workspace/data_platform/utils/platform_specific_columns.py` | `source_record_id` column contract |
 | `/workspace/data_platform/generate_features/is_news_or_opinion/generate_feature.py` | Example output schema |
 
 ## Files allowed to change
 
-- `/workspace/data_platform/generate_features/s3_feature_campaign.py` (new; campaign paths, manifest, progress, shard write)
-- `/workspace/data_platform/generate_features/s3_feature_shards.py` (new; immutable shard writer and final consolidation)
-- `/workspace/data_platform/generate_features/generate_features.py` (wire shard writer after each durable batch)
-- `/workspace/data_platform/generate_features/platform_cli.py` (add `--campaign-id`; enforce `--batch-size 2000` for campaign runs)
+- `/workspace/data_platform/generate_features/s3_feature_campaign.py` (new; campaign paths, manifest, progress, batch write)
+- `/workspace/data_platform/generate_features/s3_feature_batches.py` (new; immutable batch writer and final consolidation)
+- `/workspace/data_platform/generate_features/generate_features.py` (wire batch writer after each durable batch)
+- `/workspace/data_platform/generate_features/generate_bluesky_features.py` (pass through `--campaign-id` and `--preprocessed-run`)
+- `/workspace/data_platform/generate_features/platform_cli.py` (add `--campaign-id` and `--preprocessed-run`; enforce `--batch-size 2000` and exactly one `--features` value for campaign runs)
 - `/workspace/data_platform/generate_features/models.py` (campaign config fields if needed)
-- `/workspace/data_platform/generate_features/smoke_write_s3_shard.py` (new temporary smoke helper)
+- `/workspace/data_platform/generate_features/smoke_write_s3_batch.py` (new temporary smoke helper)
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md` (this file only if correcting the spec during implementation)
 
 ## Files forbidden to change
 
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step6.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step7.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md`, `step6.md`, `step7.md`
 - `/workspace/tests/**`
-- Feature prompt modules under `/workspace/data_platform/generate_features/is_*`, `political_stance`, and `llm_toxicity_tiered`
+- Feature prompt modules
 - `/workspace/webapp/**`
 - `/workspace/experiments/**`
 - Any repository code that launches Cursor agents or other autonomous agent runners
 
 ## Locked contracts
 
-### Campaign constants
+See `campaign_contract.md`. Exact values for this step:
 
-- Campaign id: `bluesky_2026_09_03_235130_llm_features_v1`
-- Dataset id: `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73`
-- Preprocessed run: `2026_09_03-23:51:30`
-- Bucket: `mirrorview-experimental-artifacts`
-- Batch size: `2000`
-- Total expected rows per feature: `200000`
+### Feature root
 
-### S3 layout
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/`
 
-For each feature `{feature}` in the seven-feature campaign:
+### Per-feature layout
+
+For `{feature}` = `is_news_or_opinion` (smoke example):
 
 ```text
-s3://mirrorview-experimental-artifacts/data_platform/data/features/bluesky_2026_09_03_235130_llm_features_v1/{feature}/
-  batches/shard_00000.parquet
-  batches/shard_00001.parquet
+s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/
+  active_openai_batch.json
+  batches/part-00000.parquet
+  batches/part-00001.parquet
   ...
+  batches/part-00099.parquet
   final.parquet
   manifest.json
   progress.jsonl
   errors.jsonl
 ```
 
-Shard object keys are immutable. Never overwrite an existing shard key. The next shard index is derived from existing keys and progress state, not from in-memory counters alone.
+Batch object keys are immutable. Never overwrite an existing `part-NNNNN.parquet` key. A full feature run writes exactly 100 batch objects totaling 200,000 rows.
 
-### Per-row provenance from Q44
+### Production batch schedule
 
-Every label row written to a shard or to `final.parquet` must include these columns in addition to the feature-specific label fields:
+| Canonical part | Provider job size | Row composition |
+|----------------|-------------------|-----------------|
+| `part-00000` | 1,990 new posts | Ten unchanged smoke output rows (original smoke `batch_id` and `request_id` preserved) plus 1,990 new labeled rows |
+| `part-00001` through `part-00099` | 2,000 new posts each | All new labeled rows |
+
+`manifest.json` batch entry for `part_index=0` may list both the smoke provider `batch_id` and the first production provider `batch_id`.
+
+### active_openai_batch.json in S3
+
+Persist Step 4 state at `{feature}/active_openai_batch.json`. Use conditional atomic whole-object replace with S3 `If-Match` ETag for concurrency control. Delete only after successful rows are in an immutable batch object and recorded in `manifest.json`.
+
+### Logical append for progress.jsonl and errors.jsonl
+
+One feature writer:
+
+1. Reads existing object bytes (empty if missing).
+2. Appends complete newline-terminated JSON records.
+3. Conditionally replaces the whole object using `If-Match` with the prior object ETag.
+
+On conditional put failure, retry from the latest object. Immutable batch objects plus `manifest.json` are the source of truth; resume may reconstruct missing observability events.
+
+`manifest.json` uses the same conditional atomic replace pattern. SHA-256 remains the content integrity check. Never use ETag as a content hash.
+
+### Deterministic run id
+
+Every row carries `run_id` = `bluesky_2026_09_03_235130_llm_features_v1:{feature}`.
+
+### Q44 row columns
+
+Every label row in `batches/part-*.parquet` and `final.parquet` must include:
 
 | Column | Value |
 |--------|-------|
-| `campaign_id` | `bluesky_2026_09_03_235130_llm_features_v1` |
-| `dataset_id` | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
-| `source_preprocessed_run` | `2026_09_03-23:51:30` |
-| `input_content_hash` | SHA-256 hex digest of the pinned 200,000-post input set |
-| `model_id` | `gpt-5.4-nano` unless the feature spec overrides it |
-| `prompt_hash` | SHA-256 hex digest of the feature system prompt |
-| `label_timestamp` | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
 | `source_record_id` | pinned input id |
-| `openai_batch_id` | provider batch id for the batch that produced the row |
-| `batch_shard_index` | zero-based durable shard index |
-| `batch_row_index` | zero-based row position inside the shard |
+| `run_id` | `bluesky_2026_09_03_235130_llm_features_v1:{feature}` |
+| `batch_id` | OpenAI Batch provider id |
+| `request_id` | provider request id for the row |
+| `attempt_count` | integer 1 through 4 |
+| `label_timestamp` | UTC from `lib.timestamp_utils.get_current_timestamp` |
+| `{label_field}` | feature-specific raw label column |
 
-### Shared immutable metadata in `manifest.json`
+Validate the Pydantic model on the label-field subset and provenance columns separately.
 
-`manifest.json` holds campaign-level immutable metadata only. It must include:
+### manifest.json
 
-- `campaign_id`, `dataset_id`, `source_preprocessed_run`, `input_content_hash`
-- `feature`, `model_id`, `prompt_hash`
-- `batch_size`, `expected_row_count`
-- `created_at`
-- `shards`: ordered list of `{shard_index, key, row_count, sha256}`
+`manifest.json` holds campaign-level immutable metadata only:
+
+- `campaign_id`, `dataset_id`, `preprocessed_run`, `feature`, `model_id`, `prompt_hash`
+- `batch_size`, `expected_row_count`, `run_id`, `created_at`
+- `batches`: ordered list of `{part_index, key, row_count, sha256, provider_batch_ids}` (part 0 may list two provider batch ids)
 - `final_parquet`: `{key, row_count, sha256}` once built
 
-Do not store mutable counters that belong in `progress.jsonl`.
+Hash fields are SHA-256 hex digests of file bytes. Never use ETag as a content hash.
 
-### SHA-256 manifests only
+### Lifecycle tag on batch objects only
 
-Hash fields in `manifest.json` are SHA-256 hex digests of file bytes. Do not use MD5, ETag alone, or size-only checks as acceptance gates.
-
-### Lifecycle tag on batch shards only
-
-When uploading a shard under `batches/`, set S3 object tag `intermediate-artifact=true`. Do not set that tag on `final.parquet`, `manifest.json`, `progress.jsonl`, or `errors.jsonl`.
+When uploading under `batches/`, set S3 object tag `intermediate-artifact=true`. Do not set that tag on `final.parquet`, `manifest.json`, `progress.jsonl`, or `errors.jsonl`.
 
 ### Deterministic order
 
-Input ids are processed in stable ascending `source_record_id` order from the pinned preprocessed run. Shard row order follows that global order within each 2000-row chunk. Resume must continue from the next unseen id, not reorder prior shards.
+Input ids are processed in stable ascending `source_record_id` order from preprocessed run `2026_09_03-23:51:30`. Batch row order follows that global order within each 2000-row chunk.
 
-### Final consolidation
+### Campaign mode resume
 
-When all 200,000 ids are present across shards, build `final.parquet` once by concatenating shards in `batch_shard_index` order, verify row count and uniqueness, write `final.parquet` with no `intermediate-artifact` tag, and record its SHA-256 in `manifest.json`.
+Re-running the same campaign command with the same `--campaign-id`, `--preprocessed-run`, and single `--features` value automatically resumes from canonical prefix state. Do not add `--resume` or `--checkpoint`.
 
-### Blocking engine and one active batch
+### Blocking engine
 
-Reuse Step 4 behavior. Shard writing happens only after a provider batch completes and rows pass schema validation.
+Reuse Step 4 behavior. Batch writing happens only after a provider batch completes and rows pass schema validation.
 
 ## Ordered implementation work
 
-1. Add campaign path helpers in `s3_feature_campaign.py` for prefix construction and input hash computation over the pinned preprocessed run.
-2. Implement immutable shard upload with SHA-256 digest, manifest shard list update, and `progress.jsonl` append in `s3_feature_shards.py`.
-3. Attach provenance columns from Q44 on every row before Parquet write.
-4. Wire the shard writer into the batch completion path in `generate_features.py`; refuse campaign runs unless `--batch-size 2000`.
-5. Implement `final.parquet` consolidation and manifest final block when row completeness check passes.
-6. Add `errors.jsonl` append for exhausted per-record failures without mutating successful shards.
-7. Add temporary smoke helper that writes one real shard for `is_news_or_opinion`, verifies S3 keys and hashes, then exits.
-8. Run live smoke commands. Commit temporary smoke evidence. Delete helper and evidence before merge.
+1. Add campaign path helpers in `s3_feature_campaign.py` for prefix construction.
+2. Implement `active_openai_batch.json` read, conditional write, and delete in S3.
+3. Implement immutable batch upload with SHA-256 digest, manifest batch list update, and logical `progress.jsonl` append in `s3_feature_batches.py`.
+4. Attach Q44 provenance columns on every row before Parquet write.
+5. Wire the batch writer into the batch completion path; refuse campaign runs unless `--batch-size 2000` and exactly one feature.
+6. Implement `final.parquet` consolidation and manifest final block when 100 batches and 200,000 rows are present.
+7. Add `errors.jsonl` logical append for exhausted per-record failures.
+8. Add temporary smoke helper that writes one disposable batch under the non-canonical prefix `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step5_batch_writer/` only. Never write under the pinned campaign feature `batches/` prefix during this step.
+9. Run live smoke commands. Commit temporary smoke evidence. Delete disposable S3 objects, verify the disposable prefix is empty, then delete helper and Git evidence before merge.
 
-## Exact live smoke/basic check commands with expected output
+## Exact live smoke and basic check commands with expected output
 
-### Offline path and hash helper check
+### Offline path helper check
 
 ```bash
 cd /workspace
@@ -169,94 +189,121 @@ export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
 PYTHONPATH=. uv run python -c "
-from data_platform.generate_features.s3_feature_campaign import campaign_prefix, input_content_hash
-p = campaign_prefix('bluesky_2026_09_03_235130_llm_features_v1', 'is_news_or_opinion')
+from data_platform.generate_features.s3_feature_campaign import feature_prefix, run_id_for_feature
+p = feature_prefix('bluesky_2026_09_03_235130_llm_features_v1', 'is_news_or_opinion')
 assert p.endswith('features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/')
-h = input_content_hash('bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73', '2026_09_03-23:51:30')
-assert len(h) == 64
-print('campaign_prefix OK')
-print('input_content_hash OK')
+rid = run_id_for_feature('bluesky_2026_09_03_235130_llm_features_v1', 'is_news_or_opinion')
+assert rid == 'bluesky_2026_09_03_235130_llm_features_v1:is_news_or_opinion'
+print('feature_prefix OK')
+print('run_id OK')
 "
 ```
 
 Expected stdout:
 
 ```text
-campaign_prefix OK
-input_content_hash OK
+feature_prefix OK
+run_id OK
 ```
 
-### Live one-shard write check (requires `OPENAI_API_KEY` and AWS credentials)
+### Live one-batch write check (requires `OPENAI_API_KEY` and AWS credentials; available after this step's implementation)
+
+Use the disposable smoke prefix only. Do not write under the pinned campaign feature `batches/` prefix; Step 6 tooling proof and Steps 8 through 14 canonical smoke must not find pre-existing canonical batch objects from this step.
 
 ```bash
 cd /workspace
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
-PYTHONPATH=. uv run python data_platform/generate_features/smoke_write_s3_shard.py \
+DISPOSABLE_PREFIX=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step5_batch_writer/
+
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_write_s3_batch.py \
   --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
   --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
   --preprocessed-run 2026_09_03-23:51:30 \
   --feature is_news_or_opinion \
+  --smoke-prefix "$DISPOSABLE_PREFIX" \
   --row-count 10
 ```
 
 Expected stdout:
 
 ```text
-shard_key=s3://mirrorview-experimental-artifacts/data_platform/data/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/batches/shard_00000.parquet
-shard_sha256=<64-char-hex>
+smoke_prefix=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step5_batch_writer/
+batch_key=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step5_batch_writer/is_news_or_opinion/batches/part-00000.parquet
+batch_sha256=<64-char-hex>
 manifest_updated=true
 progress_appended=true
 intermediate_tag=true
+canonical_batches_prefix_touched=false
 ```
-
-Expected S3 objects after the command:
-
-- `.../batches/shard_00000.parquet` exists and is tagged `intermediate-artifact=true`
-- `.../manifest.json` lists shard 0 with matching SHA-256
-- `.../progress.jsonl` has one new line with `durable_rows=10`
 
 ### Resume-without-rewrite check
 
-Run the same command a second time without deleting S3 objects.
+Run the same command a second time without deleting disposable S3 objects.
 
 Expected stdout:
 
 ```text
-shard_rewrite_refused=true
-next_shard_index=1
+batch_rewrite_refused=true
+next_part_index=1
+canonical_batches_prefix_touched=false
 ```
 
-Expected behavior: existing `shard_00000.parquet` bytes and hash remain unchanged.
+### Disposable prefix cleanup (required before merge)
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+aws s3 rm s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step5_batch_writer/ --recursive
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step5_batch_writer/ --recursive
+```
+
+Expected: `aws s3 rm` reports deleted objects (or no objects found). `aws s3 ls` prints no lines, confirming the disposable prefix is empty.
+
+Verify the canonical campaign feature `batches/` prefix was not touched during smoke:
+
+```bash
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/batches/ 2>&1 || true
+```
+
+Expected: `An error occurred (NoSuchKey)` or empty listing. No `part-*.parquet` objects under the canonical feature `batches/` prefix.
 
 ## Acceptance criteria
 
-- Each completed batch writes at most one new immutable shard object under `batches/`.
-- Every row in shards and `final.parquet` carries the full Q44 provenance column set.
+- Each completed batch writes at most one new immutable object under `batches/`.
+- Every row carries the full Q44 column set.
 - `manifest.json` contains SHA-256 digests only and matches uploaded bytes.
-- `progress.jsonl` appends one line per durable shard write.
-- Batch shards carry `intermediate-artifact=true`; final and audit files do not.
-- Resume continues shard numbering and input order without rewriting prior shards.
-- `final.parquet` is written once with exactly 200,000 unique ids when the feature completes.
-- Temporary smoke helper and evidence are committed for review and removed before merge.
+- `progress.jsonl` appends one line per durable batch write.
+- Batch objects carry `intermediate-artifact=true`; final and audit files do not.
+- Resume continues batch numbering and input order without rewriting prior batches.
+- `final.parquet` is written once with exactly 200,000 unique ids across 100 batch objects when the feature completes.
+- `active_openai_batch.json` persists and clears per Step 4 contract.
+- Logical append and conditional replace work for `progress.jsonl`, `errors.jsonl`, and `manifest.json`.
+- Campaign mode automatically resumes on restart with the same `run_id`.
+- Live batch-writer smoke writes only under `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step5_batch_writer/` and never under the pinned campaign feature `batches/` prefix.
+- Disposable S3 prefix is empty after `aws s3 rm ... --recursive` before merge.
+- Temporary smoke helper and Git evidence are committed for review and removed before merge.
 - No automated tests were added or run.
 
 ## Failure conditions
 
-- Overwriting an existing shard key.
+- Overwriting an existing `part-NNNNN.parquet` key.
 - Missing Q44 provenance columns on any written row.
-- Using non-SHA-256 manifest hashes.
+- Using non-SHA-256 manifest hashes or accepting ETag as a content hash.
 - Applying `intermediate-artifact=true` to `final.parquet`, `manifest.json`, or `progress.jsonl`.
 - Multiple active OpenAI Batch jobs for one feature run.
+- Using `shards/`, `campaigns/`, `final/` subdirectory, or per-run timestamp subfolders.
+- Step 5 live smoke writes any object under the pinned campaign feature `batches/` prefix.
+- Disposable prefix `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step5_batch_writer/` is not empty before merge.
 - Any edit under `/workspace/tests/**`.
 - Any code path that launches Cursor agents or other autonomous agent runners.
 
-## PR artifact/commit rules
+## PR artifact and commit rules
 
-- Branch name: `cursor/s3-parquet-feature-shards-86b0`
-- Keep this PR focused on shard writing and consolidation; do not fold Step 6 smoke cost gate or Step 7 watcher comments into it.
-- Commit temporary `smoke_write_s3_shard.py` and `SHARD_SMOKE_EVIDENCE.md` during review.
-- Before merge, delete the temporary helper and evidence file.
-- PR title: `Write resumable 2,000-row Parquet feature shards to S3`
-- PR body must list the exact S3 prefix written during smoke and the shard SHA-256 observed.
+- Keep this PR focused on batch writing and consolidation; do not fold Step 6 smoke tooling or Step 7 watcher into it.
+- Commit temporary `smoke_write_s3_batch.py` and `BATCH_SMOKE_EVIDENCE.md` during review.
+- Before merge: run `aws s3 rm s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step5_batch_writer/ --recursive`, verify the disposable prefix is empty, then delete the temporary helper and Git evidence file.
+- PR title: `Write resumable 2,000-row Parquet feature batches to S3`
+- PR body must list the disposable smoke prefix, the batch SHA-256 observed, confirmation that the canonical campaign feature `batches/` prefix was not touched, and confirmation that the disposable prefix was emptied before merge.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md
@@ -1,0 +1,262 @@
+# Step 5: Write resumable 2,000-row Parquet feature shards
+
+## Goal
+
+Write immutable S3-backed feature artifacts for the Bluesky LLM campaign: 2,000-row Parquet batch shards, one consolidated `final.parquet`, a SHA-256 `manifest.json`, append-only `progress.jsonl`, and error records. Preserve deterministic record order across resume and consolidation. Keep one blocking OpenAI Batch job per feature and reuse the hardened resume behavior from Step 4.
+
+## Real dependencies
+
+- Step 4 merged: persisted `input_file_id` and `batch_id`, partial success retention, four-attempt transient retry, exact input id completeness.
+- Steps 1 through 3 merged: S3 production backend under `s3://mirrorview-experimental-artifacts/data_platform/data/`.
+- Pinned campaign constants from the parent plan.
+
+## Main caller and one implementation slice
+
+**Main caller after this PR merges:**
+
+```bash
+cd /workspace
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --features is_news_or_opinion \
+  --batch-size 2000 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1
+```
+
+**One implementation slice for this PR:** add an S3 shard writer that, after each completed OpenAI Batch of up to 2000 records, writes one immutable Parquet object under `batches/`, appends one `progress.jsonl` line, updates `manifest.json` with SHA-256 only, and never mutates an existing shard object.
+
+**Out of scope for this PR:** ten-post smoke cost gate, parent-issue cost aggregation, deliberate interrupt smoke beyond one shard write/resume proof, watcher GitHub comments, Step 16 lifecycle rule infrastructure, and joining seven features into one wide artifact.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Parent plan Step 5 scope |
+| `/workspace/data_platform/generate_features/engines/openai_engine.py` | Batch completion hook point after Step 4 |
+| `/workspace/data_platform/generate_features/engines/base.py` | Batch loop and write callback |
+| `/workspace/data_platform/generate_features/generate_features.py` | Orchestrator and completion checks |
+| `/workspace/data_platform/generate_features/metadata.py` | Existing local metadata; do not break resume |
+| `/workspace/data_platform/generate_features/models.py` | Label row models and run config |
+| `/workspace/data_platform/generate_features/registry.py` | Seven LLM features |
+| `/workspace/data_platform/generate_features/platform_cli.py` | CLI flags for campaign id and batch size |
+| `/workspace/data_platform/utils/storage.py` | Post-Step-3 storage abstraction |
+| `/workspace/lib/aws/s3.py` | Low-level S3 upload and list helpers |
+| `/workspace/data_platform/utils/platform_specific_columns.py` | `source_record_id` column contract |
+| `/workspace/data_platform/generate_features/is_news_or_opinion/generate_feature.py` | Example output schema |
+
+## Files allowed to change
+
+- `/workspace/data_platform/generate_features/s3_feature_campaign.py` (new; campaign paths, manifest, progress, shard write)
+- `/workspace/data_platform/generate_features/s3_feature_shards.py` (new; immutable shard writer and final consolidation)
+- `/workspace/data_platform/generate_features/generate_features.py` (wire shard writer after each durable batch)
+- `/workspace/data_platform/generate_features/platform_cli.py` (add `--campaign-id`; enforce `--batch-size 2000` for campaign runs)
+- `/workspace/data_platform/generate_features/models.py` (campaign config fields if needed)
+- `/workspace/data_platform/generate_features/smoke_write_s3_shard.py` (new temporary smoke helper)
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md` (this file only if correcting the spec during implementation)
+
+## Files forbidden to change
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step6.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step7.md`
+- `/workspace/tests/**`
+- Feature prompt modules under `/workspace/data_platform/generate_features/is_*`, `political_stance`, and `llm_toxicity_tiered`
+- `/workspace/webapp/**`
+- `/workspace/experiments/**`
+- Any repository code that launches Cursor agents or other autonomous agent runners
+
+## Locked contracts
+
+### Campaign constants
+
+- Campaign id: `bluesky_2026_09_03_235130_llm_features_v1`
+- Dataset id: `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73`
+- Preprocessed run: `2026_09_03-23:51:30`
+- Bucket: `mirrorview-experimental-artifacts`
+- Batch size: `2000`
+- Total expected rows per feature: `200000`
+
+### S3 layout
+
+For each feature `{feature}` in the seven-feature campaign:
+
+```text
+s3://mirrorview-experimental-artifacts/data_platform/data/features/bluesky_2026_09_03_235130_llm_features_v1/{feature}/
+  batches/shard_00000.parquet
+  batches/shard_00001.parquet
+  ...
+  final.parquet
+  manifest.json
+  progress.jsonl
+  errors.jsonl
+```
+
+Shard object keys are immutable. Never overwrite an existing shard key. The next shard index is derived from existing keys and progress state, not from in-memory counters alone.
+
+### Per-row provenance from Q44
+
+Every label row written to a shard or to `final.parquet` must include these columns in addition to the feature-specific label fields:
+
+| Column | Value |
+|--------|-------|
+| `campaign_id` | `bluesky_2026_09_03_235130_llm_features_v1` |
+| `dataset_id` | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| `source_preprocessed_run` | `2026_09_03-23:51:30` |
+| `input_content_hash` | SHA-256 hex digest of the pinned 200,000-post input set |
+| `model_id` | `gpt-5.4-nano` unless the feature spec overrides it |
+| `prompt_hash` | SHA-256 hex digest of the feature system prompt |
+| `label_timestamp` | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
+| `source_record_id` | pinned input id |
+| `openai_batch_id` | provider batch id for the batch that produced the row |
+| `batch_shard_index` | zero-based durable shard index |
+| `batch_row_index` | zero-based row position inside the shard |
+
+### Shared immutable metadata in `manifest.json`
+
+`manifest.json` holds campaign-level immutable metadata only. It must include:
+
+- `campaign_id`, `dataset_id`, `source_preprocessed_run`, `input_content_hash`
+- `feature`, `model_id`, `prompt_hash`
+- `batch_size`, `expected_row_count`
+- `created_at`
+- `shards`: ordered list of `{shard_index, key, row_count, sha256}`
+- `final_parquet`: `{key, row_count, sha256}` once built
+
+Do not store mutable counters that belong in `progress.jsonl`.
+
+### SHA-256 manifests only
+
+Hash fields in `manifest.json` are SHA-256 hex digests of file bytes. Do not use MD5, ETag alone, or size-only checks as acceptance gates.
+
+### Lifecycle tag on batch shards only
+
+When uploading a shard under `batches/`, set S3 object tag `intermediate-artifact=true`. Do not set that tag on `final.parquet`, `manifest.json`, `progress.jsonl`, or `errors.jsonl`.
+
+### Deterministic order
+
+Input ids are processed in stable ascending `source_record_id` order from the pinned preprocessed run. Shard row order follows that global order within each 2000-row chunk. Resume must continue from the next unseen id, not reorder prior shards.
+
+### Final consolidation
+
+When all 200,000 ids are present across shards, build `final.parquet` once by concatenating shards in `batch_shard_index` order, verify row count and uniqueness, write `final.parquet` with no `intermediate-artifact` tag, and record its SHA-256 in `manifest.json`.
+
+### Blocking engine and one active batch
+
+Reuse Step 4 behavior. Shard writing happens only after a provider batch completes and rows pass schema validation.
+
+## Ordered implementation work
+
+1. Add campaign path helpers in `s3_feature_campaign.py` for prefix construction and input hash computation over the pinned preprocessed run.
+2. Implement immutable shard upload with SHA-256 digest, manifest shard list update, and `progress.jsonl` append in `s3_feature_shards.py`.
+3. Attach provenance columns from Q44 on every row before Parquet write.
+4. Wire the shard writer into the batch completion path in `generate_features.py`; refuse campaign runs unless `--batch-size 2000`.
+5. Implement `final.parquet` consolidation and manifest final block when row completeness check passes.
+6. Add `errors.jsonl` append for exhausted per-record failures without mutating successful shards.
+7. Add temporary smoke helper that writes one real shard for `is_news_or_opinion`, verifies S3 keys and hashes, then exits.
+8. Run live smoke commands. Commit temporary smoke evidence. Delete helper and evidence before merge.
+
+## Exact live smoke/basic check commands with expected output
+
+### Offline path and hash helper check
+
+```bash
+cd /workspace
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.s3_feature_campaign import campaign_prefix, input_content_hash
+p = campaign_prefix('bluesky_2026_09_03_235130_llm_features_v1', 'is_news_or_opinion')
+assert p.endswith('features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/')
+h = input_content_hash('bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73', '2026_09_03-23:51:30')
+assert len(h) == 64
+print('campaign_prefix OK')
+print('input_content_hash OK')
+"
+```
+
+Expected stdout:
+
+```text
+campaign_prefix OK
+input_content_hash OK
+```
+
+### Live one-shard write check (requires `OPENAI_API_KEY` and AWS credentials)
+
+```bash
+cd /workspace
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_write_s3_shard.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --feature is_news_or_opinion \
+  --row-count 10
+```
+
+Expected stdout:
+
+```text
+shard_key=s3://mirrorview-experimental-artifacts/data_platform/data/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/batches/shard_00000.parquet
+shard_sha256=<64-char-hex>
+manifest_updated=true
+progress_appended=true
+intermediate_tag=true
+```
+
+Expected S3 objects after the command:
+
+- `.../batches/shard_00000.parquet` exists and is tagged `intermediate-artifact=true`
+- `.../manifest.json` lists shard 0 with matching SHA-256
+- `.../progress.jsonl` has one new line with `durable_rows=10`
+
+### Resume-without-rewrite check
+
+Run the same command a second time without deleting S3 objects.
+
+Expected stdout:
+
+```text
+shard_rewrite_refused=true
+next_shard_index=1
+```
+
+Expected behavior: existing `shard_00000.parquet` bytes and hash remain unchanged.
+
+## Acceptance criteria
+
+- Each completed batch writes at most one new immutable shard object under `batches/`.
+- Every row in shards and `final.parquet` carries the full Q44 provenance column set.
+- `manifest.json` contains SHA-256 digests only and matches uploaded bytes.
+- `progress.jsonl` appends one line per durable shard write.
+- Batch shards carry `intermediate-artifact=true`; final and audit files do not.
+- Resume continues shard numbering and input order without rewriting prior shards.
+- `final.parquet` is written once with exactly 200,000 unique ids when the feature completes.
+- Temporary smoke helper and evidence are committed for review and removed before merge.
+- No automated tests were added or run.
+
+## Failure conditions
+
+- Overwriting an existing shard key.
+- Missing Q44 provenance columns on any written row.
+- Using non-SHA-256 manifest hashes.
+- Applying `intermediate-artifact=true` to `final.parquet`, `manifest.json`, or `progress.jsonl`.
+- Multiple active OpenAI Batch jobs for one feature run.
+- Any edit under `/workspace/tests/**`.
+- Any code path that launches Cursor agents or other autonomous agent runners.
+
+## PR artifact/commit rules
+
+- Branch name: `cursor/s3-parquet-feature-shards-86b0`
+- Keep this PR focused on shard writing and consolidation; do not fold Step 6 smoke cost gate or Step 7 watcher comments into it.
+- Commit temporary `smoke_write_s3_shard.py` and `SHARD_SMOKE_EVIDENCE.md` during review.
+- Before merge, delete the temporary helper and evidence file.
+- PR title: `Write resumable 2,000-row Parquet feature shards to S3`
+- PR body must list the exact S3 prefix written during smoke and the shard SHA-256 observed.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step6.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step6.md
@@ -1,0 +1,310 @@
+# Step 6: Add ten-post smoke cost reports and a campaign approval gate
+
+## Goal
+
+Add a deterministic ten-post smoke path shared by all seven LLM features. Record current model pricing, average and maximum token usage per feature, estimated full-run cost, S3 artifact checks, and one deliberate interruption-and-resume proof. Aggregate all seven estimates on the parent campaign issue and block full generation until one explicit human approval is recorded. After approval, the first production shard for each feature must combine the ten smoke outputs with 1,990 new outputs.
+
+## Real dependencies
+
+- Step 4 merged: OpenAI Batch resume and partial success behavior.
+- Step 5 merged: S3 shard layout, Q44 provenance columns, immutable shards, manifest and progress files.
+- Steps 1 through 3 merged: S3 production backend and pinned dataset availability.
+- Parent plan constants and seven-feature registry.
+
+## Main caller and one implementation slice
+
+**Main caller after this PR merges:**
+
+```bash
+cd /workspace
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/bluesky_llm_campaign_smoke.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --feature is_news_or_opinion \
+  --mode smoke-and-cost
+```
+
+**One implementation slice for this PR:** implement deterministic ten-post selection, per-feature cost report JSON, S3 verification, interrupt-and-resume proof, parent aggregate report generation, and an approval gate file that full generation refuses to bypass.
+
+**Out of scope for this PR:** generating all 200,000 rows per feature, watcher GitHub comments every 10,000 rows, Step 16 lifecycle infrastructure, wide seven-feature join, and any code that posts to GitHub automatically.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Parent plan Step 6 scope |
+| `/workspace/data_platform/generate_features/smoke_openai_engine.py` | Existing smoke metrics pattern |
+| `/workspace/data_platform/generate_features/OPENAI_BATCH_SMOKE_RESULTS.md` | Published pricing and token baselines |
+| `/workspace/data_platform/generate_features/s3_feature_campaign.py` | Campaign paths after Step 5 |
+| `/workspace/data_platform/generate_features/s3_feature_shards.py` | Shard write and resume after Step 5 |
+| `/workspace/data_platform/generate_features/engines/openai_engine.py` | Batch usage fields |
+| `/workspace/data_platform/generate_features/registry.py` | Seven LLM features |
+| `/workspace/data_platform/generate_features/platform_cli.py` | Production CLI entry |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Bluesky wrapper |
+| `/workspace/lib/constants.py` | `DEFAULT_LLM_MODEL` |
+| `/workspace/lib/load_env_vars.py` | API key loading |
+
+## Files allowed to change
+
+- `/workspace/data_platform/generate_features/bluesky_llm_campaign_smoke.py` (new; smoke, cost, S3 checks, interrupt/resume)
+- `/workspace/data_platform/generate_features/campaign_cost_report.py` (new; pricing math and aggregate report builder)
+- `/workspace/data_platform/generate_features/campaign_approval_gate.py` (new; approval token file contract)
+- `/workspace/data_platform/generate_features/s3_feature_campaign.py` (extend only if needed for smoke artifact paths)
+- `/workspace/data_platform/generate_features/platform_cli.py` (refuse full campaign run without approval file)
+- `/workspace/data_platform/generate_features/deterministic_smoke_sample.py` (new; shared ten-post selector)
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/` (new; committed smoke outputs and cost JSON during PR review)
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step6.md` (this file only if correcting the spec during implementation)
+
+## Files forbidden to change
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step7.md`
+- `/workspace/tests/**`
+- Feature prompt modules under `/workspace/data_platform/generate_features/is_*`, `political_stance`, and `llm_toxicity_tiered`
+- `/workspace/webapp/**`
+- `/workspace/experiments/**`
+- Any repository code that launches Cursor agents, opens GitHub issues, or posts GitHub comments automatically
+
+## Locked contracts
+
+### Shared deterministic ten-post sample
+
+All seven features must label the same ten `source_record_id` values from the pinned preprocessed run. Selection rule:
+
+1. Load rows from preprocessed run `2026_09_03-23:51:30` for dataset `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73`.
+2. Keep rows with non-empty `text`.
+3. Sort by ascending `source_record_id`.
+4. Take the first ten rows.
+
+Write the selected ids to `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/deterministic_ten_post_ids.json` during the PR. Every feature smoke run must read that file rather than re-derive ad hoc ids.
+
+### Pricing and token estimates
+
+Use current published Batch pricing for `gpt-5.4-nano` at smoke run time. Record in each feature cost report:
+
+- pricing source URL
+- input USD per million tokens
+- output USD per million tokens
+- average input tokens per request
+- average output tokens per request
+- maximum input tokens among the ten requests
+- maximum output tokens among the ten requests
+- estimated full-run cost for 200,000 posts using both average and max token assumptions
+
+### Parent aggregate and one explicit approval
+
+Each feature smoke writes `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/{feature}_cost_report.json`.
+
+A parent aggregate file `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/parent_cost_aggregate.json` sums all seven features and must exist before full generation can start.
+
+Full generation requires an approval token file:
+
+```text
+docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/APPROVED.txt
+```
+
+Content must include the exact string `approved_by=<human>` and `approved_at=<UTC ISO timestamp>`. The production CLI refuses to run without this file. No repository code may create or mutate `APPROVED.txt`; only a human operator adds it after reviewing the parent aggregate on the parent campaign issue.
+
+### Deliberate interruption and resume
+
+Each feature smoke must perform one deliberate interrupt after provider submit and before shard finalize, then resume without creating a second provider batch for the same in-flight job. Record evidence in `{feature}_resume_evidence.json`.
+
+### First production shard after approval
+
+After approval, the first durable production shard for each feature must contain:
+
+- the ten smoke rows, unchanged ids and labels
+- 1,990 new rows from the next ids in deterministic order
+- total row count 2000
+- one immutable shard object and matching manifest and progress entries
+
+Do not relabel the ten smoke posts during the 1,990-row completion step.
+
+### S3 checks during smoke
+
+Each feature smoke verifies:
+
+- shard object exists at the campaign prefix
+- manifest SHA-256 matches shard bytes
+- progress line appended
+- batch shard tag `intermediate-artifact=true`
+
+## Ordered implementation work
+
+1. Implement deterministic ten-post selector and commit `deterministic_ten_post_ids.json`.
+2. Implement per-feature smoke runner that labels those ten posts through the hardened OpenAI Batch path and writes S3 smoke shard 0.
+3. Record token usage from `engine.last_batch.usage`; compute average, max, and full-run cost estimates in `{feature}_cost_report.json`.
+4. Add interrupt-and-resume proof and write `{feature}_resume_evidence.json`.
+5. Build `parent_cost_aggregate.json` from seven feature reports; fail if any feature is missing.
+6. Add approval gate check to production CLI; ensure full run stops without `APPROVED.txt`.
+7. Implement post-approval first-shard combiner that merges ten smoke rows plus 1,990 new rows without duplicate ids.
+8. Run live smoke commands for all seven features. Commit smoke artifacts for review. Delete temporary-only helpers before merge; keep deterministic ids and cost reports only if the parent plan expects them to remain documented artifacts.
+
+## Exact live smoke/basic check commands with expected output
+
+### Offline deterministic sample check
+
+```bash
+cd /workspace
+
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.deterministic_smoke_sample import load_deterministic_ten_post_ids
+ids = load_deterministic_ten_post_ids(
+    'bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73',
+    '2026_09_03-23:51:30',
+)
+assert len(ids) == 10
+assert ids == sorted(ids)
+print('deterministic_ten_post_ids OK')
+print('first_id=' + ids[0])
+"
+```
+
+Expected stdout shape:
+
+```text
+deterministic_ten_post_ids OK
+first_id=at://...
+```
+
+### Live single-feature smoke and cost report
+
+```bash
+cd /workspace
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/bluesky_llm_campaign_smoke.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --feature is_news_or_opinion \
+  --mode smoke-and-cost
+```
+
+Expected stdout:
+
+```text
+smoke_rows=10
+avg_input_tokens=<number>
+max_input_tokens=<number>
+avg_output_tokens=<number>
+max_output_tokens=<number>
+estimated_full_run_usd_avg=<number>
+estimated_full_run_usd_max=<number>
+s3_manifest_sha256_ok=true
+resume_without_resubmit=true
+cost_report=docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/is_news_or_opinion_cost_report.json
+```
+
+### Build parent aggregate for all seven features
+
+Run the same command once per feature name:
+
+`is_news_or_opinion`, `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tiered`
+
+Then:
+
+```bash
+cd /workspace
+
+PYTHONPATH=. uv run python data_platform/generate_features/campaign_cost_report.py \
+  --aggregate \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --output docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/parent_cost_aggregate.json
+```
+
+Expected stdout:
+
+```text
+features_included=7
+total_estimated_full_run_usd_avg=<number>
+total_estimated_full_run_usd_max=<number>
+parent_cost_aggregate.json written
+```
+
+### Approval gate refusal check (before human approval)
+
+```bash
+cd /workspace
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --features is_news_or_opinion \
+  --batch-size 2000 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1
+```
+
+Expected stderr or stdout before approval file exists:
+
+```text
+Campaign approval missing: docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/APPROVED.txt
+```
+
+Exit code must be non-zero.
+
+### First production shard after manual approval
+
+After a human adds `APPROVED.txt`, run:
+
+```bash
+cd /workspace
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/bluesky_llm_campaign_smoke.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --feature is_news_or_opinion \
+  --mode first-production-shard
+```
+
+Expected stdout:
+
+```text
+production_shard_rows=2000
+smoke_rows_reused=10
+new_rows=1990
+duplicate_source_record_id_count=0
+```
+
+## Acceptance criteria
+
+- All seven features smoke the same ten deterministic posts.
+- Each feature cost report records current pricing, average and max token usage, and estimated full-run cost.
+- Parent aggregate includes all seven features and totals both average and max cost estimates.
+- Production CLI refuses to run until `APPROVED.txt` exists with explicit human approval fields.
+- Interrupt-and-resume smoke completes without duplicate provider batch creation.
+- First production shard after approval contains 10 reused smoke rows and 1,990 new rows with no duplicate ids.
+- S3 manifest, progress, and intermediate tag checks pass during smoke.
+- No automated tests were added or run.
+- No repository code posts GitHub comments or launches Cursor agents.
+
+## Failure conditions
+
+- Different ten-post ids across features.
+- Missing max token fields in any cost report.
+- Parent aggregate built from fewer than seven features.
+- Production run starts without explicit human `APPROVED.txt`.
+- First production shard relabels smoke posts or exceeds 2000 rows.
+- Resume smoke creates a second provider batch for the same job.
+- Any edit under `/workspace/tests/**`.
+- Any automatic GitHub comment or issue mutation from repository code.
+
+## PR artifact/commit rules
+
+- Branch name: `cursor/campaign-smoke-cost-gate-86b0`
+- Commit deterministic ids, seven `{feature}_cost_report.json` files, `{feature}_resume_evidence.json`, and `parent_cost_aggregate.json` during review.
+- Do not commit `APPROVED.txt`; that file is human-created after parent issue review.
+- Delete any throwaway debug scripts before merge; keep the smoke CLI and cost report modules.
+- PR title: `Add ten-post smoke cost reports and campaign approval gate`
+- PR body must paste the parent aggregate totals and link to the seven per-feature reports.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step6.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step6.md
@@ -1,17 +1,17 @@
-# Step 6: Add ten-post smoke cost reports and a campaign approval gate
+# Step 6: Add smoke tooling and cost aggregation
 
 ## Goal
 
-Add a deterministic ten-post smoke path shared by all seven LLM features. Record current model pricing, average and maximum token usage per feature, estimated full-run cost, S3 artifact checks, and one deliberate interruption-and-resume proof. Aggregate all seven estimates on the parent campaign issue and block full generation until one explicit human approval is recorded. After approval, the first production shard for each feature must combine the ten smoke outputs with 1,990 new outputs.
+Add reusable smoke tooling for the deterministic ten-post sample shared by all seven LLM features. Record current model pricing, average and maximum token usage per feature, estimated full-run cost, and S3 artifact checks. Include one deliberate interruption-and-resume proof inside the smoke caller. Provide an aggregation command that sums all seven per-feature estimates. This step delivers tooling only and does not run full 200k labeling or add a file-based approval gate.
 
-## Real dependencies
+## Dependencies
 
-- Step 4 merged: OpenAI Batch resume and partial success behavior.
-- Step 5 merged: S3 shard layout, Q44 provenance columns, immutable shards, manifest and progress files.
-- Steps 1 through 3 merged: S3 production backend and pinned dataset availability.
-- Parent plan constants and seven-feature registry.
+- **Step 5 merged:** canonical S3 layout, Q44 provenance columns, `active_openai_batch.json`, immutable batches, `manifest.json`, and logical-append `progress.jsonl`.
+- See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` for smoke flow and report paths.
 
-## Main caller and one implementation slice
+Step 6 may proceed in parallel with Step 7 after Step 5 merges. Both Step 6 and Step 7 must complete before Steps 8 through 14.
+
+## Main caller and implementation slice
 
 **Main caller after this PR merges:**
 
@@ -20,69 +20,64 @@ cd /workspace
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
-PYTHONPATH=. uv run python data_platform/generate_features/bluesky_llm_campaign_smoke.py \
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_bluesky_campaign.py \
   --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
   --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
   --preprocessed-run 2026_09_03-23:51:30 \
-  --feature is_news_or_opinion \
-  --mode smoke-and-cost
+  --feature is_news_or_opinion
 ```
 
-**One implementation slice for this PR:** implement deterministic ten-post selection, per-feature cost report JSON, S3 verification, interrupt-and-resume proof, parent aggregate report generation, and an approval gate file that full generation refuses to bypass.
+**One implementation slice for this PR:** implement `smoke_bluesky_campaign.py` with deterministic ten-post selection, per-feature cost report JSON, S3 verification, interrupt-and-resume proof, and `campaign_cost_report.py` with an `--aggregate` mode. Do not add `APPROVED.txt`, do not refuse production runs from repository code, and do not post to GitHub from repository code.
 
-**Out of scope for this PR:** generating all 200,000 rows per feature, watcher GitHub comments every 10,000 rows, Step 16 lifecycle infrastructure, wide seven-feature join, and any code that posts to GitHub automatically.
+**Out of scope for this PR:** generating all 200,000 rows per feature (that is Steps 8 through 14), watcher GitHub comments (Step 7), Step 16 lifecycle infrastructure, wide seven-feature join (Step 15), and any code that posts to GitHub automatically.
 
 ## Files to inspect (read-only)
 
 | Path | Why |
 |------|-----|
-| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Parent plan Step 6 scope |
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | Smoke flow, report paths, forbidden approval files |
 | `/workspace/data_platform/generate_features/smoke_openai_engine.py` | Existing smoke metrics pattern |
-| `/workspace/data_platform/generate_features/OPENAI_BATCH_SMOKE_RESULTS.md` | Published pricing and token baselines |
 | `/workspace/data_platform/generate_features/s3_feature_campaign.py` | Campaign paths after Step 5 |
-| `/workspace/data_platform/generate_features/s3_feature_shards.py` | Shard write and resume after Step 5 |
+| `/workspace/data_platform/generate_features/s3_feature_batches.py` | Batch write and resume after Step 5 |
 | `/workspace/data_platform/generate_features/engines/openai_engine.py` | Batch usage fields |
 | `/workspace/data_platform/generate_features/registry.py` | Seven LLM features |
-| `/workspace/data_platform/generate_features/platform_cli.py` | Production CLI entry |
-| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Bluesky wrapper |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Production CLI entry |
 | `/workspace/lib/constants.py` | `DEFAULT_LLM_MODEL` |
 | `/workspace/lib/load_env_vars.py` | API key loading |
 
 ## Files allowed to change
 
-- `/workspace/data_platform/generate_features/bluesky_llm_campaign_smoke.py` (new; smoke, cost, S3 checks, interrupt/resume)
+- `/workspace/data_platform/generate_features/smoke_bluesky_campaign.py` (new)
 - `/workspace/data_platform/generate_features/campaign_cost_report.py` (new; pricing math and aggregate report builder)
-- `/workspace/data_platform/generate_features/campaign_approval_gate.py` (new; approval token file contract)
-- `/workspace/data_platform/generate_features/s3_feature_campaign.py` (extend only if needed for smoke artifact paths)
-- `/workspace/data_platform/generate_features/platform_cli.py` (refuse full campaign run without approval file)
 - `/workspace/data_platform/generate_features/deterministic_smoke_sample.py` (new; shared ten-post selector)
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/` (new; committed smoke outputs and cost JSON during PR review)
+- `/workspace/data_platform/generate_features/s3_feature_campaign.py` (extend only if needed for smoke artifact paths)
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step6.md` (this file only if correcting the spec during implementation)
 
 ## Files forbidden to change
 
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step7.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md`, `step5.md`, `step7.md`
 - `/workspace/tests/**`
-- Feature prompt modules under `/workspace/data_platform/generate_features/is_*`, `political_stance`, and `llm_toxicity_tiered`
+- Feature prompt modules
 - `/workspace/webapp/**`
 - `/workspace/experiments/**`
 - Any repository code that launches Cursor agents, opens GitHub issues, or posts GitHub comments automatically
+- Any `APPROVED.txt` or file-based approval gate
 
 ## Locked contracts
 
+See `campaign_contract.md`. This step owns tooling only.
+
 ### Shared deterministic ten-post sample
 
-All seven features must label the same ten `source_record_id` values from the pinned preprocessed run. Selection rule:
+All seven features must label the same ten `source_record_id` values. Selection rule:
 
 1. Load rows from preprocessed run `2026_09_03-23:51:30` for dataset `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73`.
 2. Keep rows with non-empty `text`.
 3. Sort by ascending `source_record_id`.
 4. Take the first ten rows.
 
-Write the selected ids to `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/deterministic_ten_post_ids.json` during the PR. Every feature smoke run must read that file rather than re-derive ad hoc ids.
+Write the selected ids to `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/deterministic_ten_post_ids.json` during the PR.
 
 ### Pricing and token estimates
 
@@ -97,56 +92,79 @@ Use current published Batch pricing for `gpt-5.4-nano` at smoke run time. Record
 - maximum output tokens among the ten requests
 - estimated full-run cost for 200,000 posts using both average and max token assumptions
 
-### Parent aggregate and one explicit approval
+### Per-feature smoke evidence path
 
-Each feature smoke writes `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/{feature}_cost_report.json`.
+Each feature smoke writes under:
 
-A parent aggregate file `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/parent_cost_aggregate.json` sums all seven features and must exist before full generation can start.
+`docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/{feature}/`
 
-Full generation requires an approval token file:
+Expected files per feature (committed during Steps 8 through 14 Phase A; temporary Git copies deleted before merge):
 
-```text
-docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/APPROVED.txt
+- `{feature}_cost_report.json`
+- `{feature}_resume_evidence.json`
+- `{feature}_s3_checks.txt`
+
+S3 smoke evidence under the canonical feature prefix remains after Git cleanup in Steps 8 through 14 Phase A. Step 6 does not write canonical `{feature}/smoke/`.
+
+### Parent aggregate command
+
+After all seven per-feature cost reports exist:
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/campaign_cost_report.py \
+  --aggregate \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --smoke-reports-dir docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke \
+  --output docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/parent_cost_aggregate.json
 ```
 
-Content must include the exact string `approved_by=<human>` and `approved_at=<UTC ISO timestamp>`. The production CLI refuses to run without this file. No repository code may create or mutate `APPROVED.txt`; only a human operator adds it after reviewing the parent aggregate on the parent campaign issue.
+Human approval is recorded on the parent GitHub issue only. No repository file gates full generation.
 
-### Deliberate interruption and resume
+### S3 smoke evidence (canonical layout; Steps 8 through 14 only)
 
-Each feature smoke must perform one deliberate interrupt after provider submit and before shard finalize, then resume without creating a second provider batch for the same in-flight job. Record evidence in `{feature}_resume_evidence.json`.
+Step 6 tooling proof must not write canonical `{feature}/smoke/`. Step 8 owns the first official canonical smoke for each feature.
 
-### First production shard after approval
+When Steps 8 through 14 run `smoke_bluesky_campaign.py` in Phase A, each feature writes exactly these untagged objects under the canonical `{feature}/smoke/` prefix:
 
-After approval, the first durable production shard for each feature must contain:
+| Object | Path |
+|--------|------|
+| Input sample | `.../{feature}/smoke/input.parquet` |
+| Output labels | `.../{feature}/smoke/output.parquet` |
+| Cost report | `.../{feature}/smoke/cost_report.json` |
+| Resume evidence | `.../{feature}/smoke/resume_evidence.json` |
 
-- the ten smoke rows, unchanged ids and labels
-- 1,990 new rows from the next ids in deterministic order
-- total row count 2000
-- one immutable shard object and matching manifest and progress entries
+Smoke never writes `batches/part-*.parquet` or any other canonical production batch object.
 
-Do not relabel the ten smoke posts during the 1,990-row completion step.
+### Deliberate interruption and resume (inside smoke caller only)
+
+`smoke_bluesky_campaign.py` performs one deliberate interrupt after provider submit and before finalize, then resumes without creating a second provider batch for the same in-flight job. It writes `resume_evidence.json` to S3 and a Git copy under `reports/smoke/{feature}/`. Feature run steps must not repeat this procedure.
+
+### Production batch schedule (Steps 8 through 14, after parent approval)
+
+After parent approval, the first production provider job labels 1,990 new posts. Its successful rows are combined with the ten unchanged smoke output rows into immutable `batches/part-00000.parquet` (2,000 rows total). The next 99 provider jobs each label 2,000 posts and each write one canonical batch object (`part-00001` through `part-00099`). Total: 100 batch objects and 200,000 rows.
+
+Preserve original smoke `batch_id` and `request_id` in the ten rows folded into `part-00000`.
 
 ### S3 checks during smoke
 
-Each feature smoke verifies:
+Each feature smoke verifies (against the smoke prefix in use):
 
-- shard object exists at the campaign prefix
-- manifest SHA-256 matches shard bytes
-- progress line appended
-- batch shard tag `intermediate-artifact=true`
+- `smoke/input.parquet`, `smoke/output.parquet`, `smoke/cost_report.json`, and `smoke/resume_evidence.json` exist and are untagged
+- `smoke/output.parquet` has exactly ten Q44 rows
+- no objects exist under `batches/` yet
+- interrupt-and-resume proof recorded in `smoke/resume_evidence.json`
+
+Step 6 tooling proof runs these checks under the disposable prefix only.
 
 ## Ordered implementation work
 
-1. Implement deterministic ten-post selector and commit `deterministic_ten_post_ids.json`.
-2. Implement per-feature smoke runner that labels those ten posts through the hardened OpenAI Batch path and writes S3 smoke shard 0.
-3. Record token usage from `engine.last_batch.usage`; compute average, max, and full-run cost estimates in `{feature}_cost_report.json`.
-4. Add interrupt-and-resume proof and write `{feature}_resume_evidence.json`.
-5. Build `parent_cost_aggregate.json` from seven feature reports; fail if any feature is missing.
-6. Add approval gate check to production CLI; ensure full run stops without `APPROVED.txt`.
-7. Implement post-approval first-shard combiner that merges ten smoke rows plus 1,990 new rows without duplicate ids.
-8. Run live smoke commands for all seven features. Commit smoke artifacts for review. Delete temporary-only helpers before merge; keep deterministic ids and cost reports only if the parent plan expects them to remain documented artifacts.
+1. Implement deterministic ten-post selector and commit `deterministic_ten_post_ids.json` under `reports/smoke/`.
+2. Implement `smoke_bluesky_campaign.py` that labels those ten posts, writes untagged S3 smoke artifacts under `{feature}/smoke/` when no smoke-prefix override is set, and performs interrupt-and-resume inside the same invocation.
+3. Record token usage from `engine.last_batch.usage`; compute average, max, and full-run cost estimates.
+4. Implement `campaign_cost_report.py --aggregate` to sum seven feature reports.
+5. Run live tooling proof for one feature under the disposable prefix only. Commit smoke tooling only. Do not run all seven features, full 200k, or write canonical `{feature}/smoke/` in this PR.
 
-## Exact live smoke/basic check commands with expected output
+## Exact live smoke and basic check commands with expected output
 
 ### Offline deterministic sample check
 
@@ -166,31 +184,37 @@ print('first_id=' + ids[0])
 "
 ```
 
-Expected stdout shape:
+Expected stdout:
 
 ```text
 deterministic_ten_post_ids OK
 first_id=at://...
 ```
 
-### Live single-feature smoke and cost report
+### Live single-feature tooling proof (requires `OPENAI_API_KEY`; available after this step's implementation)
+
+Use the disposable smoke prefix only. Step 8 owns the first official canonical `{feature}/smoke/` write. Do not write under the pinned campaign feature `batches/` prefix.
 
 ```bash
 cd /workspace
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
-PYTHONPATH=. uv run python data_platform/generate_features/bluesky_llm_campaign_smoke.py \
+DISPOSABLE_PREFIX=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step6_campaign_smoke/
+
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_bluesky_campaign.py \
   --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
   --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
   --preprocessed-run 2026_09_03-23:51:30 \
   --feature is_news_or_opinion \
-  --mode smoke-and-cost
+  --smoke-prefix "$DISPOSABLE_PREFIX" \
+  --output-dir docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_news_or_opinion
 ```
 
 Expected stdout:
 
 ```text
+smoke_prefix=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step6_campaign_smoke/
 smoke_rows=10
 avg_input_tokens=<number>
 max_input_tokens=<number>
@@ -198,18 +222,34 @@ avg_output_tokens=<number>
 max_output_tokens=<number>
 estimated_full_run_usd_avg=<number>
 estimated_full_run_usd_max=<number>
-s3_manifest_sha256_ok=true
-resume_without_resubmit=true
-cost_report=docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/is_news_or_opinion_cost_report.json
+s3_smoke_output_ok=true
+s3_smoke_resume_evidence_ok=true
+no_batches_prefix_objects=true
+canonical_smoke_prefix_touched=false
+cost_report=docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_news_or_opinion/is_news_or_opinion_cost_report.json
 ```
 
-### Build parent aggregate for all seven features
+### Disposable prefix cleanup (required before merge)
 
-Run the same command once per feature name:
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
-`is_news_or_opinion`, `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tiered`
+aws s3 rm s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step6_campaign_smoke/ --recursive
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step6_campaign_smoke/ --recursive
+```
 
-Then:
+Expected: `aws s3 rm` reports deleted objects (or no objects found). `aws s3 ls` prints no lines, confirming the disposable prefix is empty.
+
+Verify canonical `is_news_or_opinion/smoke/` was not written during Step 6 tooling proof:
+
+```bash
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/smoke/ 2>&1 || true
+```
+
+Expected: `An error occurred (NoSuchKey)` or empty listing. No objects under canonical `is_news_or_opinion/smoke/` until Step 8 Phase A.
+
+### Aggregate command shape (used by Steps 8 through 14 after all seven smokes)
 
 ```bash
 cd /workspace
@@ -217,7 +257,8 @@ cd /workspace
 PYTHONPATH=. uv run python data_platform/generate_features/campaign_cost_report.py \
   --aggregate \
   --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
-  --output docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/parent_cost_aggregate.json
+  --smoke-reports-dir docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke \
+  --output docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/parent_cost_aggregate.json
 ```
 
 Expected stdout:
@@ -229,82 +270,34 @@ total_estimated_full_run_usd_max=<number>
 parent_cost_aggregate.json written
 ```
 
-### Approval gate refusal check (before human approval)
-
-```bash
-cd /workspace
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-
-PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --features is_news_or_opinion \
-  --batch-size 2000 \
-  --campaign-id bluesky_2026_09_03_235130_llm_features_v1
-```
-
-Expected stderr or stdout before approval file exists:
-
-```text
-Campaign approval missing: docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_smoke/APPROVED.txt
-```
-
-Exit code must be non-zero.
-
-### First production shard after manual approval
-
-After a human adds `APPROVED.txt`, run:
-
-```bash
-cd /workspace
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-
-PYTHONPATH=. uv run python data_platform/generate_features/bluesky_llm_campaign_smoke.py \
-  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --preprocessed-run 2026_09_03-23:51:30 \
-  --feature is_news_or_opinion \
-  --mode first-production-shard
-```
-
-Expected stdout:
-
-```text
-production_shard_rows=2000
-smoke_rows_reused=10
-new_rows=1990
-duplicate_source_record_id_count=0
-```
-
 ## Acceptance criteria
 
-- All seven features smoke the same ten deterministic posts.
-- Each feature cost report records current pricing, average and max token usage, and estimated full-run cost.
-- Parent aggregate includes all seven features and totals both average and max cost estimates.
-- Production CLI refuses to run until `APPROVED.txt` exists with explicit human approval fields.
-- Interrupt-and-resume smoke completes without duplicate provider batch creation.
-- First production shard after approval contains 10 reused smoke rows and 1,990 new rows with no duplicate ids.
-- S3 manifest, progress, and intermediate tag checks pass during smoke.
+- `smoke_bluesky_campaign.py` and `campaign_cost_report.py --aggregate` exist and run.
+- Deterministic ten-post selector returns the same ids for every feature.
+- Smoke tooling writes cost, resume, and S3 check artifacts to the `reports/smoke/{feature}/` layout.
+- Step 6 tooling proof writes untagged objects only under `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step6_campaign_smoke/`; no canonical `{feature}/smoke/` or `batches/` objects.
+- Disposable S3 prefix is empty after `aws s3 rm ... --recursive` before merge.
+- Canonical `is_news_or_opinion/smoke/` remains absent after Step 6 tooling proof.
+- No `APPROVED.txt` or repository approval gate is added.
 - No automated tests were added or run.
 - No repository code posts GitHub comments or launches Cursor agents.
 
 ## Failure conditions
 
 - Different ten-post ids across features.
-- Missing max token fields in any cost report.
-- Parent aggregate built from fewer than seven features.
-- Production run starts without explicit human `APPROVED.txt`.
-- First production shard relabels smoke posts or exceeds 2000 rows.
-- Resume smoke creates a second provider batch for the same job.
+- Missing max token fields in cost report schema.
+- Aggregate command cannot read seven per-feature reports.
+- Repository code refuses or permits full generation based on a file marker.
+- Repository code posts to GitHub automatically.
+- Smoke writes canonical `batches/part-*.parquet` during smoke.
+- Step 6 tooling proof writes any object under canonical `{feature}/smoke/`.
+- Disposable prefix `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step6_campaign_smoke/` is not empty before merge.
 - Any edit under `/workspace/tests/**`.
-- Any automatic GitHub comment or issue mutation from repository code.
 
-## PR artifact/commit rules
+## PR artifact and commit rules
 
-- Branch name: `cursor/campaign-smoke-cost-gate-86b0`
-- Commit deterministic ids, seven `{feature}_cost_report.json` files, `{feature}_resume_evidence.json`, and `parent_cost_aggregate.json` during review.
-- Do not commit `APPROVED.txt`; that file is human-created after parent issue review.
-- Delete any throwaway debug scripts before merge; keep the smoke CLI and cost report modules.
-- PR title: `Add ten-post smoke cost reports and campaign approval gate`
-- PR body must paste the parent aggregate totals and link to the seven per-feature reports.
+- Commit smoke tooling modules and `deterministic_ten_post_ids.json` only.
+- Do not commit all seven feature smoke outputs in this PR (those belong to Steps 8 through 14 Phase A).
+- Before merge: run `aws s3 rm s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step6_campaign_smoke/ --recursive`, verify the disposable prefix is empty, and confirm canonical `is_news_or_opinion/smoke/` is still absent.
+- PR title: `Add smoke tooling and cost aggregation for Bluesky LLM campaign`
+- PR body must state: tooling only, no approval file, no full runs, disposable smoke prefix used for proof, canonical smoke deferred to Step 8.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step7.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step7.md
@@ -1,0 +1,273 @@
+# Step 7: Add durable progress reports for feature run watchers
+
+## Goal
+
+Write structured progress records to durable S3 state after each immutable shard lands. Give operators enough information to run short, restartable watcher processes that update one rolling GitHub issue comment at every 10,000 completed durable rows per feature. Watchers read S3 only; they do not mutate shards, manifests, or labels.
+
+## Real dependencies
+
+- Step 4 merged: OpenAI Batch resume behavior.
+- Step 5 merged: immutable shards, `manifest.json`, `progress.jsonl`, Q44 provenance, S3 layout.
+- Step 6 merged: deterministic smoke artifacts, approval gate, and first production shard combiner.
+- Steps 1 through 3 merged: S3 production backend.
+
+## Main caller and one implementation slice
+
+**Main caller after this PR merges:**
+
+```bash
+cd /workspace
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/feature_progress_watcher.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --feature is_news_or_opinion \
+  --github-issue 999 \
+  --once
+```
+
+The watcher is a short-lived CLI meant to be restarted by a human operator or external scheduler. It is not a long-running daemon inside the feature generator.
+
+**One implementation slice for this PR:** extend durable `progress.jsonl` entries with watcher-ready counters and add a standalone watcher CLI that reads S3 progress state, computes whether a 10,000-row boundary was crossed, and prints the exact rolling comment body for manual paste or for a separate non-repo automation.
+
+**Out of scope for this PR:** generating remaining feature rows beyond progress reporting, changing OpenAI Batch behavior, modifying smoke cost gate logic, lifecycle expiration rules, and any repository code that launches Cursor agents or calls the GitHub API directly.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Parent plan Step 7 scope |
+| `/workspace/data_platform/generate_features/s3_feature_shards.py` | Current progress append path |
+| `/workspace/data_platform/generate_features/s3_feature_campaign.py` | Campaign prefix helpers |
+| `/workspace/data_platform/generate_features/campaign_cost_report.py` | Cost fields to echo in progress |
+| `/workspace/data_platform/generate_features/bluesky_llm_campaign_smoke.py` | Smoke artifact locations |
+| `/workspace/data_platform/generate_features/generate_features.py` | Batch completion hook |
+| `/workspace/lib/aws/s3.py` | S3 read helpers |
+| `/workspace/lib/timestamp_utils.py` | UTC timestamps |
+
+## Files allowed to change
+
+- `/workspace/data_platform/generate_features/progress_record.py` (new; structured progress schema)
+- `/workspace/data_platform/generate_features/feature_progress_watcher.py` (new; short restartable watcher CLI)
+- `/workspace/data_platform/generate_features/s3_feature_shards.py` (append enriched progress lines after each durable shard)
+- `/workspace/data_platform/generate_features/s3_feature_campaign.py` (helper to read progress tail if needed)
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/runbooks/feature_progress_watcher.md` (new operator runbook for manual subagents)
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step7.md` (this file only if correcting the spec during implementation)
+
+## Files forbidden to change
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step6.md`
+- `/workspace/tests/**`
+- `/workspace/data_platform/generate_features/engines/openai_engine.py` except if a one-line hook is absolutely required; prefer editing shard writer only
+- Feature prompt modules
+- `/workspace/webapp/**`
+- `/workspace/experiments/**`
+- Any repository code that launches Cursor agents, GitHub Actions that auto-comment, or direct GitHub API clients inside the generator path
+
+## Locked contracts
+
+### Durable S3 progress state
+
+Append one JSON object per line to:
+
+```text
+s3://mirrorview-experimental-artifacts/data_platform/data/features/bluesky_2026_09_03_235130_llm_features_v1/{feature}/progress.jsonl
+```
+
+Each line after a durable shard lands must include at minimum:
+
+| Field | Meaning |
+|-------|---------|
+| `campaign_id` | `bluesky_2026_09_03_235130_llm_features_v1` |
+| `feature` | feature name |
+| `recorded_at` | UTC timestamp |
+| `batch_shard_index` | shard just written |
+| `shard_row_count` | rows in that shard |
+| `durable_row_total` | cumulative labeled rows across all shards |
+| `expected_row_total` | `200000` |
+| `percent_complete` | `durable_row_total / 200000` |
+| `last_source_record_id` | last id in shard order |
+| `manifest_sha256` | SHA-256 of `manifest.json` after update |
+| `estimated_cost_usd_to_date` | optional running estimate from token usage |
+| `active_openai_batch_id` | null when idle; set while polling |
+
+Progress lines are append-only. Watchers treat the file as authoritative durable state.
+
+### Watcher cadence: one rolling comment every 10,000 durable rows
+
+For each feature issue, emit an updated rolling comment body when `durable_row_total` crosses a new multiple of 10,000:
+
+`10000, 20000, 30000, ... 200000`
+
+Watchers must not emit duplicate updates for the same boundary. Persist last emitted boundary in a small S3 sidecar:
+
+```text
+.../{feature}/watcher_state.json
+```
+
+### Short restartable watcher subagents
+
+Watchers must be safe to kill and restart. On restart, reload `progress.jsonl` and `watcher_state.json` from S3, recompute the highest durable total, and continue from the next unseen 10,000 boundary.
+
+The operator runbook describes manual subagent restarts. Repository code must not spawn subagents, Cursor agents, background threads that loop forever, or GitHub API calls.
+
+### Rolling comment body format
+
+The watcher CLI prints a single markdown block to stdout for manual paste into the feature issue. Required sections:
+
+1. Campaign id, feature name, durable rows, expected rows, percent complete
+2. Latest shard index and manifest SHA-256
+3. Estimated cost to date and projected final cost if available from Step 6 reports
+4. Active OpenAI batch id or `idle`
+5. Last updated UTC timestamp
+
+Example shape:
+
+```markdown
+## Feature progress: is_news_or_opinion
+Campaign: bluesky_2026_09_03_235130_llm_features_v1
+Durable rows: 10000 / 200000 (5.0%)
+Latest shard: 4 (manifest sha256: abcd...)
+Estimated cost to date: $0.42
+Active OpenAI batch: idle
+Updated: 2026-09-05T20:15:00Z
+```
+
+### No repository agent launching
+
+Hard rule: no Python module in this repository may invoke Cursor Cloud agents, GitHub Copilot agents, or other autonomous coding agents. Watchers report state only.
+
+## Ordered implementation work
+
+1. Define `progress_record.py` schema and validation for append-only lines.
+2. Extend shard completion path to append enriched progress records with cumulative durable totals.
+3. Implement `feature_progress_watcher.py` with `--once` mode that reads S3, detects crossed 10,000 boundaries, updates `watcher_state.json`, and prints the rolling comment body.
+4. Write operator runbook `runbooks/feature_progress_watcher.md` describing manual restart steps for short watcher subagents outside the repo.
+5. Add temporary smoke helper or reuse Step 6 first production shard output to simulate at least 10,000 durable rows, or document a reduced-boundary dev flag limited to smoke evidence only.
+6. Run live smoke commands below. Commit watcher runbook and sample printed comment during review. Remove temporary dev-only boundary override before merge.
+
+## Exact live smoke/basic check commands with expected output
+
+### Offline schema check
+
+```bash
+cd /workspace
+
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.progress_record import ProgressRecord
+r = ProgressRecord(
+    campaign_id='bluesky_2026_09_03_235130_llm_features_v1',
+    feature='is_news_or_opinion',
+    recorded_at='2026-09-05T20:00:00Z',
+    batch_shard_index=0,
+    shard_row_count=2000,
+    durable_row_total=2000,
+    expected_row_total=200000,
+    percent_complete=0.01,
+    last_source_record_id='at://example/1',
+    manifest_sha256='abc',
+    estimated_cost_usd_to_date=0.01,
+    active_openai_batch_id=None,
+)
+assert r.expected_row_total == 200000
+print('ProgressRecord schema OK')
+"
+```
+
+Expected stdout:
+
+```text
+ProgressRecord schema OK
+```
+
+### Live watcher read against existing S3 progress
+
+After Step 5 or Step 6 smoke has written at least one shard:
+
+```bash
+cd /workspace
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/feature_progress_watcher.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --feature is_news_or_opinion \
+  --github-issue 999 \
+  --once
+```
+
+Expected stdout when durable total is below 10,000:
+
+```text
+boundary_crossed=false
+durable_row_total=<number less than 10000>
+no_comment_update_needed=true
+```
+
+Expected stdout when durable total reaches at least 10,000:
+
+```text
+boundary_crossed=true
+boundary=10000
+watcher_state_updated=true
+rolling_comment<<<
+## Feature progress: is_news_or_opinion
+...
+>>>rolling_comment
+```
+
+### Restart idempotency check
+
+Run the same watcher command twice without new shards landing.
+
+Expected second stdout:
+
+```text
+boundary_crossed=false
+duplicate_boundary_suppressed=true
+```
+
+Expected S3 effect: `watcher_state.json` unchanged after the second run.
+
+### Manual subagent restart proof documented in runbook
+
+The operator runbook must include these exact steps:
+
+1. Stop the watcher process.
+2. Confirm the feature generator or batch job is still running or safely idle.
+3. Re-run the watcher command with the same `--campaign-id` and `--feature`.
+4. Verify `duplicate_boundary_suppressed=true` when no new durable rows arrived.
+
+No repository command may start a Cursor agent.
+
+## Acceptance criteria
+
+- Every durable shard append adds one validated `progress.jsonl` line with cumulative totals.
+- Watcher CLI reads S3 state only and prints a rolling comment at each new 10,000-row boundary.
+- Restarting the watcher does not duplicate boundary notifications.
+- `watcher_state.json` persists the last emitted boundary in S3.
+- Operator runbook documents short restartable manual watcher subagents outside the repo.
+- No repository code launches Cursor agents or posts to GitHub automatically.
+- No automated tests were added or run.
+
+## Failure conditions
+
+- Progress totals derived only from memory, not from durable S3 shard state.
+- Missing cumulative `durable_row_total` on any progress line.
+- Duplicate rolling comment emission for the same 10,000 boundary after restart.
+- Watcher mutates shard objects or manifest content.
+- Any GitHub API client added to the generator or watcher path.
+- Any code path that launches Cursor agents or other autonomous agent runners.
+- Any edit under `/workspace/tests/**`.
+
+## PR artifact/commit rules
+
+- Branch name: `cursor/feature-progress-watcher-86b0`
+- Commit `feature_progress_watcher.py`, `progress_record.py`, runbook, and one sample printed rolling comment captured in `WATCHER_SMOKE_EVIDENCE.md` during review.
+- Delete dev-only boundary override helpers before merge; keep production 10,000-row cadence.
+- PR title: `Add durable progress reports for feature run watchers`
+- PR body must include a pasted sample rolling comment and the S3 keys for `progress.jsonl` and `watcher_state.json`.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step7.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step7.md
@@ -2,16 +2,16 @@
 
 ## Goal
 
-Write structured progress records to durable S3 state after each immutable shard lands. Give operators enough information to run short, restartable watcher processes that update one rolling GitHub issue comment at every 10,000 completed durable rows per feature. Watchers read S3 only; they do not mutate shards, manifests, or labels.
+Enrich `progress.jsonl` entries after each immutable batch lands. Add `watcher.json` for rolling GitHub comment state. Provide a short, restartable watcher CLI that reads S3 progress state, detects 10,000-row boundaries, prints a prepared markdown report, and updates `watcher.json`. Watchers read S3 only for feature artifacts; they do not mutate batches, manifests, or labels.
 
-## Real dependencies
+## Dependencies
 
-- Step 4 merged: OpenAI Batch resume behavior.
-- Step 5 merged: immutable shards, `manifest.json`, `progress.jsonl`, Q44 provenance, S3 layout.
-- Step 6 merged: deterministic smoke artifacts, approval gate, and first production shard combiner.
-- Steps 1 through 3 merged: S3 production backend.
+- **Step 5 merged:** immutable batches, `manifest.json`, logical-append `progress.jsonl`, Q44 provenance, canonical S3 layout.
+- See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` for `watcher.json` schema, milestone cadence, and append semantics.
 
-## Main caller and one implementation slice
+Step 7 may proceed in parallel with Step 6 after Step 5 merges. Both Step 6 and Step 7 must complete before Steps 8 through 14. Step 7 does not depend on Step 6 smoke outputs.
+
+## Main caller and implementation slice
 
 **Main caller after this PR merges:**
 
@@ -23,25 +23,22 @@ export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 PYTHONPATH=. uv run python data_platform/generate_features/feature_progress_watcher.py \
   --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
   --feature is_news_or_opinion \
-  --github-issue 999 \
   --once
 ```
 
 The watcher is a short-lived CLI meant to be restarted by a human operator or external scheduler. It is not a long-running daemon inside the feature generator.
 
-**One implementation slice for this PR:** extend durable `progress.jsonl` entries with watcher-ready counters and add a standalone watcher CLI that reads S3 progress state, computes whether a 10,000-row boundary was crossed, and prints the exact rolling comment body for manual paste or for a separate non-repo automation.
+**One implementation slice for this PR:** extend durable `progress.jsonl` entries with watcher-ready counters, add `watcher.json` read/write helpers, and add a standalone watcher CLI that reads S3 progress state, computes whether a 10,000-row boundary was crossed, prints the exact rolling comment body, and atomically updates `watcher.json`.
 
-**Out of scope for this PR:** generating remaining feature rows beyond progress reporting, changing OpenAI Batch behavior, modifying smoke cost gate logic, lifecycle expiration rules, and any repository code that launches Cursor agents or calls the GitHub API directly.
+**Out of scope for this PR:** generating remaining feature rows, changing OpenAI Batch behavior, smoke cost tooling (Step 6), lifecycle expiration rules (Step 16), and any repository code that launches Cursor agents or calls the GitHub API directly.
 
 ## Files to inspect (read-only)
 
 | Path | Why |
 |------|-----|
-| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Parent plan Step 7 scope |
-| `/workspace/data_platform/generate_features/s3_feature_shards.py` | Current progress append path |
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | `watcher.json` schema and milestone cadence |
+| `/workspace/data_platform/generate_features/s3_feature_batches.py` | Current progress append path |
 | `/workspace/data_platform/generate_features/s3_feature_campaign.py` | Campaign prefix helpers |
-| `/workspace/data_platform/generate_features/campaign_cost_report.py` | Cost fields to echo in progress |
-| `/workspace/data_platform/generate_features/bluesky_llm_campaign_smoke.py` | Smoke artifact locations |
 | `/workspace/data_platform/generate_features/generate_features.py` | Batch completion hook |
 | `/workspace/lib/aws/s3.py` | S3 read helpers |
 | `/workspace/lib/timestamp_utils.py` | UTC timestamps |
@@ -50,78 +47,78 @@ The watcher is a short-lived CLI meant to be restarted by a human operator or ex
 
 - `/workspace/data_platform/generate_features/progress_record.py` (new; structured progress schema)
 - `/workspace/data_platform/generate_features/feature_progress_watcher.py` (new; short restartable watcher CLI)
-- `/workspace/data_platform/generate_features/s3_feature_shards.py` (append enriched progress lines after each durable shard)
-- `/workspace/data_platform/generate_features/s3_feature_campaign.py` (helper to read progress tail if needed)
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/runbooks/feature_progress_watcher.md` (new operator runbook for manual subagents)
+- `/workspace/data_platform/generate_features/seed_progress_watcher_smoke.py` (new temporary smoke helper; delete before merge)
+- `/workspace/data_platform/generate_features/s3_feature_batches.py` (append enriched progress lines after each durable batch)
+- `/workspace/data_platform/generate_features/s3_feature_campaign.py` (helper to read progress tail and `watcher.json` if needed)
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/runbooks/feature_progress_watcher.md` (new operator runbook)
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step7.md` (this file only if correcting the spec during implementation)
 
 ## Files forbidden to change
 
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step5.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step6.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step4.md`, `step5.md`, `step6.md`
 - `/workspace/tests/**`
-- `/workspace/data_platform/generate_features/engines/openai_engine.py` except if a one-line hook is absolutely required; prefer editing shard writer only
+- `/workspace/data_platform/generate_features/engines/openai_engine.py` except if a one-line hook is absolutely required
 - Feature prompt modules
 - `/workspace/webapp/**`
 - `/workspace/experiments/**`
-- Any repository code that launches Cursor agents, GitHub Actions that auto-comment, or direct GitHub API clients inside the generator path
+- Any repository code that launches Cursor agents, GitHub Actions that auto-comment, or direct GitHub API write clients inside the generator path
 
 ## Locked contracts
 
-### Durable S3 progress state
+See `campaign_contract.md`. Exact values for this step:
 
-Append one JSON object per line to:
+### progress.jsonl (append-only)
 
-```text
-s3://mirrorview-experimental-artifacts/data_platform/data/features/bluesky_2026_09_03_235130_llm_features_v1/{feature}/progress.jsonl
-```
+Path per feature:
 
-Each line after a durable shard lands must include at minimum:
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/{feature}/progress.jsonl`
+
+Each line after a durable batch lands must include at minimum:
 
 | Field | Meaning |
 |-------|---------|
 | `campaign_id` | `bluesky_2026_09_03_235130_llm_features_v1` |
 | `feature` | feature name |
+| `run_id` | `bluesky_2026_09_03_235130_llm_features_v1:{feature}` |
 | `recorded_at` | UTC timestamp |
-| `batch_shard_index` | shard just written |
-| `shard_row_count` | rows in that shard |
-| `durable_row_total` | cumulative labeled rows across all shards |
+| `part_index` | batch part just written |
+| `batch_row_count` | rows in that batch |
+| `durable_row_total` | cumulative labeled rows across all batches |
 | `expected_row_total` | `200000` |
 | `percent_complete` | `durable_row_total / 200000` |
-| `last_source_record_id` | last id in shard order |
+| `last_source_record_id` | last id in batch order |
 | `manifest_sha256` | SHA-256 of `manifest.json` after update |
-| `estimated_cost_usd_to_date` | optional running estimate from token usage |
 | `active_openai_batch_id` | null when idle; set while polling |
 
-Progress lines are append-only. Watchers treat the file as authoritative durable state.
+`progress.jsonl` is the only progress event file. Each append uses logical read-append-conditional-replace with S3 `If-Match` ETag for concurrency control only. SHA-256 remains the content integrity check for parquet and manifest bytes.
 
-### Watcher cadence: one rolling comment every 10,000 durable rows
+### watcher.json
 
-For each feature issue, emit an updated rolling comment body when `durable_row_total` crosses a new multiple of 10,000:
+Path per feature:
 
-`10000, 20000, 30000, ... 200000`
+`.../features/bluesky_2026_09_03_235130_llm_features_v1/{feature}/watcher.json`
 
-Watchers must not emit duplicate updates for the same boundary. Persist last emitted boundary in a small S3 sidecar:
+Stores:
 
-```text
-.../{feature}/watcher_state.json
-```
+| Field | Meaning |
+|-------|---------|
+| `github_comment_id` | id of the rolling feature-issue comment, or null before first post |
+| `last_posted_milestone` | last 10k boundary posted (10000, 20000, …, 200000) |
 
-### Short restartable watcher subagents
+Atomic replace is permitted using conditional `If-Match` ETag. The watcher CLI updates this file after preparing a new comment.
 
-Watchers must be safe to kill and restart. On restart, reload `progress.jsonl` and `watcher_state.json` from S3, recompute the highest durable total, and continue from the next unseen 10,000 boundary.
+### Watcher cadence
 
-The operator runbook describes manual subagent restarts. Repository code must not spawn subagents, Cursor agents, background threads that loop forever, or GitHub API calls.
+Emit an updated rolling comment body when `durable_row_total` crosses a new multiple of 10,000. Do not emit duplicate updates for the same boundary.
 
 ### Rolling comment body format
 
-The watcher CLI prints a single markdown block to stdout for manual paste into the feature issue. Required sections:
+The watcher CLI prints a single markdown block to stdout. An agent with authenticated GitHub integration posts or updates the feature-issue comment. Required sections:
 
 1. Campaign id, feature name, durable rows, expected rows, percent complete
-2. Latest shard index and manifest SHA-256
-3. Estimated cost to date and projected final cost if available from Step 6 reports
+2. Latest part index and manifest SHA-256
+3. Estimated cost to date if available from smoke reports
 4. Active OpenAI batch id or `idle`
 5. Last updated UTC timestamp
 
@@ -131,26 +128,25 @@ Example shape:
 ## Feature progress: is_news_or_opinion
 Campaign: bluesky_2026_09_03_235130_llm_features_v1
 Durable rows: 10000 / 200000 (5.0%)
-Latest shard: 4 (manifest sha256: abcd...)
+Latest part: 4 (manifest sha256: abcd...)
 Estimated cost to date: $0.42
 Active OpenAI batch: idle
 Updated: 2026-09-05T20:15:00Z
 ```
 
-### No repository agent launching
+### No repository agent launching or GitHub writes
 
-Hard rule: no Python module in this repository may invoke Cursor Cloud agents, GitHub Copilot agents, or other autonomous coding agents. Watchers report state only.
+Hard rule: no Python module in this repository may invoke Cursor Cloud agents or call GitHub write APIs. Describe GitHub posting as an agent responsibility in the runbook. Do not prescribe `gh` write commands from the read-only cloud CLI.
 
 ## Ordered implementation work
 
 1. Define `progress_record.py` schema and validation for append-only lines.
-2. Extend shard completion path to append enriched progress records with cumulative durable totals.
-3. Implement `feature_progress_watcher.py` with `--once` mode that reads S3, detects crossed 10,000 boundaries, updates `watcher_state.json`, and prints the rolling comment body.
+2. Extend batch completion path to append enriched progress records with cumulative durable totals.
+3. Implement `feature_progress_watcher.py` with `--once` mode that reads S3, detects crossed 10,000 boundaries, updates `watcher.json`, and prints the rolling comment body.
 4. Write operator runbook `runbooks/feature_progress_watcher.md` describing manual restart steps for short watcher subagents outside the repo.
-5. Add temporary smoke helper or reuse Step 6 first production shard output to simulate at least 10,000 durable rows, or document a reduced-boundary dev flag limited to smoke evidence only.
-6. Run live smoke commands below. Commit watcher runbook and sample printed comment during review. Remove temporary dev-only boundary override before merge.
+5. Seed disposable `progress.jsonl` and `watcher.json` under `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step7_progress_watcher/`, run the watcher proof against that prefix in `--dry-render` mode, then recursively clean the disposable prefix before merge.
 
-## Exact live smoke/basic check commands with expected output
+## Exact live smoke and basic check commands with expected output
 
 ### Offline schema check
 
@@ -162,15 +158,15 @@ from data_platform.generate_features.progress_record import ProgressRecord
 r = ProgressRecord(
     campaign_id='bluesky_2026_09_03_235130_llm_features_v1',
     feature='is_news_or_opinion',
+    run_id='bluesky_2026_09_03_235130_llm_features_v1:is_news_or_opinion',
     recorded_at='2026-09-05T20:00:00Z',
-    batch_shard_index=0,
-    shard_row_count=2000,
+    part_index=0,
+    batch_row_count=2000,
     durable_row_total=2000,
     expected_row_total=200000,
     percent_complete=0.01,
     last_source_record_id='at://example/1',
     manifest_sha256='abc',
-    estimated_cost_usd_to_date=0.01,
     active_openai_batch_id=None,
 )
 assert r.expected_row_total == 200000
@@ -184,90 +180,113 @@ Expected stdout:
 ProgressRecord schema OK
 ```
 
-### Live watcher read against existing S3 progress
+### Live watcher proof against disposable prefix (available after this step's implementation)
 
-After Step 5 or Step 6 smoke has written at least one shard:
+Step 5 and Step 6 do not write canonical campaign `batches/` or canonical `{feature}/smoke/`. Seed watcher inputs under a disposable prefix only.
 
 ```bash
 cd /workspace
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
+DISPOSABLE_PREFIX=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step7_progress_watcher/
+
+PYTHONPATH=. uv run python data_platform/generate_features/seed_progress_watcher_smoke.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --feature is_news_or_opinion \
+  --smoke-prefix "$DISPOSABLE_PREFIX" \
+  --durable-row-total 10000
+```
+
+Expected stdout:
+
+```text
+smoke_prefix=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step7_progress_watcher/
+progress_seeded=true
+watcher_seeded=true
+durable_row_total=10000
+```
+
+Run the watcher against the disposable prefix in dry-render mode (prints the rolling comment body without GitHub writes):
+
+```bash
 PYTHONPATH=. uv run python data_platform/generate_features/feature_progress_watcher.py \
   --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
   --feature is_news_or_opinion \
-  --github-issue 999 \
+  --smoke-prefix "$DISPOSABLE_PREFIX" \
+  --dry-render \
   --once
 ```
 
-Expected stdout when durable total is below 10,000:
-
-```text
-boundary_crossed=false
-durable_row_total=<number less than 10000>
-no_comment_update_needed=true
-```
-
-Expected stdout when durable total reaches at least 10,000:
+Expected stdout when durable total is at least 10,000:
 
 ```text
 boundary_crossed=true
 boundary=10000
-watcher_state_updated=true
+watcher_json_updated=true
+github_write_skipped=true
 rolling_comment<<<
-## Feature progress: is_news_or_opinion
+(same heading and body shape as Rolling comment body format example above)
 ...
 >>>rolling_comment
 ```
 
 ### Restart idempotency check
 
-Run the same watcher command twice without new shards landing.
+Run the same watcher command twice without changing seeded progress.
 
 Expected second stdout:
 
 ```text
 boundary_crossed=false
 duplicate_boundary_suppressed=true
+github_write_skipped=true
 ```
 
-Expected S3 effect: `watcher_state.json` unchanged after the second run.
+Expected S3 effect under the disposable prefix: `watcher.json` unchanged after the second run.
 
-### Manual subagent restart proof documented in runbook
+### Disposable prefix cleanup (required before merge)
 
-The operator runbook must include these exact steps:
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 
-1. Stop the watcher process.
-2. Confirm the feature generator or batch job is still running or safely idle.
-3. Re-run the watcher command with the same `--campaign-id` and `--feature`.
-4. Verify `duplicate_boundary_suppressed=true` when no new durable rows arrived.
+aws s3 rm s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step7_progress_watcher/ --recursive
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step7_progress_watcher/ --recursive
+```
 
-No repository command may start a Cursor agent.
+Expected: `aws s3 rm` reports deleted objects (or no objects found). `aws s3 ls` prints no lines, confirming the disposable prefix is empty.
 
 ## Acceptance criteria
 
-- Every durable shard append adds one validated `progress.jsonl` line with cumulative totals.
+- Every durable batch append adds one validated `progress.jsonl` line with cumulative totals.
+- `watcher.json` persists `github_comment_id` and `last_posted_milestone`.
 - Watcher CLI reads S3 state only and prints a rolling comment at each new 10,000-row boundary.
+- Step 7 watcher proof seeds and reads only under `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step7_progress_watcher/`; it does not depend on Step 5 or Step 6 writing canonical batches or canonical smoke.
+- Disposable S3 prefix is empty after `aws s3 rm ... --recursive` before merge.
 - Restarting the watcher does not duplicate boundary notifications.
-- `watcher_state.json` persists the last emitted boundary in S3.
 - Operator runbook documents short restartable manual watcher subagents outside the repo.
 - No repository code launches Cursor agents or posts to GitHub automatically.
 - No automated tests were added or run.
 
 ## Failure conditions
 
-- Progress totals derived only from memory, not from durable S3 shard state.
+- Progress totals derived only from memory, not from durable S3 batch state.
 - Missing cumulative `durable_row_total` on any progress line.
 - Duplicate rolling comment emission for the same 10,000 boundary after restart.
-- Watcher mutates shard objects or manifest content.
-- Any GitHub API client added to the generator or watcher path.
+- Watcher proof writes under the canonical campaign feature prefix instead of the disposable prefix.
+- Disposable prefix `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step7_progress_watcher/` is not empty before merge.
+- Claiming Step 5 or Step 6 wrote canonical campaign batches as a prerequisite for watcher proof.
+- Watcher mutates batch objects or manifest content.
+- Any GitHub API write client added to the generator or watcher path.
 - Any code path that launches Cursor agents or other autonomous agent runners.
+- Using `watcher_state.json` or a `progress/` directory instead of the canonical paths.
 - Any edit under `/workspace/tests/**`.
 
-## PR artifact/commit rules
+## PR artifact and commit rules
 
-- Branch name: `cursor/feature-progress-watcher-86b0`
-- Commit `feature_progress_watcher.py`, `progress_record.py`, runbook, and one sample printed rolling comment captured in `WATCHER_SMOKE_EVIDENCE.md` during review.
-- Delete dev-only boundary override helpers before merge; keep production 10,000-row cadence.
-- PR title: `Add durable progress reports for feature run watchers`
-- PR body must include a pasted sample rolling comment and the S3 keys for `progress.jsonl` and `watcher_state.json`.
+- Commit `feature_progress_watcher.py`, `progress_record.py`, and runbook.
+- Capture one sample printed rolling comment in `WATCHER_SMOKE_EVIDENCE.md` during review; delete before merge.
+- Before merge: delete `seed_progress_watcher_smoke.py`, run `aws s3 rm s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/step7_progress_watcher/ --recursive`, and verify the disposable prefix is empty.
+- PR title: `Add durable progress reports and watcher CLI for feature runs`
+- PR body must include a pasted sample rolling comment from `--dry-render` mode and the disposable smoke prefix used for proof.

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step8.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step8.md
@@ -1,136 +1,90 @@
-# Step 8: Generate `is_news_or_opinion` for 200,000 Bluesky posts
+# Step 8: Generate is_news_or_opinion for 200,000 Bluesky posts
 
 ## Goal
 
-Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_news_or_opinion` feature only. Publish immutable S3 shards, the final Parquet file, hash manifest, progress history, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
+Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_news_or_opinion` feature only. Publish immutable S3 batches, `final.parquet`, `manifest.json`, `progress.jsonl`, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
 
 This step is one future pull request and one GitHub feature issue. The issue stays open until the feature run is complete and validated.
 
-## Dependencies on Steps 3–7
+## Dependencies
 
-Do not start this step until Steps 3–7 have merged to `main`.
+Do not start until Steps 3, 6, and 7 have merged to `main`. Steps 2, 4, and 5 are required transitively through Step 6 and Step 7. See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md`.
 
-**Step 3 (S3 default backend).** Production feature generation reads preprocessed input and writes feature output through S3, not local `data_platform/data/` or Git LFS. Export AWS credentials before any S3-touching command:
+| Step | Requirement |
+|------|-------------|
+| Step 3 | S3 is the production backend |
+| Step 6 | `smoke_bluesky_campaign.py` and cost aggregation command (single invocation includes deliberate interruption and resume) |
+| Step 7 | `progress.jsonl`, `watcher.json`, and watcher CLI |
+
+## Main caller and implementation slice
+
+**Main caller (campaign mode; same command resumes automatically):**
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --features is_news_or_opinion \
+  --batch-size 2000
 ```
 
-**Step 4 (OpenAI Batch hardening and resume).** The engine persists in-flight OpenAI Batch job identity before polling, keeps successful records from partly failed jobs, retries only transient failures, and resumes without creating duplicate provider jobs. A failed or interrupted run reuses the same feature run directory and the same `--checkpoint` value.
+**Smoke caller (Phase A only; available after Step 6):**
 
-**Step 5 (Parquet shards and manifests).** Each durable batch writes one immutable 2,000-row Parquet shard under the feature S3 prefix, plus error records and a hash manifest. One blocking OpenAI Batch job stays active per feature. The run ends with one consolidated final Parquet file for `is_news_or_opinion`.
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_bluesky_campaign.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --feature is_news_or_opinion \
+  --output-dir docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_news_or_opinion
+```
 
-**Step 6 (ten-post smoke and campaign approval gate).** Use the deterministic ten-post sample shipped in Step 6 for every feature. Record average and maximum token usage, current model pricing, estimated full-run cost, S3 presence checks, and one deliberate interruption plus resume. Post the smoke cost estimate to this feature issue. Wait until the parent campaign issue records the sum of all seven feature estimates and receives one explicit approval before starting the 200,000-post run.
-
-**Step 7 (progress watcher).** After each durable shard, the runner writes a structured progress record. A restartable watcher subagent reads those records and updates one rolling GitHub issue comment at every 10,000 completed records for this feature.
+**Implementation slice for this PR:** documentation and run artifacts only. No product code changes.
 
 ## Pinned identity contract
-
-Use exactly these values for the full campaign. A different dataset, preprocessed run, campaign id, model, or prompt requires a new campaign and must not reuse this prefix.
 
 | Field | Pinned value |
 |-------|----------------|
 | Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
 | Preprocessed run | `2026_09_03-23:51:30` |
-| Preprocessed row count | `200000` (`metadata.json` `row_counts.output`) |
-| Preprocessed input S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/` |
-| Campaign id / feature run family | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Preprocessed row count | `200000` |
+| Campaign id | `bluesky_2026_09_03_235130_llm_features_v1` |
 | Feature name | `is_news_or_opinion` |
-| Feature S3 campaign prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/` |
-| Model id | `gpt-5.4-nano` (`lib.constants.DEFAULT_LLM_MODEL`) |
-| Engine | OpenAI Batch (`engine_type="openai"`) |
+| Run id | `bluesky_2026_09_03_235130_llm_features_v1:is_news_or_opinion` |
+| Feature S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/` |
+| Model id | `gpt-5.4-nano` |
 | Batch size | `2000` |
-| Temperature | `0.0` |
-| System prompt source | `data_platform/generate_features/is_news_or_opinion/generate_feature.py` → `SYSTEM_PROMPT` |
-| LLM output schema | `LlmIsNewsOrOpinionModel` in the same file |
-| Stored label schema | `IsNewsOrOpinionModel`: `source_record_id`, `label_timestamp`, `category` |
-| Prompt identity in metadata | `metadata.json` `features.is_news_or_opinion.model_id` = `gpt-5.4-nano` and `prompt_hash` = SHA-256 hex of `SYSTEM_PROMPT` |
-
-Record the exact `prompt_hash` from the smoke run metadata in the permanent run report. If `model_id` or `prompt_hash` drifts from the smoke run, stop and open a new campaign instead of resuming.
-
-## Caller command
-
-Run only this feature with batch size 2000. Do not pass any other `--features` value.
-
-**New feature run (smoke phase uses the Step 6 ten-post path; full run uses this command):**
-
-```bash
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-
-PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --features is_news_or_opinion \
-  --batch-size 2000
-```
-
-**Resume an interrupted run (same issue, same feature run directory name):**
-
-```bash
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-
-PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --features is_news_or_opinion \
-  --batch-size 2000 \
-  --checkpoint <feature_run_timestamp>
-```
-
-Replace `<feature_run_timestamp>` with the folder name under the campaign prefix (for example `2026_09_05-14:30:00`). Never start a second concurrent OpenAI Batch job for this feature while an unfinished run exists.
-
-## Two-phase pull request flow
-
-### Phase A — smoke, estimate, and review artifacts
-
-1. Confirm Steps 3–7 are on `main`.
-2. Run the Step 6 ten-post smoke for `is_news_or_opinion` only.
-3. Perform the deliberate interruption and resume required by Step 6 on the same feature run.
-4. Write temporary smoke artifacts under the plan reports folder (see Allowed files).
-5. Commit and push those temporary smoke artifacts to the feature branch. Do not commit labels.
-6. Post the estimated full-run cost (derived from smoke token usage and current `gpt-5.4-nano` Batch pricing) to this feature issue.
-7. Stop. Do not start the 200,000-post run until the parent campaign issue shows one approval covering all seven feature estimates.
-
-### Phase B — full run after parent approval
-
-1. Confirm the parent campaign issue has explicit approval for the combined estimate.
-2. Start or resume the full run with the caller command above.
-3. Start the Step 7 progress watcher for this feature. It must update the rolling GitHub comment at every 10,000 durable rows.
-4. When the run completes, validate S3 artifacts and row counts (see Acceptance checks).
-5. Write the permanent run report at `reports/is_news_or_opinion_run_report.md` with actual cost, throughput, retries, error rate, and label counts.
-6. Delete every temporary smoke artifact from the plan reports folder.
-7. Commit and push only the permanent run report. Push the final S3 objects (already written during the run). Open or update the pull request for merge.
-
-If the full run fails or is interrupted, keep the same GitHub issue and the same `--checkpoint` value. Resume; do not open a parallel run or a new campaign prefix.
+| Label field | `category` |
+| Pydantic model | `IsNewsOrOpinionModel` |
+| Accepted label values | `news`, `opinion`, `neither` |
+| Prompt source | `data_platform/generate_features/is_news_or_opinion/generate_feature.py` → `SYSTEM_PROMPT` |
 
 ## Files to inspect (read-only)
 
 | Path | Why |
 |------|-----|
-| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope and done criteria |
-| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Bluesky feature CLI entrypoint |
-| `/workspace/data_platform/generate_features/platform_cli.py` | `--features`, `--batch-size`, `--checkpoint` |
-| `/workspace/data_platform/generate_features/is_news_or_opinion/generate_feature.py` | `SYSTEM_PROMPT`, accepted label schema |
-| `/workspace/data_platform/generate_features/registry.py` | Feature registry entry for `is_news_or_opinion` |
-| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch engine and default model |
-| `/workspace/data_platform/generate_features/metadata.py` | `model_id`, `prompt_hash`, resume identity checks |
-| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Pinned input row count and run id |
-| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export, no automated tests |
-
-After Steps 3–7 merge, also read the Step 6 smoke helper, Step 7 progress watcher entrypoint, and any S3 layout docs those steps add.
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | Canonical layout and smoke flow |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Campaign CLI |
+| `/workspace/data_platform/generate_features/smoke_bluesky_campaign.py` | Ten-post smoke (Step 6) |
+| `/workspace/data_platform/generate_features/feature_progress_watcher.py` | Progress watcher (Step 7) |
+| `/workspace/data_platform/generate_features/is_news_or_opinion/generate_feature.py` | Prompt and schema |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credentials, no automated tests |
 
 ## Files allowed to change
 
-Only documentation artifacts for this feature run. No product code, no label data in Git.
+Documentation artifacts only.
 
-**Temporary smoke artifacts (committed during Phase A, deleted before merge):**
+**Temporary smoke artifacts (Phase A; deleted before merge):**
 
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_news_or_opinion_smoke_cost.json`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_news_or_opinion_smoke_resume_evidence.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_news_or_opinion_smoke_s3_checks.txt`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_news_or_opinion/is_news_or_opinion_cost_report.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_news_or_opinion/is_news_or_opinion_resume_evidence.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_news_or_opinion/is_news_or_opinion_s3_checks.txt`
 
-**Permanent run report (committed during Phase B, kept after merge):**
+**Permanent run report (Phase B; kept after merge):**
 
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_news_or_opinion_run_report.md`
 
@@ -138,40 +92,64 @@ Only documentation artifacts for this feature run. No product code, no label dat
 
 - Any file under `/workspace/data_platform/`, `/workspace/lib/`, `/workspace/ml_tooling/`, `/workspace/tests/`, `/workspace/pyproject.toml`, `/workspace/CHANGELOG.md`
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
-- Any other step file under `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/`
-- Any path under the S3 prefixes for the other six features:
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_political/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
+- Any other step file under `steps/`
+- S3 prefixes for the other six features
 - Any committed Parquet, CSV, or JSON label files anywhere in the repository
 
 Do not add or run automated tests.
 
-## S3 artifacts
+## Locked contracts
 
-All objects live under:
+See `campaign_contract.md`. S3 objects for this feature:
 
-`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
+| Object | Path |
+|--------|------|
+| Smoke input | `.../is_news_or_opinion/smoke/input.parquet` |
+| Smoke output | `.../is_news_or_opinion/smoke/output.parquet` |
+| Smoke cost report | `.../is_news_or_opinion/smoke/cost_report.json` |
+| Smoke resume evidence | `.../is_news_or_opinion/smoke/resume_evidence.json` |
+| Batches | `.../is_news_or_opinion/batches/part-NNNNN.parquet` |
+| Final | `.../is_news_or_opinion/final.parquet` |
+| Manifest | `.../is_news_or_opinion/manifest.json` |
+| Progress | `.../is_news_or_opinion/progress.jsonl` |
+| Errors | `.../is_news_or_opinion/errors.jsonl` (when needed) |
+| Watcher | `.../is_news_or_opinion/watcher.json` |
 
-Expected layout after Step 5 (exact subfolder names follow the Step 5 implementation):
+Q44 columns in `final.parquet`: `source_record_id`, `run_id`, `batch_id`, `request_id`, `attempt_count`, `label_timestamp`, `category`.
 
-| Artifact | Purpose |
-|----------|---------|
-| `shards/` | Immutable 2,000-row Parquet shards |
-| `final/is_news_or_opinion.parquet` | Consolidated feature output |
-| `manifest/` | SHA-256 hash manifest over shards and final file |
-| `progress/` | Structured progress records (one per durable shard) |
-| `errors/` | Error records for rows that failed after retries |
-| `metadata.json` | Run metadata including `model_id`, `prompt_hash`, labeled counts, OpenAI job ids |
+After parent approval, `part-00000.parquet` must contain ten unchanged smoke labels plus 1,990 new labels (2,000 rows total). The next 99 provider jobs each write `part-00001` through `part-00099` with 2,000 rows each. Total: exactly 100 canonical batch objects and 200,000 rows. Preserve original smoke `batch_id` and `request_id` in the ten rows in `part-00000`. `manifest.json` batch entry for `part_index=0` may list both the smoke provider `batch_id` and the first production provider `batch_id`.
 
-Intermediate shards may carry the intermediate-artifact lifecycle tag from Step 16. Final Parquet, manifest, progress records, and reports are retained.
+## Two-phase pull request flow
 
-## Basic commands and checks
+### Phase A: smoke, estimate, and review artifacts
 
-**List campaign prefix:**
+1. Confirm Steps 3, 6, and 7 are on `main`.
+2. Run `smoke_bluesky_campaign.py` once for `is_news_or_opinion` only. The smoke caller performs one deliberate interruption and resume and writes untagged S3 evidence under `is_news_or_opinion/smoke/` including `resume_evidence.json`. Do not repeat the interruption procedure in this step.
+3. Commit temporary Git smoke artifacts under `reports/smoke/is_news_or_opinion/` (include a local copy of `resume_evidence.json`).
+4. Post estimated full-run cost to this feature's GitHub issue through authenticated GitHub integration.
+5. Stop. Do not start the 200,000-post run until the parent campaign issue has one aggregate estimate and explicit human approval.
+
+### Phase B: full run after parent approval
+
+1. Confirm parent campaign issue has explicit approval.
+2. Run the campaign CLI command above (same command resumes automatically).
+3. Run the Step 7 watcher at every 10,000 durable rows; post rolling comment through authenticated GitHub integration.
+4. Validate S3 artifacts and row counts.
+5. Write `reports/is_news_or_opinion_run_report.md`.
+6. Delete temporary smoke artifacts from Git. S3 smoke evidence remains.
+7. Commit and push only the permanent run report.
+
+## Ordered work
+
+1. Phase A smoke and cost estimate.
+2. Pause for parent aggregate and human approval.
+3. Phase B full run with watcher.
+4. Runtime validation.
+5. Permanent report and Git cleanup.
+
+## Exact commands and expected output
+
+### List feature prefix
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
@@ -180,97 +158,98 @@ export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/ --recursive
 ```
 
-**Download final Parquet for validation:**
+### Download final parquet for validation
 
 ```bash
 aws s3 cp \
-  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/final/is_news_or_opinion.parquet \
-  /tmp/is_news_or_opinion.parquet
+  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/final.parquet \
+  /tmp/is_news_or_opinion_final.parquet
 ```
 
-**Validate row count, uniqueness, schema, and accepted values:**
+### Validate row count, Q44 schema, and accepted values
 
 ```bash
-python - <<'PY'
+PYTHONPATH=. uv run python - <<'PY'
 import pandas as pd
 
 ACCEPTED = {"news", "opinion", "neither"}
-REQUIRED_COLS = ["source_record_id", "label_timestamp", "category"]
+Q44_COLS = [
+    "source_record_id", "run_id", "batch_id", "request_id",
+    "attempt_count", "label_timestamp", "category",
+]
 
-df = pd.read_parquet("/tmp/is_news_or_opinion.parquet")
-assert list(df.columns) == REQUIRED_COLS, df.columns.tolist()
+df = pd.read_parquet("/tmp/is_news_or_opinion_final.parquet")
+assert list(df.columns) == Q44_COLS, df.columns.tolist()
 assert len(df) == 200_000, len(df)
-assert df["source_record_id"].is_unique, "duplicate source_record_id"
-assert df["category"].notna().all(), "missing category"
+assert df["source_record_id"].is_unique
+assert df["run_id"].nunique() == 1
+assert df["run_id"].iloc[0] == "bluesky_2026_09_03_235130_llm_features_v1:is_news_or_opinion"
+assert df["category"].notna().all()
 bad = set(df["category"].unique()) - ACCEPTED
 assert not bad, bad
 print("ok", df["category"].value_counts().to_dict())
 PY
 ```
 
-**Compare labeled ids to preprocessed input:**
+Expected: `ok` plus category counts and exit code 0.
+
+### Verify manifest SHA-256
 
 ```bash
-python - <<'PY'
-import pandas as pd
-
-pre = pd.read_parquet(
-    "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
-)
-feat = pd.read_parquet("/tmp/is_news_or_opinion.parquet")
-input_ids = set(pre["source_record_id"])
-output_ids = set(feat["source_record_id"])
-assert input_ids == output_ids, (len(input_ids), len(output_ids), len(input_ids - output_ids))
-print("ok ids match")
-PY
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/manifest.json -
 ```
 
-When production reads preprocessed input from S3 (Step 3), download `posts.parquet` from the preprocessed S3 prefix instead of the local path.
+Expected: JSON with `final_parquet.sha256` matching downloaded bytes (SHA-256 only, not ETag).
 
-**Verify manifest hashes** using the Step 5 manifest verifier against `manifest/` and `final/is_news_or_opinion.parquet`.
-
-**Read progress for the watcher:**
+### Read progress for watcher
 
 ```bash
-aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/progress/ --recursive /tmp/is_news_or_opinion_progress/
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/progress.jsonl /tmp/is_news_or_opinion_progress.jsonl
 ```
 
-Confirm a new progress record exists after each 2,000-row shard and that the watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
-
-## Exact accepted values
-
-Each output row must validate as `IsNewsOrOpinionModel`:
-
-| Column | Type | Accepted values |
-|--------|------|-----------------|
-| `source_record_id` | string | One per preprocessed post; exactly 200,000 unique values |
-| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
-| `category` | string | Exactly one of: `news`, `opinion`, `neither` |
-
-No nulls. No extra columns. No duplicate `source_record_id`.
+Confirm watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
 
 ## Acceptance criteria
 
-1. **Coverage:** Exactly 200,000 rows. Exactly 200,000 unique `source_record_id` values. Zero missing outputs relative to the pinned preprocessed run.
-2. **Schema:** Columns match `IsNewsOrOpinionModel`. All `category` values are in the accepted set.
-3. **Identity:** `metadata.json` records `model_id` = `gpt-5.4-nano` and the `prompt_hash` of the pinned `SYSTEM_PROMPT`.
-4. **S3:** Final Parquet, manifest, progress history, and error records (if any) are present under the feature campaign prefix.
-5. **Cost and operations:** The permanent run report records estimated cost (from smoke), actual cost (from OpenAI usage), throughput (posts per second and tokens per second), retry count, error rate, and label counts per category.
-6. **Progress:** Watcher updated the GitHub comment at every 10,000 durable rows.
-7. **Resume:** If the run was interrupted, resume used the same issue, same `--checkpoint`, and no duplicate OpenAI Batch job.
-8. **Repository hygiene:** No label files committed. Temporary smoke artifacts removed before merge. Only `reports/is_news_or_opinion_run_report.md` remains from this step in Git.
+1. Exactly 200,000 unique `source_record_id` values with zero missing outputs.
+2. Q44 columns present with correct `run_id` and accepted `category` values.
+3. `manifest.json`, `progress.jsonl`, and `final.parquet` present under the feature prefix.
+4. Permanent run report records smoke estimate, actual cost, throughput, retries, error rate, and label counts.
+5. Watcher updated the GitHub comment at every 10,000 durable rows.
+6. Resume reused the same `run_id` with no duplicate OpenAI Batch job.
+7. S3 smoke evidence under `is_news_or_opinion/smoke/` includes `resume_evidence.json` from the single smoke invocation.
+8. Temporary Git smoke files removed before merge. S3 smoke evidence remains.
+9. Only `reports/is_news_or_opinion_run_report.md` remains from this step in Git.
+
+## Failure conditions
+
+- Full 200k run starts before parent campaign issue approval.
+- Smoke run twice for the same feature or different ten-post ids than other features.
+- Smoke writes any object under `batches/` (smoke never writes canonical batch objects).
+- `part-00000.parquet` after full run does not contain ten unchanged smoke labels plus 1,990 new labels.
+- Missing Q44 columns or wrong `run_id`.
+- Any `category` value outside `news`, `opinion`, `neither`.
+- Using `--checkpoint`, `--resume`, `run_bluesky_llm_campaign.py`, or `APPROVED.txt`.
+- Objects under `campaigns/`, `shards/`, `final/` subdirectory, or per-run timestamp folders.
+- Label files committed to Git.
+- Temporary smoke artifacts left in Git after merge.
+- Any product code change in this PR.
+- Any automated test added or run.
+
+## PR artifact and commit rules
+
+- Phase A: commit temporary smoke artifacts for review.
+- Phase B: commit only permanent run report; delete temporary smoke files before merge.
+- Do not edit `plan.md` or other step specs.
 
 ## Permanent run report contents
 
 `reports/is_news_or_opinion_run_report.md` must include:
 
-- Pinned identity table (dataset, preprocessed run, campaign id, model, prompt file path, `prompt_hash`)
-- S3 URIs for final Parquet, manifest, and progress folder
-- Smoke estimated full-run cost (USD) and assumptions
-- Actual cost (USD), input/output/total tokens
-- Throughput (posts per second, tokens per second)
-- Retry count and error rate (failed rows / 200,000)
-- Label counts: `news`, `opinion`, `neither`
-- Validation command outputs (pass/fail summary)
-- Feature run timestamp and `--checkpoint` value used
-- OpenAI Batch job id(s) from metadata
+- Pinned identity table (dataset, preprocessed run, campaign id, run id, model, prompt path, prompt hash)
+- S3 URIs for `final.parquet`, `manifest.json`, and `progress.jsonl`
+- Smoke estimated full-run cost and assumptions
+- Actual cost, tokens, throughput, retry count, error rate
+- Label counts for `news`, `opinion`, `neither`
+- Validation command pass/fail summary
+- OpenAI Batch job id(s) from manifest or progress lines

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step8.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step8.md
@@ -1,0 +1,276 @@
+# Step 8: Generate `is_news_or_opinion` for 200,000 Bluesky posts
+
+## Goal
+
+Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_news_or_opinion` feature only. Publish immutable S3 shards, the final Parquet file, hash manifest, progress history, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
+
+This step is one future pull request and one GitHub feature issue. The issue stays open until the feature run is complete and validated.
+
+## Dependencies on Steps 3–7
+
+Do not start this step until Steps 3–7 have merged to `main`.
+
+**Step 3 (S3 default backend).** Production feature generation reads preprocessed input and writes feature output through S3, not local `data_platform/data/` or Git LFS. Export AWS credentials before any S3-touching command:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+```
+
+**Step 4 (OpenAI Batch hardening and resume).** The engine persists in-flight OpenAI Batch job identity before polling, keeps successful records from partly failed jobs, retries only transient failures, and resumes without creating duplicate provider jobs. A failed or interrupted run reuses the same feature run directory and the same `--checkpoint` value.
+
+**Step 5 (Parquet shards and manifests).** Each durable batch writes one immutable 2,000-row Parquet shard under the feature S3 prefix, plus error records and a hash manifest. One blocking OpenAI Batch job stays active per feature. The run ends with one consolidated final Parquet file for `is_news_or_opinion`.
+
+**Step 6 (ten-post smoke and campaign approval gate).** Use the deterministic ten-post sample shipped in Step 6 for every feature. Record average and maximum token usage, current model pricing, estimated full-run cost, S3 presence checks, and one deliberate interruption plus resume. Post the smoke cost estimate to this feature issue. Wait until the parent campaign issue records the sum of all seven feature estimates and receives one explicit approval before starting the 200,000-post run.
+
+**Step 7 (progress watcher).** After each durable shard, the runner writes a structured progress record. A restartable watcher subagent reads those records and updates one rolling GitHub issue comment at every 10,000 completed records for this feature.
+
+## Pinned identity contract
+
+Use exactly these values for the full campaign. A different dataset, preprocessed run, campaign id, model, or prompt requires a new campaign and must not reuse this prefix.
+
+| Field | Pinned value |
+|-------|----------------|
+| Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| Preprocessed run | `2026_09_03-23:51:30` |
+| Preprocessed row count | `200000` (`metadata.json` `row_counts.output`) |
+| Preprocessed input S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/` |
+| Campaign id / feature run family | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Feature name | `is_news_or_opinion` |
+| Feature S3 campaign prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/` |
+| Model id | `gpt-5.4-nano` (`lib.constants.DEFAULT_LLM_MODEL`) |
+| Engine | OpenAI Batch (`engine_type="openai"`) |
+| Batch size | `2000` |
+| Temperature | `0.0` |
+| System prompt source | `data_platform/generate_features/is_news_or_opinion/generate_feature.py` → `SYSTEM_PROMPT` |
+| LLM output schema | `LlmIsNewsOrOpinionModel` in the same file |
+| Stored label schema | `IsNewsOrOpinionModel`: `source_record_id`, `label_timestamp`, `category` |
+| Prompt identity in metadata | `metadata.json` `features.is_news_or_opinion.model_id` = `gpt-5.4-nano` and `prompt_hash` = SHA-256 hex of `SYSTEM_PROMPT` |
+
+Record the exact `prompt_hash` from the smoke run metadata in the permanent run report. If `model_id` or `prompt_hash` drifts from the smoke run, stop and open a new campaign instead of resuming.
+
+## Caller command
+
+Run only this feature with batch size 2000. Do not pass any other `--features` value.
+
+**New feature run (smoke phase uses the Step 6 ten-post path; full run uses this command):**
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --features is_news_or_opinion \
+  --batch-size 2000
+```
+
+**Resume an interrupted run (same issue, same feature run directory name):**
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --features is_news_or_opinion \
+  --batch-size 2000 \
+  --checkpoint <feature_run_timestamp>
+```
+
+Replace `<feature_run_timestamp>` with the folder name under the campaign prefix (for example `2026_09_05-14:30:00`). Never start a second concurrent OpenAI Batch job for this feature while an unfinished run exists.
+
+## Two-phase pull request flow
+
+### Phase A — smoke, estimate, and review artifacts
+
+1. Confirm Steps 3–7 are on `main`.
+2. Run the Step 6 ten-post smoke for `is_news_or_opinion` only.
+3. Perform the deliberate interruption and resume required by Step 6 on the same feature run.
+4. Write temporary smoke artifacts under the plan reports folder (see Allowed files).
+5. Commit and push those temporary smoke artifacts to the feature branch. Do not commit labels.
+6. Post the estimated full-run cost (derived from smoke token usage and current `gpt-5.4-nano` Batch pricing) to this feature issue.
+7. Stop. Do not start the 200,000-post run until the parent campaign issue shows one approval covering all seven feature estimates.
+
+### Phase B — full run after parent approval
+
+1. Confirm the parent campaign issue has explicit approval for the combined estimate.
+2. Start or resume the full run with the caller command above.
+3. Start the Step 7 progress watcher for this feature. It must update the rolling GitHub comment at every 10,000 durable rows.
+4. When the run completes, validate S3 artifacts and row counts (see Acceptance checks).
+5. Write the permanent run report at `reports/is_news_or_opinion_run_report.md` with actual cost, throughput, retries, error rate, and label counts.
+6. Delete every temporary smoke artifact from the plan reports folder.
+7. Commit and push only the permanent run report. Push the final S3 objects (already written during the run). Open or update the pull request for merge.
+
+If the full run fails or is interrupted, keep the same GitHub issue and the same `--checkpoint` value. Resume; do not open a parallel run or a new campaign prefix.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope and done criteria |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Bluesky feature CLI entrypoint |
+| `/workspace/data_platform/generate_features/platform_cli.py` | `--features`, `--batch-size`, `--checkpoint` |
+| `/workspace/data_platform/generate_features/is_news_or_opinion/generate_feature.py` | `SYSTEM_PROMPT`, accepted label schema |
+| `/workspace/data_platform/generate_features/registry.py` | Feature registry entry for `is_news_or_opinion` |
+| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch engine and default model |
+| `/workspace/data_platform/generate_features/metadata.py` | `model_id`, `prompt_hash`, resume identity checks |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Pinned input row count and run id |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export, no automated tests |
+
+After Steps 3–7 merge, also read the Step 6 smoke helper, Step 7 progress watcher entrypoint, and any S3 layout docs those steps add.
+
+## Files allowed to change
+
+Only documentation artifacts for this feature run. No product code, no label data in Git.
+
+**Temporary smoke artifacts (committed during Phase A, deleted before merge):**
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_news_or_opinion_smoke_cost.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_news_or_opinion_smoke_resume_evidence.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_news_or_opinion_smoke_s3_checks.txt`
+
+**Permanent run report (committed during Phase B, kept after merge):**
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_news_or_opinion_run_report.md`
+
+## Files forbidden to change
+
+- Any file under `/workspace/data_platform/`, `/workspace/lib/`, `/workspace/ml_tooling/`, `/workspace/tests/`, `/workspace/pyproject.toml`, `/workspace/CHANGELOG.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
+- Any other step file under `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/`
+- Any path under the S3 prefixes for the other six features:
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_political/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
+- Any committed Parquet, CSV, or JSON label files anywhere in the repository
+
+Do not add or run automated tests.
+
+## S3 artifacts
+
+All objects live under:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
+
+Expected layout after Step 5 (exact subfolder names follow the Step 5 implementation):
+
+| Artifact | Purpose |
+|----------|---------|
+| `shards/` | Immutable 2,000-row Parquet shards |
+| `final/is_news_or_opinion.parquet` | Consolidated feature output |
+| `manifest/` | SHA-256 hash manifest over shards and final file |
+| `progress/` | Structured progress records (one per durable shard) |
+| `errors/` | Error records for rows that failed after retries |
+| `metadata.json` | Run metadata including `model_id`, `prompt_hash`, labeled counts, OpenAI job ids |
+
+Intermediate shards may carry the intermediate-artifact lifecycle tag from Step 16. Final Parquet, manifest, progress records, and reports are retained.
+
+## Basic commands and checks
+
+**List campaign prefix:**
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/ --recursive
+```
+
+**Download final Parquet for validation:**
+
+```bash
+aws s3 cp \
+  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/final/is_news_or_opinion.parquet \
+  /tmp/is_news_or_opinion.parquet
+```
+
+**Validate row count, uniqueness, schema, and accepted values:**
+
+```bash
+python - <<'PY'
+import pandas as pd
+
+ACCEPTED = {"news", "opinion", "neither"}
+REQUIRED_COLS = ["source_record_id", "label_timestamp", "category"]
+
+df = pd.read_parquet("/tmp/is_news_or_opinion.parquet")
+assert list(df.columns) == REQUIRED_COLS, df.columns.tolist()
+assert len(df) == 200_000, len(df)
+assert df["source_record_id"].is_unique, "duplicate source_record_id"
+assert df["category"].notna().all(), "missing category"
+bad = set(df["category"].unique()) - ACCEPTED
+assert not bad, bad
+print("ok", df["category"].value_counts().to_dict())
+PY
+```
+
+**Compare labeled ids to preprocessed input:**
+
+```bash
+python - <<'PY'
+import pandas as pd
+
+pre = pd.read_parquet(
+    "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
+)
+feat = pd.read_parquet("/tmp/is_news_or_opinion.parquet")
+input_ids = set(pre["source_record_id"])
+output_ids = set(feat["source_record_id"])
+assert input_ids == output_ids, (len(input_ids), len(output_ids), len(input_ids - output_ids))
+print("ok ids match")
+PY
+```
+
+When production reads preprocessed input from S3 (Step 3), download `posts.parquet` from the preprocessed S3 prefix instead of the local path.
+
+**Verify manifest hashes** using the Step 5 manifest verifier against `manifest/` and `final/is_news_or_opinion.parquet`.
+
+**Read progress for the watcher:**
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/progress/ --recursive /tmp/is_news_or_opinion_progress/
+```
+
+Confirm a new progress record exists after each 2,000-row shard and that the watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
+
+## Exact accepted values
+
+Each output row must validate as `IsNewsOrOpinionModel`:
+
+| Column | Type | Accepted values |
+|--------|------|-----------------|
+| `source_record_id` | string | One per preprocessed post; exactly 200,000 unique values |
+| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
+| `category` | string | Exactly one of: `news`, `opinion`, `neither` |
+
+No nulls. No extra columns. No duplicate `source_record_id`.
+
+## Acceptance criteria
+
+1. **Coverage:** Exactly 200,000 rows. Exactly 200,000 unique `source_record_id` values. Zero missing outputs relative to the pinned preprocessed run.
+2. **Schema:** Columns match `IsNewsOrOpinionModel`. All `category` values are in the accepted set.
+3. **Identity:** `metadata.json` records `model_id` = `gpt-5.4-nano` and the `prompt_hash` of the pinned `SYSTEM_PROMPT`.
+4. **S3:** Final Parquet, manifest, progress history, and error records (if any) are present under the feature campaign prefix.
+5. **Cost and operations:** The permanent run report records estimated cost (from smoke), actual cost (from OpenAI usage), throughput (posts per second and tokens per second), retry count, error rate, and label counts per category.
+6. **Progress:** Watcher updated the GitHub comment at every 10,000 durable rows.
+7. **Resume:** If the run was interrupted, resume used the same issue, same `--checkpoint`, and no duplicate OpenAI Batch job.
+8. **Repository hygiene:** No label files committed. Temporary smoke artifacts removed before merge. Only `reports/is_news_or_opinion_run_report.md` remains from this step in Git.
+
+## Permanent run report contents
+
+`reports/is_news_or_opinion_run_report.md` must include:
+
+- Pinned identity table (dataset, preprocessed run, campaign id, model, prompt file path, `prompt_hash`)
+- S3 URIs for final Parquet, manifest, and progress folder
+- Smoke estimated full-run cost (USD) and assumptions
+- Actual cost (USD), input/output/total tokens
+- Throughput (posts per second, tokens per second)
+- Retry count and error rate (failed rows / 200,000)
+- Label counts: `news`, `opinion`, `neither`
+- Validation command outputs (pass/fail summary)
+- Feature run timestamp and `--checkpoint` value used
+- OpenAI Batch job id(s) from metadata

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step9.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step9.md
@@ -1,136 +1,90 @@
-# Step 9: Generate `is_political` for 200,000 Bluesky posts
+# Step 9: Generate is_political for 200,000 Bluesky posts
 
 ## Goal
 
-Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_political` feature only. Publish immutable S3 shards, the final Parquet file, hash manifest, progress history, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
+Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_political` feature only. Publish immutable S3 batches, `final.parquet`, `manifest.json`, `progress.jsonl`, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
 
 This step is one future pull request and one GitHub feature issue. The issue stays open until the feature run is complete and validated.
 
-## Dependencies on Steps 3–7
+## Dependencies
 
-Do not start this step until Steps 3–7 have merged to `main`.
+Do not start until Steps 3, 6, and 7 have merged to `main`. Steps 2, 4, and 5 are required transitively through Step 6 and Step 7. See `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md`.
 
-**Step 3 (S3 default backend).** Production feature generation reads preprocessed input and writes feature output through S3, not local `data_platform/data/` or Git LFS. Export AWS credentials before any S3-touching command:
+| Step | Requirement |
+|------|-------------|
+| Step 3 | S3 is the production backend |
+| Step 6 | `smoke_bluesky_campaign.py` and cost aggregation command (single invocation includes deliberate interruption and resume) |
+| Step 7 | `progress.jsonl`, `watcher.json`, and watcher CLI |
+
+## Main caller and implementation slice
+
+**Main caller (campaign mode; same command resumes automatically):**
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --features is_political \
+  --batch-size 2000
 ```
 
-**Step 4 (OpenAI Batch hardening and resume).** The engine persists in-flight OpenAI Batch job identity before polling, keeps successful records from partly failed jobs, retries only transient failures, and resumes without creating duplicate provider jobs. A failed or interrupted run reuses the same feature run directory and the same `--checkpoint` value.
+**Smoke caller (Phase A only; available after Step 6):**
 
-**Step 5 (Parquet shards and manifests).** Each durable batch writes one immutable 2,000-row Parquet shard under the feature S3 prefix, plus error records and a hash manifest. One blocking OpenAI Batch job stays active per feature. The run ends with one consolidated final Parquet file for `is_political`.
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_bluesky_campaign.py \
+  --campaign-id bluesky_2026_09_03_235130_llm_features_v1 \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --preprocessed-run 2026_09_03-23:51:30 \
+  --feature is_political \
+  --output-dir docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_political
+```
 
-**Step 6 (ten-post smoke and campaign approval gate).** Use the deterministic ten-post sample shipped in Step 6 for every feature. Record average and maximum token usage, current model pricing, estimated full-run cost, S3 presence checks, and one deliberate interruption plus resume. Post the smoke cost estimate to this feature issue. Wait until the parent campaign issue records the sum of all seven feature estimates and receives one explicit approval before starting the 200,000-post run.
-
-**Step 7 (progress watcher).** After each durable shard, the runner writes a structured progress record. A restartable watcher subagent reads those records and updates one rolling GitHub issue comment at every 10,000 completed records for this feature.
+**Implementation slice for this PR:** documentation and run artifacts only. No product code changes.
 
 ## Pinned identity contract
-
-Use exactly these values for the full campaign. A different dataset, preprocessed run, campaign id, model, or prompt requires a new campaign and must not reuse this prefix.
 
 | Field | Pinned value |
 |-------|----------------|
 | Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
 | Preprocessed run | `2026_09_03-23:51:30` |
-| Preprocessed row count | `200000` (`metadata.json` `row_counts.output`) |
-| Preprocessed input S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/` |
-| Campaign id / feature run family | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Preprocessed row count | `200000` |
+| Campaign id | `bluesky_2026_09_03_235130_llm_features_v1` |
 | Feature name | `is_political` |
-| Feature S3 campaign prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/` |
-| Model id | `gpt-5.4-nano` (`lib.constants.DEFAULT_LLM_MODEL`) |
-| Engine | OpenAI Batch (`engine_type="openai"`) |
+| Run id | `bluesky_2026_09_03_235130_llm_features_v1:is_political` |
+| Feature S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/` |
+| Model id | `gpt-5.4-nano` |
 | Batch size | `2000` |
-| Temperature | `0.0` |
-| System prompt source | `data_platform/generate_features/is_political/generate_feature.py` → `SYSTEM_PROMPT` |
-| LLM output schema | `LlmIsPoliticalModel` in the same file |
-| Stored label schema | `IsPoliticalModel`: `source_record_id`, `label_timestamp`, `is_political` |
-| Prompt identity in metadata | `metadata.json` `features.is_political.model_id` = `gpt-5.4-nano` and `prompt_hash` = SHA-256 hex of `SYSTEM_PROMPT` |
-
-Record the exact `prompt_hash` from the smoke run metadata in the permanent run report. If `model_id` or `prompt_hash` drifts from the smoke run, stop and open a new campaign instead of resuming.
-
-## Caller command
-
-Run only this feature with batch size 2000. Do not pass any other `--features` value.
-
-**New feature run (smoke phase uses the Step 6 ten-post path; full run uses this command):**
-
-```bash
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-
-PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --features is_political \
-  --batch-size 2000
-```
-
-**Resume an interrupted run (same issue, same feature run directory name):**
-
-```bash
-export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-
-PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
-  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
-  --features is_political \
-  --batch-size 2000 \
-  --checkpoint <feature_run_timestamp>
-```
-
-Replace `<feature_run_timestamp>` with the folder name under the campaign prefix (for example `2026_09_05-14:30:00`). Never start a second concurrent OpenAI Batch job for this feature while an unfinished run exists.
-
-## Two-phase pull request flow
-
-### Phase A — smoke, estimate, and review artifacts
-
-1. Confirm Steps 3–7 are on `main`.
-2. Run the Step 6 ten-post smoke for `is_political` only.
-3. Perform the deliberate interruption and resume required by Step 6 on the same feature run.
-4. Write temporary smoke artifacts under the plan reports folder (see Allowed files).
-5. Commit and push those temporary smoke artifacts to the feature branch. Do not commit labels.
-6. Post the estimated full-run cost (derived from smoke token usage and current `gpt-5.4-nano` Batch pricing) to this feature issue.
-7. Stop. Do not start the 200,000-post run until the parent campaign issue shows one approval covering all seven feature estimates.
-
-### Phase B — full run after parent approval
-
-1. Confirm the parent campaign issue has explicit approval for the combined estimate.
-2. Start or resume the full run with the caller command above.
-3. Start the Step 7 progress watcher for this feature. It must update the rolling GitHub comment at every 10,000 durable rows.
-4. When the run completes, validate S3 artifacts and row counts (see Acceptance checks).
-5. Write the permanent run report at `reports/is_political_run_report.md` with actual cost, throughput, retries, error rate, and label counts.
-6. Delete every temporary smoke artifact from the plan reports folder.
-7. Commit and push only the permanent run report. Push the final S3 objects (already written during the run). Open or update the pull request for merge.
-
-If the full run fails or is interrupted, keep the same GitHub issue and the same `--checkpoint` value. Resume; do not open a parallel run or a new campaign prefix.
+| Label field | `is_political` |
+| Pydantic model | `IsPoliticalModel` |
+| Accepted label values | boolean `true` or `false` |
+| Prompt source | `data_platform/generate_features/is_political/generate_feature.py` → `SYSTEM_PROMPT` |
 
 ## Files to inspect (read-only)
 
 | Path | Why |
 |------|-----|
-| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope and done criteria |
-| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Bluesky feature CLI entrypoint |
-| `/workspace/data_platform/generate_features/platform_cli.py` | `--features`, `--batch-size`, `--checkpoint` |
-| `/workspace/data_platform/generate_features/is_political/generate_feature.py` | `SYSTEM_PROMPT`, accepted label schema |
-| `/workspace/data_platform/generate_features/registry.py` | Feature registry entry for `is_political` |
-| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch engine and default model |
-| `/workspace/data_platform/generate_features/metadata.py` | `model_id`, `prompt_hash`, resume identity checks |
-| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Pinned input row count and run id |
-| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export, no automated tests |
-
-After Steps 3–7 merge, also read the Step 6 smoke helper, Step 7 progress watcher entrypoint, and any S3 layout docs those steps add.
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | Canonical layout and smoke flow |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Campaign CLI |
+| `/workspace/data_platform/generate_features/smoke_bluesky_campaign.py` | Ten-post smoke (Step 6) |
+| `/workspace/data_platform/generate_features/feature_progress_watcher.py` | Progress watcher (Step 7) |
+| `/workspace/data_platform/generate_features/is_political/generate_feature.py` | Prompt and schema |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credentials, no automated tests |
 
 ## Files allowed to change
 
-Only documentation artifacts for this feature run. No product code, no label data in Git.
+Documentation artifacts only.
 
-**Temporary smoke artifacts (committed during Phase A, deleted before merge):**
+**Temporary smoke artifacts (Phase A; deleted before merge):**
 
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_political_smoke_cost.json`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_political_smoke_resume_evidence.md`
-- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_political_smoke_s3_checks.txt`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_political/is_political_cost_report.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_political/is_political_resume_evidence.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/is_political/is_political_s3_checks.txt`
 
-**Permanent run report (committed during Phase B, kept after merge):**
+**Permanent run report (Phase B; kept after merge):**
 
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_political_run_report.md`
 
@@ -138,40 +92,71 @@ Only documentation artifacts for this feature run. No product code, no label dat
 
 - Any file under `/workspace/data_platform/`, `/workspace/lib/`, `/workspace/ml_tooling/`, `/workspace/tests/`, `/workspace/pyproject.toml`, `/workspace/CHANGELOG.md`
 - `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
-- Any other step file under `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/`
+- Any other step file under `steps/`
 - Any path under the S3 prefixes for the other six features:
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
-  - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
+ - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
 - Any committed Parquet, CSV, or JSON label files anywhere in the repository
+
 
 Do not add or run automated tests.
 
-## S3 artifacts
+## Locked contracts
 
-All objects live under:
+See `campaign_contract.md`. S3 objects for this feature:
 
-`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/`
+| Object | Path |
+|--------|------|
+| Smoke input | `.../is_political/smoke/input.parquet` |
+| Smoke output | `.../is_political/smoke/output.parquet` |
+| Smoke cost report | `.../is_political/smoke/cost_report.json` |
+| Smoke resume evidence | `.../is_political/smoke/resume_evidence.json` |
+| Batches | `.../is_political/batches/part-NNNNN.parquet` |
+| Final | `.../is_political/final.parquet` |
+| Manifest | `.../is_political/manifest.json` |
+| Progress | `.../is_political/progress.jsonl` |
+| Errors | `.../is_political/errors.jsonl` (when needed) |
+| Watcher | `.../is_political/watcher.json` |
 
-Expected layout after Step 5 (exact subfolder names follow the Step 5 implementation):
+Q44 columns in `final.parquet`: `source_record_id`, `run_id`, `batch_id`, `request_id`, `attempt_count`, `label_timestamp`, `is_political`.
 
-| Artifact | Purpose |
-|----------|---------|
-| `shards/` | Immutable 2,000-row Parquet shards |
-| `final/is_political.parquet` | Consolidated feature output |
-| `manifest/` | SHA-256 hash manifest over shards and final file |
-| `progress/` | Structured progress records (one per durable shard) |
-| `errors/` | Error records for rows that failed after retries |
-| `metadata.json` | Run metadata including `model_id`, `prompt_hash`, labeled counts, OpenAI job ids |
+After parent approval, `part-00000.parquet` must contain ten unchanged smoke labels plus 1,990 new labels (2,000 rows total). The next 99 provider jobs each write `part-00001` through `part-00099` with 2,000 rows each. Total: exactly 100 canonical batch objects and 200,000 rows. Preserve original smoke `batch_id` and `request_id` in the ten rows in `part-00000`. `manifest.json` batch entry for `part_index=0` may list both the smoke provider `batch_id` and the first production provider `batch_id`.
 
-Intermediate shards may carry the intermediate-artifact lifecycle tag from Step 16. Final Parquet, manifest, progress records, and reports are retained.
+## Two-phase pull request flow
 
-## Basic commands and checks
+### Phase A: smoke, estimate, and review artifacts
 
-**List campaign prefix:**
+1. Confirm Steps 3, 6, and 7 are on `main`.
+2. Run `smoke_bluesky_campaign.py` once for `is_political` only. The smoke caller performs one deliberate interruption and resume and writes untagged S3 evidence under `is_political/smoke/` including `resume_evidence.json`. Do not repeat the interruption procedure in this step.
+3. Commit temporary Git smoke artifacts under `reports/smoke/is_political/` (include a local copy of `resume_evidence.json`).
+4. Post estimated full-run cost to this feature's GitHub issue through authenticated GitHub integration.
+5. Stop. Do not start the 200,000-post run until the parent campaign issue has one aggregate estimate and explicit human approval.
+
+### Phase B: full run after parent approval
+
+1. Confirm parent campaign issue has explicit approval.
+2. Run the campaign CLI command above (same command resumes automatically).
+3. Run the Step 7 watcher at every 10,000 durable rows; post rolling comment through authenticated GitHub integration.
+4. Validate S3 artifacts and row counts.
+5. Write `reports/is_political_run_report.md`.
+6. Delete temporary smoke artifacts from Git. S3 smoke evidence remains.
+7. Commit and push only the permanent run report.
+
+## Ordered work
+
+1. Phase A smoke and cost estimate.
+2. Pause for parent aggregate and human approval.
+3. Phase B full run with watcher.
+4. Runtime validation.
+5. Permanent report and Git cleanup.
+
+## Exact commands and expected output
+
+### List feature prefix
 
 ```bash
 export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
@@ -180,95 +165,96 @@ export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/ --recursive
 ```
 
-**Download final Parquet for validation:**
+### Download final parquet for validation
 
 ```bash
 aws s3 cp \
-  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/final/is_political.parquet \
-  /tmp/is_political.parquet
+  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/final.parquet \
+  /tmp/is_political_final.parquet
 ```
 
-**Validate row count, uniqueness, schema, and accepted values:**
+### Validate row count, Q44 schema, and accepted values
 
 ```bash
-python - <<'PY'
+PYTHONPATH=. uv run python - <<'PY'
 import pandas as pd
 
-REQUIRED_COLS = ["source_record_id", "label_timestamp", "is_political"]
+Q44_COLS = [
+    "source_record_id", "run_id", "batch_id", "request_id",
+    "attempt_count", "label_timestamp", "is_political",
+]
 
-df = pd.read_parquet("/tmp/is_political.parquet")
-assert list(df.columns) == REQUIRED_COLS, df.columns.tolist()
+df = pd.read_parquet("/tmp/is_political_final.parquet")
+assert list(df.columns) == Q44_COLS, df.columns.tolist()
 assert len(df) == 200_000, len(df)
-assert df["source_record_id"].is_unique, "duplicate source_record_id"
-assert df["is_political"].notna().all(), "missing is_political"
+assert df["source_record_id"].is_unique
+assert df["run_id"].nunique() == 1
+assert df["run_id"].iloc[0] == "bluesky_2026_09_03_235130_llm_features_v1:is_political"
+assert df["is_political"].notna().all()
 assert df["is_political"].dtype == bool or set(df["is_political"].unique()) <= {True, False}
 print("ok", df["is_political"].value_counts().to_dict())
 PY
 ```
 
-**Compare labeled ids to preprocessed input:**
+Expected: `ok` plus value counts and exit code 0.
+
+### Verify manifest SHA-256
 
 ```bash
-python - <<'PY'
-import pandas as pd
-
-pre = pd.read_parquet(
-    "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
-)
-feat = pd.read_parquet("/tmp/is_political.parquet")
-input_ids = set(pre["source_record_id"])
-output_ids = set(feat["source_record_id"])
-assert input_ids == output_ids, (len(input_ids), len(output_ids), len(input_ids - output_ids))
-print("ok ids match")
-PY
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/manifest.json -
 ```
 
-When production reads preprocessed input from S3 (Step 3), download `posts.parquet` from the preprocessed S3 prefix instead of the local path.
+Expected: JSON with `final_parquet.sha256` matching downloaded bytes (SHA-256 only, not ETag).
 
-**Verify manifest hashes** using the Step 5 manifest verifier against `manifest/` and `final/is_political.parquet`.
-
-**Read progress for the watcher:**
+### Read progress for watcher
 
 ```bash
-aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/progress/ --recursive /tmp/is_political_progress/
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/progress.jsonl /tmp/is_political_progress.jsonl
 ```
 
-Confirm a new progress record exists after each 2,000-row shard and that the watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
-
-## Exact accepted values
-
-Each output row must validate as `IsPoliticalModel`:
-
-| Column | Type | Accepted values |
-|--------|------|-----------------|
-| `source_record_id` | string | One per preprocessed post; exactly 200,000 unique values |
-| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
-| `is_political` | boolean | `true` or `false` |
-
-No nulls. No extra columns. No duplicate `source_record_id`.
+Confirm watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
 
 ## Acceptance criteria
 
-1. **Coverage:** Exactly 200,000 rows. Exactly 200,000 unique `source_record_id` values. Zero missing outputs relative to the pinned preprocessed run.
-2. **Schema:** Columns match `IsPoliticalModel`. All `is_political` values are boolean.
-3. **Identity:** `metadata.json` records `model_id` = `gpt-5.4-nano` and the `prompt_hash` of the pinned `SYSTEM_PROMPT`.
-4. **S3:** Final Parquet, manifest, progress history, and error records (if any) are present under the feature campaign prefix.
-5. **Cost and operations:** The permanent run report records estimated cost (from smoke), actual cost (from OpenAI usage), throughput (posts per second and tokens per second), retry count, error rate, and label counts for `true` and `false`.
-6. **Progress:** Watcher updated the GitHub comment at every 10,000 durable rows.
-7. **Resume:** If the run was interrupted, resume used the same issue, same `--checkpoint`, and no duplicate OpenAI Batch job.
-8. **Repository hygiene:** No label files committed. Temporary smoke artifacts removed before merge. Only `reports/is_political_run_report.md` remains from this step in Git.
+1. Exactly 200,000 unique `source_record_id` values with zero missing outputs.
+2. Q44 columns present with correct `run_id` and accepted `is_political` values.
+3. `manifest.json`, `progress.jsonl`, and `final.parquet` present under the feature prefix.
+4. Permanent run report records smoke estimate, actual cost, throughput, retries, error rate, and label counts.
+5. Watcher updated the GitHub comment at every 10,000 durable rows.
+6. Resume reused the same `run_id` with no duplicate OpenAI Batch job.
+7. S3 smoke evidence under `is_political/smoke/` includes `resume_evidence.json` from the single smoke invocation.
+8. Temporary Git smoke files removed before merge. S3 smoke evidence remains.
+9. Only `reports/is_political_run_report.md` remains from this step in Git.
+
+## Failure conditions
+
+- Full 200k run starts before parent campaign issue approval.
+- Smoke run twice for the same feature or different ten-post ids than other features.
+- Smoke writes any object under `batches/` (smoke never writes canonical batch objects).
+- `part-00000.parquet` after full run does not contain ten unchanged smoke labels plus 1,990 new labels.
+- Missing Q44 columns or wrong `run_id`.
+- Any non-boolean `is_political` value.
+- Using `--checkpoint`, `--resume`, `run_bluesky_llm_campaign.py`, or `APPROVED.txt`.
+- Objects under `campaigns/`, `shards/`, `final/` subdirectory, or per-run timestamp folders.
+- Label files committed to Git.
+- Temporary smoke artifacts left in Git after merge.
+- Any product code change in this PR.
+- Any automated test added or run.
+
+## PR artifact and commit rules
+
+- Phase A: commit temporary smoke artifacts for review.
+- Phase B: commit only permanent run report; delete temporary smoke files before merge.
+- Do not edit `plan.md` or other step specs.
 
 ## Permanent run report contents
 
 `reports/is_political_run_report.md` must include:
 
-- Pinned identity table (dataset, preprocessed run, campaign id, model, prompt file path, `prompt_hash`)
-- S3 URIs for final Parquet, manifest, and progress folder
-- Smoke estimated full-run cost (USD) and assumptions
-- Actual cost (USD), input/output/total tokens
-- Throughput (posts per second, tokens per second)
-- Retry count and error rate (failed rows / 200,000)
-- Label counts: `is_political=true`, `is_political=false`
-- Validation command outputs (pass/fail summary)
-- Feature run timestamp and `--checkpoint` value used
-- OpenAI Batch job id(s) from metadata
+- Pinned identity table (dataset, preprocessed run, campaign id, run id, model, prompt path, prompt hash)
+- S3 URIs for `final.parquet`, `manifest.json`, and `progress.jsonl`
+- Smoke estimated full-run cost and assumptions
+- Actual cost, tokens, throughput, retry count, error rate
+- Label counts for `is_political=true` and `is_political=false`
+- Validation command pass/fail summary
+- OpenAI Batch job id(s) from manifest or progress lines

--- a/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step9.md
+++ b/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step9.md
@@ -1,0 +1,274 @@
+# Step 9: Generate `is_political` for 200,000 Bluesky posts
+
+## Goal
+
+Run the approved ten-post smoke flow and the full 200,000-post OpenAI Batch generation for the `is_political` feature only. Publish immutable S3 shards, the final Parquet file, hash manifest, progress history, validation results, and one permanent run report. Do not change product code in this pull request. Do not commit label Parquet or CSV files to Git.
+
+This step is one future pull request and one GitHub feature issue. The issue stays open until the feature run is complete and validated.
+
+## Dependencies on Steps 3–7
+
+Do not start this step until Steps 3–7 have merged to `main`.
+
+**Step 3 (S3 default backend).** Production feature generation reads preprocessed input and writes feature output through S3, not local `data_platform/data/` or Git LFS. Export AWS credentials before any S3-touching command:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+```
+
+**Step 4 (OpenAI Batch hardening and resume).** The engine persists in-flight OpenAI Batch job identity before polling, keeps successful records from partly failed jobs, retries only transient failures, and resumes without creating duplicate provider jobs. A failed or interrupted run reuses the same feature run directory and the same `--checkpoint` value.
+
+**Step 5 (Parquet shards and manifests).** Each durable batch writes one immutable 2,000-row Parquet shard under the feature S3 prefix, plus error records and a hash manifest. One blocking OpenAI Batch job stays active per feature. The run ends with one consolidated final Parquet file for `is_political`.
+
+**Step 6 (ten-post smoke and campaign approval gate).** Use the deterministic ten-post sample shipped in Step 6 for every feature. Record average and maximum token usage, current model pricing, estimated full-run cost, S3 presence checks, and one deliberate interruption plus resume. Post the smoke cost estimate to this feature issue. Wait until the parent campaign issue records the sum of all seven feature estimates and receives one explicit approval before starting the 200,000-post run.
+
+**Step 7 (progress watcher).** After each durable shard, the runner writes a structured progress record. A restartable watcher subagent reads those records and updates one rolling GitHub issue comment at every 10,000 completed records for this feature.
+
+## Pinned identity contract
+
+Use exactly these values for the full campaign. A different dataset, preprocessed run, campaign id, model, or prompt requires a new campaign and must not reuse this prefix.
+
+| Field | Pinned value |
+|-------|----------------|
+| Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| Preprocessed run | `2026_09_03-23:51:30` |
+| Preprocessed row count | `200000` (`metadata.json` `row_counts.output`) |
+| Preprocessed input S3 prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/` |
+| Campaign id / feature run family | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Feature name | `is_political` |
+| Feature S3 campaign prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/` |
+| Model id | `gpt-5.4-nano` (`lib.constants.DEFAULT_LLM_MODEL`) |
+| Engine | OpenAI Batch (`engine_type="openai"`) |
+| Batch size | `2000` |
+| Temperature | `0.0` |
+| System prompt source | `data_platform/generate_features/is_political/generate_feature.py` → `SYSTEM_PROMPT` |
+| LLM output schema | `LlmIsPoliticalModel` in the same file |
+| Stored label schema | `IsPoliticalModel`: `source_record_id`, `label_timestamp`, `is_political` |
+| Prompt identity in metadata | `metadata.json` `features.is_political.model_id` = `gpt-5.4-nano` and `prompt_hash` = SHA-256 hex of `SYSTEM_PROMPT` |
+
+Record the exact `prompt_hash` from the smoke run metadata in the permanent run report. If `model_id` or `prompt_hash` drifts from the smoke run, stop and open a new campaign instead of resuming.
+
+## Caller command
+
+Run only this feature with batch size 2000. Do not pass any other `--features` value.
+
+**New feature run (smoke phase uses the Step 6 ten-post path; full run uses this command):**
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --features is_political \
+  --batch-size 2000
+```
+
+**Resume an interrupted run (same issue, same feature run directory name):**
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/generate_bluesky_features.py \
+  --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \
+  --features is_political \
+  --batch-size 2000 \
+  --checkpoint <feature_run_timestamp>
+```
+
+Replace `<feature_run_timestamp>` with the folder name under the campaign prefix (for example `2026_09_05-14:30:00`). Never start a second concurrent OpenAI Batch job for this feature while an unfinished run exists.
+
+## Two-phase pull request flow
+
+### Phase A — smoke, estimate, and review artifacts
+
+1. Confirm Steps 3–7 are on `main`.
+2. Run the Step 6 ten-post smoke for `is_political` only.
+3. Perform the deliberate interruption and resume required by Step 6 on the same feature run.
+4. Write temporary smoke artifacts under the plan reports folder (see Allowed files).
+5. Commit and push those temporary smoke artifacts to the feature branch. Do not commit labels.
+6. Post the estimated full-run cost (derived from smoke token usage and current `gpt-5.4-nano` Batch pricing) to this feature issue.
+7. Stop. Do not start the 200,000-post run until the parent campaign issue shows one approval covering all seven feature estimates.
+
+### Phase B — full run after parent approval
+
+1. Confirm the parent campaign issue has explicit approval for the combined estimate.
+2. Start or resume the full run with the caller command above.
+3. Start the Step 7 progress watcher for this feature. It must update the rolling GitHub comment at every 10,000 durable rows.
+4. When the run completes, validate S3 artifacts and row counts (see Acceptance checks).
+5. Write the permanent run report at `reports/is_political_run_report.md` with actual cost, throughput, retries, error rate, and label counts.
+6. Delete every temporary smoke artifact from the plan reports folder.
+7. Commit and push only the permanent run report. Push the final S3 objects (already written during the run). Open or update the pull request for merge.
+
+If the full run fails or is interrupted, keep the same GitHub issue and the same `--checkpoint` value. Resume; do not open a parallel run or a new campaign prefix.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md` | Epic scope and done criteria |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Bluesky feature CLI entrypoint |
+| `/workspace/data_platform/generate_features/platform_cli.py` | `--features`, `--batch-size`, `--checkpoint` |
+| `/workspace/data_platform/generate_features/is_political/generate_feature.py` | `SYSTEM_PROMPT`, accepted label schema |
+| `/workspace/data_platform/generate_features/registry.py` | Feature registry entry for `is_political` |
+| `/workspace/data_platform/generate_features/engines/openai_engine.py` | OpenAI Batch engine and default model |
+| `/workspace/data_platform/generate_features/metadata.py` | `model_id`, `prompt_hash`, resume identity checks |
+| `/workspace/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json` | Pinned input row count and run id |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.`, AWS credential export, no automated tests |
+
+After Steps 3–7 merge, also read the Step 6 smoke helper, Step 7 progress watcher entrypoint, and any S3 layout docs those steps add.
+
+## Files allowed to change
+
+Only documentation artifacts for this feature run. No product code, no label data in Git.
+
+**Temporary smoke artifacts (committed during Phase A, deleted before merge):**
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_political_smoke_cost.json`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_political_smoke_resume_evidence.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_political_smoke_s3_checks.txt`
+
+**Permanent run report (committed during Phase B, kept after merge):**
+
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/is_political_run_report.md`
+
+## Files forbidden to change
+
+- Any file under `/workspace/data_platform/`, `/workspace/lib/`, `/workspace/ml_tooling/`, `/workspace/tests/`, `/workspace/pyproject.toml`, `/workspace/CHANGELOG.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/plan.md`
+- Any other step file under `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/`
+- Any path under the S3 prefixes for the other six features:
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_news_or_opinion/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_likely_spam/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_self_contained/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/is_structurally_complete/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/political_stance/`
+  - `.../bluesky_2026_09_03_235130_llm_features_v1/llm_toxicity_tiered/`
+- Any committed Parquet, CSV, or JSON label files anywhere in the repository
+
+Do not add or run automated tests.
+
+## S3 artifacts
+
+All objects live under:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/`
+
+Expected layout after Step 5 (exact subfolder names follow the Step 5 implementation):
+
+| Artifact | Purpose |
+|----------|---------|
+| `shards/` | Immutable 2,000-row Parquet shards |
+| `final/is_political.parquet` | Consolidated feature output |
+| `manifest/` | SHA-256 hash manifest over shards and final file |
+| `progress/` | Structured progress records (one per durable shard) |
+| `errors/` | Error records for rows that failed after retries |
+| `metadata.json` | Run metadata including `model_id`, `prompt_hash`, labeled counts, OpenAI job ids |
+
+Intermediate shards may carry the intermediate-artifact lifecycle tag from Step 16. Final Parquet, manifest, progress records, and reports are retained.
+
+## Basic commands and checks
+
+**List campaign prefix:**
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/ --recursive
+```
+
+**Download final Parquet for validation:**
+
+```bash
+aws s3 cp \
+  s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/final/is_political.parquet \
+  /tmp/is_political.parquet
+```
+
+**Validate row count, uniqueness, schema, and accepted values:**
+
+```bash
+python - <<'PY'
+import pandas as pd
+
+REQUIRED_COLS = ["source_record_id", "label_timestamp", "is_political"]
+
+df = pd.read_parquet("/tmp/is_political.parquet")
+assert list(df.columns) == REQUIRED_COLS, df.columns.tolist()
+assert len(df) == 200_000, len(df)
+assert df["source_record_id"].is_unique, "duplicate source_record_id"
+assert df["is_political"].notna().all(), "missing is_political"
+assert df["is_political"].dtype == bool or set(df["is_political"].unique()) <= {True, False}
+print("ok", df["is_political"].value_counts().to_dict())
+PY
+```
+
+**Compare labeled ids to preprocessed input:**
+
+```bash
+python - <<'PY'
+import pandas as pd
+
+pre = pd.read_parquet(
+    "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet"
+)
+feat = pd.read_parquet("/tmp/is_political.parquet")
+input_ids = set(pre["source_record_id"])
+output_ids = set(feat["source_record_id"])
+assert input_ids == output_ids, (len(input_ids), len(output_ids), len(input_ids - output_ids))
+print("ok ids match")
+PY
+```
+
+When production reads preprocessed input from S3 (Step 3), download `posts.parquet` from the preprocessed S3 prefix instead of the local path.
+
+**Verify manifest hashes** using the Step 5 manifest verifier against `manifest/` and `final/is_political.parquet`.
+
+**Read progress for the watcher:**
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/features/bluesky_2026_09_03_235130_llm_features_v1/is_political/progress/ --recursive /tmp/is_political_progress/
+```
+
+Confirm a new progress record exists after each 2,000-row shard and that the watcher comment updates at 10,000, 20,000, …, 200,000 durable rows.
+
+## Exact accepted values
+
+Each output row must validate as `IsPoliticalModel`:
+
+| Column | Type | Accepted values |
+|--------|------|-----------------|
+| `source_record_id` | string | One per preprocessed post; exactly 200,000 unique values |
+| `label_timestamp` | string | UTC timestamp from `lib.timestamp_utils.get_current_timestamp` |
+| `is_political` | boolean | `true` or `false` |
+
+No nulls. No extra columns. No duplicate `source_record_id`.
+
+## Acceptance criteria
+
+1. **Coverage:** Exactly 200,000 rows. Exactly 200,000 unique `source_record_id` values. Zero missing outputs relative to the pinned preprocessed run.
+2. **Schema:** Columns match `IsPoliticalModel`. All `is_political` values are boolean.
+3. **Identity:** `metadata.json` records `model_id` = `gpt-5.4-nano` and the `prompt_hash` of the pinned `SYSTEM_PROMPT`.
+4. **S3:** Final Parquet, manifest, progress history, and error records (if any) are present under the feature campaign prefix.
+5. **Cost and operations:** The permanent run report records estimated cost (from smoke), actual cost (from OpenAI usage), throughput (posts per second and tokens per second), retry count, error rate, and label counts for `true` and `false`.
+6. **Progress:** Watcher updated the GitHub comment at every 10,000 durable rows.
+7. **Resume:** If the run was interrupted, resume used the same issue, same `--checkpoint`, and no duplicate OpenAI Batch job.
+8. **Repository hygiene:** No label files committed. Temporary smoke artifacts removed before merge. Only `reports/is_political_run_report.md` remains from this step in Git.
+
+## Permanent run report contents
+
+`reports/is_political_run_report.md` must include:
+
+- Pinned identity table (dataset, preprocessed run, campaign id, model, prompt file path, `prompt_hash`)
+- S3 URIs for final Parquet, manifest, and progress folder
+- Smoke estimated full-run cost (USD) and assumptions
+- Actual cost (USD), input/output/total tokens
+- Throughput (posts per second, tokens per second)
+- Retry count and error rate (failed rows / 200,000)
+- Label counts: `is_political=true`, `is_political=false`
+- Validation command outputs (pass/fail summary)
+- Feature run timestamp and `--checkpoint` value used
+- OpenAI Batch job id(s) from metadata


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Implementation of S3-backed LLM feature generation for 200,000 Bluesky posts needs a written plan with ordered, reviewable steps. The pinned Bluesky pipeline data lives only as Git LFS objects in the repository. Later work must generate seven LLM features from files stored in S3, and OpenAI Batch feature generation must run reliably at that scale.

## Solution

The pull request adds a complete plan package under `docs/plans/`. The package includes an executive plan with 16 independently mergeable steps. It also includes a shared campaign contract for identities, S3 paths, schemas, smoke checks, cost approval, progress reporting, and dependencies. Each child issue has one expanded implementation specification.

## Purpose

The full 200,000-post runs must not start until all of the following are true:
- The prerequisite implementation pull requests are approved.
- All seven smoke estimates and the aggregate campaign estimate are posted.
- The repository owner has explicitly signed off in the parent issue.

The pull request does not change application code.

## How to run

Document checks on this branch confirm the following:

- All 16 step titles match the executive plan.
- Every required section is present in each step document.
- The branch contains plan files only.
- Integration and QA reviews found no blocking contradictions.
- Plan implementation steps use live smoke checks and basic artifact checks instead of automated tests.

## Tracking issues

Parent issue: [#180](https://github.com/METResearchGroup/mirrorView-task/issues/180)

- [#181](https://github.com/METResearchGroup/mirrorView-task/issues/181) Copy current pipeline LFS artifacts to S3
- [#182](https://github.com/METResearchGroup/mirrorView-task/issues/182) Add first-class S3 storage support to the data pipeline
- [#183](https://github.com/METResearchGroup/mirrorView-task/issues/183) Make S3 the default pipeline backend and remove current LFS artifacts
- [#184](https://github.com/METResearchGroup/mirrorView-task/issues/184) Harden OpenAI Batch feature generation and resume
- [#185](https://github.com/METResearchGroup/mirrorView-task/issues/185) Write resumable 2,000-row Parquet feature batches
- [#186](https://github.com/METResearchGroup/mirrorView-task/issues/186) Add smoke tooling and cost aggregation
- [#187](https://github.com/METResearchGroup/mirrorView-task/issues/187) Add durable progress reports for feature run watchers
- [#188](https://github.com/METResearchGroup/mirrorView-task/issues/188) Generate is_news_or_opinion for 200,000 Bluesky posts
- [#189](https://github.com/METResearchGroup/mirrorView-task/issues/189) Generate is_political for 200,000 Bluesky posts
- [#190](https://github.com/METResearchGroup/mirrorView-task/issues/190) Generate is_likely_spam for 200,000 Bluesky posts
- [#191](https://github.com/METResearchGroup/mirrorView-task/issues/191) Generate is_self_contained for 200,000 Bluesky posts
- [#192](https://github.com/METResearchGroup/mirrorView-task/issues/192) Generate is_structurally_complete for 200,000 Bluesky posts
- [#193](https://github.com/METResearchGroup/mirrorView-task/issues/193) Generate political_stance for 200,000 Bluesky posts
- [#194](https://github.com/METResearchGroup/mirrorView-task/issues/194) Generate llm_toxicity_tiered for 200,000 Bluesky posts
- [#195](https://github.com/METResearchGroup/mirrorView-task/issues/195) Consolidate seven Bluesky LLM features into one wide Parquet artifact
- [#196](https://github.com/METResearchGroup/mirrorView-task/issues/196) Expire intermediate data platform S3 batches after 30 days

Plan document: `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b86261f-7ee1-4aee-af3f-7a481c227451?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b86261f-7ee1-4aee-af3f-7a481c227451&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

