### PR TITLE
Copy pinned Bluesky LFS artifacts to S3 with hash inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 3. Feature generation now labels every LLM feature with the OpenAI Batch engine instead of LangChain. `is_toxic_tiered` still calls the Perspective API on the thread-pool engine. One `--batch-size` group of posts is now one OpenAI Batch job. [Issue #175](https://github.com/METResearchGroup/mirrorView-task/issues/175)
 4. The feature generation pipeline can use the OpenAI Batch API and structured output to label posts for LLM features. A smoke CLI labels 100 posts as news, opinion, or neither and reports throughput and estimated tokens per request. [PR #168](https://github.com/METResearchGroup/mirrorView-task/pull/168)
 5. Twitter sync requests now omit user expansions and user fields, so requests avoid User Read charges for each tweet. In preprocessing, the pipeline now populates the author handle directly from the author ID. [PR #173](https://github.com/METResearchGroup/mirrorView-task/pull/173)
+6. The pinned Bluesky dataset (raw run, preprocessed 200,000-post sample, and the 2026-09-01 source dump) now exists in the `mirrorview-experimental-artifacts` S3 bucket at repo-relative keys, and a committed inventory records the SHA-256 of all 53 objects. Git LFS copies stay in the repository. [Issue #181](https://github.com/METResearchGroup/mirrorView-task/issues/181)
 
 ## 2026-09-04
 

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json
@@ -1,0 +1,327 @@
+{
+  "bucket": "mirrorview-experimental-artifacts",
+  "region": "us-east-2",
+  "dataset_id": "bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73",
+  "uploaded_at": "2026_09_05-21:50:45",
+  "object_count": 53,
+  "objects": [
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json",
+      "bytes": 284,
+      "sha256": "cc88e814c96b759a5661e99a692bd8249b5877d938a68e4300773ebb46b48922"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/metadata.json",
+      "bytes": 408,
+      "sha256": "669e5a2ee70105c963e65a7600bc247fffd84c995766e4cc2e7edc9320eadcc7"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet",
+      "bytes": 68290757,
+      "sha256": "3d267201de22378e2d5e1a2c9eb4eae4ab3bc174aca5a134233caa54df3578fe"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=00/87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=00/87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef.parquet",
+      "bytes": 11740620,
+      "sha256": "87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=01/07a13b46f6e914e3fbfd0c87ef4ebdcf9c2d4f634322c915ee90f6c6590cc182.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=01/07a13b46f6e914e3fbfd0c87ef4ebdcf9c2d4f634322c915ee90f6c6590cc182.parquet",
+      "bytes": 11404734,
+      "sha256": "07a13b46f6e914e3fbfd0c87ef4ebdcf9c2d4f634322c915ee90f6c6590cc182"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=02/9291dd02ea6779db0af5c4e7338dff05d5a1b8a757bd1887d96e7dc5fa8e8be3.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=02/9291dd02ea6779db0af5c4e7338dff05d5a1b8a757bd1887d96e7dc5fa8e8be3.parquet",
+      "bytes": 10688027,
+      "sha256": "9291dd02ea6779db0af5c4e7338dff05d5a1b8a757bd1887d96e7dc5fa8e8be3"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=03/f507657e54bd11a974d2d3360dfd20ea5a37720b2720060a20a62392d32fa838.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=03/f507657e54bd11a974d2d3360dfd20ea5a37720b2720060a20a62392d32fa838.parquet",
+      "bytes": 10671055,
+      "sha256": "f507657e54bd11a974d2d3360dfd20ea5a37720b2720060a20a62392d32fa838"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=04/8f71e793b20221a35c9c068c7e1b5a2c92d20d3b6d07d7b6f14c96fa6e7b9b8a.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=04/8f71e793b20221a35c9c068c7e1b5a2c92d20d3b6d07d7b6f14c96fa6e7b9b8a.parquet",
+      "bytes": 9343254,
+      "sha256": "8f71e793b20221a35c9c068c7e1b5a2c92d20d3b6d07d7b6f14c96fa6e7b9b8a"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=05/b75983817d2a7caa33652e907d87e0045d765613ff8912c75b6677460546c2a9.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=05/b75983817d2a7caa33652e907d87e0045d765613ff8912c75b6677460546c2a9.parquet",
+      "bytes": 8913253,
+      "sha256": "b75983817d2a7caa33652e907d87e0045d765613ff8912c75b6677460546c2a9"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=06/1d1efb717db79a6012e21439d1d99583a844b489bf851514d3c17f25060c245d.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=06/1d1efb717db79a6012e21439d1d99583a844b489bf851514d3c17f25060c245d.parquet",
+      "bytes": 9377626,
+      "sha256": "1d1efb717db79a6012e21439d1d99583a844b489bf851514d3c17f25060c245d"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=07/bdcf5c6a124a8427d6243ca1cb4dad21de091a9cc2f861bc31e68dc4ae0e8ee7.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=07/bdcf5c6a124a8427d6243ca1cb4dad21de091a9cc2f861bc31e68dc4ae0e8ee7.parquet",
+      "bytes": 9470376,
+      "sha256": "bdcf5c6a124a8427d6243ca1cb4dad21de091a9cc2f861bc31e68dc4ae0e8ee7"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=08/0276dae1716f95233fc8cc45af8e0fab85a9c6c30f38b7b873633d3555316cec.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=08/0276dae1716f95233fc8cc45af8e0fab85a9c6c30f38b7b873633d3555316cec.parquet",
+      "bytes": 10062784,
+      "sha256": "0276dae1716f95233fc8cc45af8e0fab85a9c6c30f38b7b873633d3555316cec"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=09/065a1008065c2274e24202136e72b152d6b04d780a854c04dee3765d68357508.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=09/065a1008065c2274e24202136e72b152d6b04d780a854c04dee3765d68357508.parquet",
+      "bytes": 11035625,
+      "sha256": "065a1008065c2274e24202136e72b152d6b04d780a854c04dee3765d68357508"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=10/a1f035bf84ffc505ea57fda0c373c18633dbf65c2b4686c9326d63170026f88c.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=10/a1f035bf84ffc505ea57fda0c373c18633dbf65c2b4686c9326d63170026f88c.parquet",
+      "bytes": 12357796,
+      "sha256": "a1f035bf84ffc505ea57fda0c373c18633dbf65c2b4686c9326d63170026f88c"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=11/819729c9892253012b62bb3a28dc5c3a05c3b66b1836533f44065a330a116e3b.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=11/819729c9892253012b62bb3a28dc5c3a05c3b66b1836533f44065a330a116e3b.parquet",
+      "bytes": 13858534,
+      "sha256": "819729c9892253012b62bb3a28dc5c3a05c3b66b1836533f44065a330a116e3b"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=12/c215309e4986c3414dbc5570af8e35d14d13324c8025301fbec2a5346c9b8f8b.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=12/c215309e4986c3414dbc5570af8e35d14d13324c8025301fbec2a5346c9b8f8b.parquet",
+      "bytes": 15732460,
+      "sha256": "c215309e4986c3414dbc5570af8e35d14d13324c8025301fbec2a5346c9b8f8b"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=13/4e8e9fa304aa7077c79f235570515987684b758e2c3faa7b70e90590c90e7c98.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=13/4e8e9fa304aa7077c79f235570515987684b758e2c3faa7b70e90590c90e7c98.parquet",
+      "bytes": 16707580,
+      "sha256": "4e8e9fa304aa7077c79f235570515987684b758e2c3faa7b70e90590c90e7c98"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=14/996a62335449379e3495e840958d5d11b7833c4c5e77490ec69f1acf1f2d393c.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=14/996a62335449379e3495e840958d5d11b7833c4c5e77490ec69f1acf1f2d393c.parquet",
+      "bytes": 17463736,
+      "sha256": "996a62335449379e3495e840958d5d11b7833c4c5e77490ec69f1acf1f2d393c"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=15/c17354f4d79805d27549fe6b1008cc8b1bdf70b6f801b68c9b844e27ef5a8c78.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=15/c17354f4d79805d27549fe6b1008cc8b1bdf70b6f801b68c9b844e27ef5a8c78.parquet",
+      "bytes": 17344905,
+      "sha256": "c17354f4d79805d27549fe6b1008cc8b1bdf70b6f801b68c9b844e27ef5a8c78"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=16/11044bc252e2f74cd4a8b1cccee37f09fa7c7f0805e9c5951e3e003cbf9b0508.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=16/11044bc252e2f74cd4a8b1cccee37f09fa7c7f0805e9c5951e3e003cbf9b0508.parquet",
+      "bytes": 16706456,
+      "sha256": "11044bc252e2f74cd4a8b1cccee37f09fa7c7f0805e9c5951e3e003cbf9b0508"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=17/7561d13554b77359f734feab412d997b54ec77b75aad0cb0c88a42d544af4412.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=17/7561d13554b77359f734feab412d997b54ec77b75aad0cb0c88a42d544af4412.parquet",
+      "bytes": 15775445,
+      "sha256": "7561d13554b77359f734feab412d997b54ec77b75aad0cb0c88a42d544af4412"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=18/d8a3189e9a0ccf1573d931c21a7a0406c624c795f64c0b78bddb255ddc5fbee9.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=18/d8a3189e9a0ccf1573d931c21a7a0406c624c795f64c0b78bddb255ddc5fbee9.parquet",
+      "bytes": 15066164,
+      "sha256": "d8a3189e9a0ccf1573d931c21a7a0406c624c795f64c0b78bddb255ddc5fbee9"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=19/ebb4b2d8fd185c4a957629af8e777ef84cf979057fdaf7be998db4eeb7afed17.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=19/ebb4b2d8fd185c4a957629af8e777ef84cf979057fdaf7be998db4eeb7afed17.parquet",
+      "bytes": 14583727,
+      "sha256": "ebb4b2d8fd185c4a957629af8e777ef84cf979057fdaf7be998db4eeb7afed17"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=20/1e9397d32125d44702131b572c3300c4da2dc65cde2ab324cfb13f2437d679d7.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=20/1e9397d32125d44702131b572c3300c4da2dc65cde2ab324cfb13f2437d679d7.parquet",
+      "bytes": 14261458,
+      "sha256": "1e9397d32125d44702131b572c3300c4da2dc65cde2ab324cfb13f2437d679d7"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=21/73a3a11c68afafe8cd2e210f02ba138cc46f2983c954aeaf71bfe38f7c02454f.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=21/73a3a11c68afafe8cd2e210f02ba138cc46f2983c954aeaf71bfe38f7c02454f.parquet",
+      "bytes": 13811652,
+      "sha256": "73a3a11c68afafe8cd2e210f02ba138cc46f2983c954aeaf71bfe38f7c02454f"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=22/71ec9881d8718156f855e4aeb9d23799bb8a5e92bd2c9d1b9ffe8ae00e41c4f7.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=22/71ec9881d8718156f855e4aeb9d23799bb8a5e92bd2c9d1b9ffe8ae00e41c4f7.parquet",
+      "bytes": 13253841,
+      "sha256": "71ec9881d8718156f855e4aeb9d23799bb8a5e92bd2c9d1b9ffe8ae00e41c4f7"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=23/7aa81f763c2c76de75602fbe77ab9483e85cb4b94c4a81b6829787a70aef0945.parquet",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=23/7aa81f763c2c76de75602fbe77ab9483e85cb4b94c4a81b6829787a70aef0945.parquet",
+      "bytes": 12541834,
+      "sha256": "7aa81f763c2c76de75602fbe77ab9483e85cb4b94c4a81b6829787a70aef0945"
+    },
+    {
+      "repo_relative_path": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/metadata.json",
+      "s3_key": "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/metadata.json",
+      "bytes": 277,
+      "sha256": "7edfa81345d2f474e247985bf21166a89bdfb5710e986bf7e447ca0b9a8dcfba"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=00/87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=00/87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef.parquet",
+      "bytes": 11740620,
+      "sha256": "87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=01/07a13b46f6e914e3fbfd0c87ef4ebdcf9c2d4f634322c915ee90f6c6590cc182.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=01/07a13b46f6e914e3fbfd0c87ef4ebdcf9c2d4f634322c915ee90f6c6590cc182.parquet",
+      "bytes": 11404734,
+      "sha256": "07a13b46f6e914e3fbfd0c87ef4ebdcf9c2d4f634322c915ee90f6c6590cc182"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=02/9291dd02ea6779db0af5c4e7338dff05d5a1b8a757bd1887d96e7dc5fa8e8be3.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=02/9291dd02ea6779db0af5c4e7338dff05d5a1b8a757bd1887d96e7dc5fa8e8be3.parquet",
+      "bytes": 10688027,
+      "sha256": "9291dd02ea6779db0af5c4e7338dff05d5a1b8a757bd1887d96e7dc5fa8e8be3"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=03/f507657e54bd11a974d2d3360dfd20ea5a37720b2720060a20a62392d32fa838.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=03/f507657e54bd11a974d2d3360dfd20ea5a37720b2720060a20a62392d32fa838.parquet",
+      "bytes": 10671055,
+      "sha256": "f507657e54bd11a974d2d3360dfd20ea5a37720b2720060a20a62392d32fa838"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=04/8f71e793b20221a35c9c068c7e1b5a2c92d20d3b6d07d7b6f14c96fa6e7b9b8a.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=04/8f71e793b20221a35c9c068c7e1b5a2c92d20d3b6d07d7b6f14c96fa6e7b9b8a.parquet",
+      "bytes": 9343254,
+      "sha256": "8f71e793b20221a35c9c068c7e1b5a2c92d20d3b6d07d7b6f14c96fa6e7b9b8a"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=05/b75983817d2a7caa33652e907d87e0045d765613ff8912c75b6677460546c2a9.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=05/b75983817d2a7caa33652e907d87e0045d765613ff8912c75b6677460546c2a9.parquet",
+      "bytes": 8913253,
+      "sha256": "b75983817d2a7caa33652e907d87e0045d765613ff8912c75b6677460546c2a9"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=06/1d1efb717db79a6012e21439d1d99583a844b489bf851514d3c17f25060c245d.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=06/1d1efb717db79a6012e21439d1d99583a844b489bf851514d3c17f25060c245d.parquet",
+      "bytes": 9377626,
+      "sha256": "1d1efb717db79a6012e21439d1d99583a844b489bf851514d3c17f25060c245d"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=07/bdcf5c6a124a8427d6243ca1cb4dad21de091a9cc2f861bc31e68dc4ae0e8ee7.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=07/bdcf5c6a124a8427d6243ca1cb4dad21de091a9cc2f861bc31e68dc4ae0e8ee7.parquet",
+      "bytes": 9470376,
+      "sha256": "bdcf5c6a124a8427d6243ca1cb4dad21de091a9cc2f861bc31e68dc4ae0e8ee7"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=08/0276dae1716f95233fc8cc45af8e0fab85a9c6c30f38b7b873633d3555316cec.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=08/0276dae1716f95233fc8cc45af8e0fab85a9c6c30f38b7b873633d3555316cec.parquet",
+      "bytes": 10062784,
+      "sha256": "0276dae1716f95233fc8cc45af8e0fab85a9c6c30f38b7b873633d3555316cec"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=09/065a1008065c2274e24202136e72b152d6b04d780a854c04dee3765d68357508.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=09/065a1008065c2274e24202136e72b152d6b04d780a854c04dee3765d68357508.parquet",
+      "bytes": 11035625,
+      "sha256": "065a1008065c2274e24202136e72b152d6b04d780a854c04dee3765d68357508"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=10/a1f035bf84ffc505ea57fda0c373c18633dbf65c2b4686c9326d63170026f88c.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=10/a1f035bf84ffc505ea57fda0c373c18633dbf65c2b4686c9326d63170026f88c.parquet",
+      "bytes": 12357796,
+      "sha256": "a1f035bf84ffc505ea57fda0c373c18633dbf65c2b4686c9326d63170026f88c"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=11/819729c9892253012b62bb3a28dc5c3a05c3b66b1836533f44065a330a116e3b.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=11/819729c9892253012b62bb3a28dc5c3a05c3b66b1836533f44065a330a116e3b.parquet",
+      "bytes": 13858534,
+      "sha256": "819729c9892253012b62bb3a28dc5c3a05c3b66b1836533f44065a330a116e3b"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=12/c215309e4986c3414dbc5570af8e35d14d13324c8025301fbec2a5346c9b8f8b.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=12/c215309e4986c3414dbc5570af8e35d14d13324c8025301fbec2a5346c9b8f8b.parquet",
+      "bytes": 15732460,
+      "sha256": "c215309e4986c3414dbc5570af8e35d14d13324c8025301fbec2a5346c9b8f8b"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=13/4e8e9fa304aa7077c79f235570515987684b758e2c3faa7b70e90590c90e7c98.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=13/4e8e9fa304aa7077c79f235570515987684b758e2c3faa7b70e90590c90e7c98.parquet",
+      "bytes": 16707580,
+      "sha256": "4e8e9fa304aa7077c79f235570515987684b758e2c3faa7b70e90590c90e7c98"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=14/996a62335449379e3495e840958d5d11b7833c4c5e77490ec69f1acf1f2d393c.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=14/996a62335449379e3495e840958d5d11b7833c4c5e77490ec69f1acf1f2d393c.parquet",
+      "bytes": 17463736,
+      "sha256": "996a62335449379e3495e840958d5d11b7833c4c5e77490ec69f1acf1f2d393c"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=15/c17354f4d79805d27549fe6b1008cc8b1bdf70b6f801b68c9b844e27ef5a8c78.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=15/c17354f4d79805d27549fe6b1008cc8b1bdf70b6f801b68c9b844e27ef5a8c78.parquet",
+      "bytes": 17344905,
+      "sha256": "c17354f4d79805d27549fe6b1008cc8b1bdf70b6f801b68c9b844e27ef5a8c78"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=16/11044bc252e2f74cd4a8b1cccee37f09fa7c7f0805e9c5951e3e003cbf9b0508.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=16/11044bc252e2f74cd4a8b1cccee37f09fa7c7f0805e9c5951e3e003cbf9b0508.parquet",
+      "bytes": 16706456,
+      "sha256": "11044bc252e2f74cd4a8b1cccee37f09fa7c7f0805e9c5951e3e003cbf9b0508"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=17/7561d13554b77359f734feab412d997b54ec77b75aad0cb0c88a42d544af4412.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=17/7561d13554b77359f734feab412d997b54ec77b75aad0cb0c88a42d544af4412.parquet",
+      "bytes": 15775445,
+      "sha256": "7561d13554b77359f734feab412d997b54ec77b75aad0cb0c88a42d544af4412"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=18/d8a3189e9a0ccf1573d931c21a7a0406c624c795f64c0b78bddb255ddc5fbee9.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=18/d8a3189e9a0ccf1573d931c21a7a0406c624c795f64c0b78bddb255ddc5fbee9.parquet",
+      "bytes": 15066164,
+      "sha256": "d8a3189e9a0ccf1573d931c21a7a0406c624c795f64c0b78bddb255ddc5fbee9"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=19/ebb4b2d8fd185c4a957629af8e777ef84cf979057fdaf7be998db4eeb7afed17.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=19/ebb4b2d8fd185c4a957629af8e777ef84cf979057fdaf7be998db4eeb7afed17.parquet",
+      "bytes": 14583727,
+      "sha256": "ebb4b2d8fd185c4a957629af8e777ef84cf979057fdaf7be998db4eeb7afed17"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=20/1e9397d32125d44702131b572c3300c4da2dc65cde2ab324cfb13f2437d679d7.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=20/1e9397d32125d44702131b572c3300c4da2dc65cde2ab324cfb13f2437d679d7.parquet",
+      "bytes": 14261458,
+      "sha256": "1e9397d32125d44702131b572c3300c4da2dc65cde2ab324cfb13f2437d679d7"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=21/73a3a11c68afafe8cd2e210f02ba138cc46f2983c954aeaf71bfe38f7c02454f.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=21/73a3a11c68afafe8cd2e210f02ba138cc46f2983c954aeaf71bfe38f7c02454f.parquet",
+      "bytes": 13811652,
+      "sha256": "73a3a11c68afafe8cd2e210f02ba138cc46f2983c954aeaf71bfe38f7c02454f"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=22/71ec9881d8718156f855e4aeb9d23799bb8a5e92bd2c9d1b9ffe8ae00e41c4f7.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=22/71ec9881d8718156f855e4aeb9d23799bb8a5e92bd2c9d1b9ffe8ae00e41c4f7.parquet",
+      "bytes": 13253841,
+      "sha256": "71ec9881d8718156f855e4aeb9d23799bb8a5e92bd2c9d1b9ffe8ae00e41c4f7"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=23/7aa81f763c2c76de75602fbe77ab9483e85cb4b94c4a81b6829787a70aef0945.parquet",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=23/7aa81f763c2c76de75602fbe77ab9483e85cb4b94c4a81b6829787a70aef0945.parquet",
+      "bytes": 12541834,
+      "sha256": "7aa81f763c2c76de75602fbe77ab9483e85cb4b94c4a81b6829787a70aef0945"
+    },
+    {
+      "repo_relative_path": "data_platform/ingestion/data_dumps/bluesky/data/summary_statistics.json",
+      "s3_key": "data_platform/ingestion/data_dumps/bluesky/data/summary_statistics.json",
+      "bytes": 155,
+      "sha256": "3b6af7c3d232c484181eb531945e8d899a53f6ca4c8d70f48949e86328679eeb"
+    }
+  ]
+}

--- a/data_platform/scripts/migrate_bluesky_lfs_to_s3.py
+++ b/data_platform/scripts/migrate_bluesky_lfs_to_s3.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 from lib.aws.s3 import S3
 from lib.constants import REPO_ROOT

--- a/data_platform/scripts/migrate_bluesky_lfs_to_s3.py
+++ b/data_platform/scripts/migrate_bluesky_lfs_to_s3.py
@@ -1,0 +1,55 @@
+"""Copy the pinned Bluesky pipeline and dump files from Git LFS to S3.
+
+Run from the repo root:
+
+    export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+    export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+    PYTHONPATH=. uv run python data_platform/scripts/migrate_bluesky_lfs_to_s3.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+from lib.aws.s3 import S3
+
+
+def scoped_repo_relative_paths() -> list[str]:
+    raise NotImplementedError
+
+
+def run_git_lfs_pull(patterns: Sequence[str]) -> None:
+    raise NotImplementedError
+
+
+def read_scoped_bytes(repo_relative_path: str) -> bytes:
+    raise NotImplementedError
+
+
+def sha256_hex(data: bytes) -> str:
+    raise NotImplementedError
+
+
+def content_type_for(repo_relative_path: str) -> str:
+    raise NotImplementedError
+
+
+def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:
+    raise NotImplementedError
+
+
+def write_inventory(rows: list[dict], path: Path) -> None:
+    raise NotImplementedError
+
+
+def main() -> None:
+    paths = scoped_repo_relative_paths()
+    run_git_lfs_pull([])
+    s3 = S3("")
+    rows = [upload_and_verify(s3, path, read_scoped_bytes(path)) for path in paths]
+    write_inventory(rows, Path())
+
+
+if __name__ == "__main__":
+    main()

--- a/data_platform/scripts/migrate_bluesky_lfs_to_s3.py
+++ b/data_platform/scripts/migrate_bluesky_lfs_to_s3.py
@@ -10,12 +10,14 @@ Run from the repo root:
 from __future__ import annotations
 
 import hashlib
+import json
 import subprocess
 from pathlib import Path
 from typing import Sequence
 
 from lib.aws.s3 import S3
 from lib.constants import REPO_ROOT
+from lib.timestamp_utils import get_current_timestamp
 
 BUCKET = "mirrorview-experimental-artifacts"
 REGION = "us-east-2"
@@ -151,19 +153,46 @@ def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:
     RuntimeError
         If the re-downloaded object differs in length or SHA-256.
     """
-    raise NotImplementedError
+    key = repo_relative_path
+    local_sha256 = sha256_hex(data)
+    s3.upload_bytes(key, data, content_type=content_type_for(repo_relative_path))
+    remote = s3.get_bytes(key)
+    remote_sha256 = sha256_hex(remote)
+    if len(remote) != len(data) or remote_sha256 != local_sha256:
+        raise RuntimeError(
+            f"remote object differs for {key}: "
+            f"{len(remote)} bytes {remote_sha256} != {len(data)} bytes {local_sha256}"
+        )
+    return {
+        "repo_relative_path": repo_relative_path,
+        "s3_key": key,
+        "bytes": len(data),
+        "sha256": local_sha256,
+    }
 
 
 def write_inventory(rows: list[dict], path: Path) -> None:
     """Write the migration inventory JSON with rows sorted by repo-relative path."""
-    raise NotImplementedError
+    inventory = {
+        "bucket": BUCKET,
+        "region": REGION,
+        "dataset_id": DATASET_ID,
+        "uploaded_at": get_current_timestamp(),
+        "object_count": len(rows),
+        "objects": sorted(rows, key=lambda row: row["repo_relative_path"]),
+    }
+    path.write_text(json.dumps(inventory, indent=2) + "\n")
 
 
 def main() -> None:
     paths = scoped_repo_relative_paths()
     run_git_lfs_pull(LFS_INCLUDE_PATTERNS)
     s3 = S3(BUCKET, region_name=REGION)
-    rows = [upload_and_verify(s3, path, read_scoped_bytes(path)) for path in paths]
+    rows = []
+    for path in paths:
+        row = upload_and_verify(s3, path, read_scoped_bytes(path))
+        print(f"verified s3://{BUCKET}/{row['s3_key']} ({row['bytes']} bytes)")
+        rows.append(row)
     write_inventory(rows, INVENTORY_PATH)
     print(f"uploaded {len(rows)} objects to s3://{BUCKET}/")
 

--- a/data_platform/scripts/migrate_bluesky_lfs_to_s3.py
+++ b/data_platform/scripts/migrate_bluesky_lfs_to_s3.py
@@ -69,7 +69,25 @@ def scoped_repo_relative_paths() -> list[str]:
         If the list does not have exactly ``EXPECTED_OBJECT_COUNT`` entries
         or any path is missing on disk.
     """
-    raise NotImplementedError
+    raw_run_root = f"{DATASET_ROOT}/raw/{RAW_RUN}"
+    preprocessed_run_root = f"{DATASET_ROOT}/preprocessed/{PREPROCESSED_RUN}"
+    paths = [
+        f"{DATASET_ROOT}/dataset.json",
+        f"{raw_run_root}/metadata.json",
+        f"{preprocessed_run_root}/metadata.json",
+        f"{preprocessed_run_root}/posts.parquet",
+        f"{DUMP_ROOT}/summary_statistics.json",
+    ]
+    for segment in HOURLY_PARQUET_SEGMENTS:
+        paths.append(f"{raw_run_root}/date=2026-09-01/{segment}")
+        paths.append(f"{DUMP_ROOT}/parquet/date=2026-09-01/{segment}")
+    paths.sort()
+    if len(paths) != EXPECTED_OBJECT_COUNT:
+        raise RuntimeError(f"expected {EXPECTED_OBJECT_COUNT} scoped paths, built {len(paths)}")
+    missing = [path for path in paths if not (REPO_ROOT / path).is_file()]
+    if missing:
+        raise RuntimeError(f"scoped paths missing on disk: {missing}")
+    return paths
 
 
 def run_git_lfs_pull(patterns: Sequence[str]) -> None:
@@ -101,7 +119,9 @@ def sha256_hex(data: bytes) -> str:
 
 def content_type_for(repo_relative_path: str) -> str:
     """Return ``application/json`` for ``.json`` and ``application/octet-stream`` otherwise."""
-    raise NotImplementedError
+    if repo_relative_path.endswith(".json"):
+        return "application/json"
+    return "application/octet-stream"
 
 
 def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:

--- a/data_platform/scripts/migrate_bluesky_lfs_to_s3.py
+++ b/data_platform/scripts/migrate_bluesky_lfs_to_s3.py
@@ -9,6 +9,8 @@ Run from the repo root:
 
 from __future__ import annotations
 
+import hashlib
+import subprocess
 from pathlib import Path
 from typing import Sequence
 
@@ -98,7 +100,12 @@ def run_git_lfs_pull(patterns: Sequence[str]) -> None:
     subprocess.CalledProcessError
         If any ``git lfs pull`` call exits non-zero.
     """
-    raise NotImplementedError
+    for pattern in patterns:
+        subprocess.run(
+            ["git", "lfs", "pull", "--include", pattern],
+            cwd=REPO_ROOT,
+            check=True,
+        )
 
 
 def read_scoped_bytes(repo_relative_path: str) -> bytes:
@@ -109,12 +116,15 @@ def read_scoped_bytes(repo_relative_path: str) -> bytes:
     ValueError
         If the file still starts with the Git LFS pointer header.
     """
-    raise NotImplementedError
+    data = (REPO_ROOT / repo_relative_path).read_bytes()
+    if data.startswith(LFS_POINTER_PREFIX):
+        raise ValueError(f"Git LFS pointer was not resolved to bytes: {repo_relative_path}")
+    return data
 
 
 def sha256_hex(data: bytes) -> str:
     """Return the lowercase hex SHA-256 digest of the bytes."""
-    raise NotImplementedError
+    return hashlib.sha256(data).hexdigest()
 
 
 def content_type_for(repo_relative_path: str) -> str:

--- a/data_platform/scripts/migrate_bluesky_lfs_to_s3.py
+++ b/data_platform/scripts/migrate_bluesky_lfs_to_s3.py
@@ -13,42 +13,129 @@ from pathlib import Path
 from typing import Sequence
 
 from lib.aws.s3 import S3
+from lib.constants import REPO_ROOT
+
+BUCKET = "mirrorview-experimental-artifacts"
+REGION = "us-east-2"
+DATASET_ID = "bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73"
+RAW_RUN = "2026_09_01-00:00:00"
+PREPROCESSED_RUN = "2026_09_03-23:51:30"
+EXPECTED_OBJECT_COUNT = 53
+LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1"
+
+DATASET_ROOT = f"data_platform/data/bluesky/{DATASET_ID}"
+DUMP_ROOT = "data_platform/ingestion/data_dumps/bluesky/data"
+INVENTORY_PATH = REPO_ROOT / DATASET_ROOT / "s3_migration_inventory.json"
+LFS_INCLUDE_PATTERNS: tuple[str, ...] = (
+    f"{DATASET_ROOT}/**",
+    f"{DUMP_ROOT}/parquet/**",
+)
+
+# The raw run and the dump tree hold the same 24 hourly files for 2026-09-01.
+HOURLY_PARQUET_SEGMENTS: tuple[str, ...] = (
+    "hour=00/87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef.parquet",
+    "hour=01/07a13b46f6e914e3fbfd0c87ef4ebdcf9c2d4f634322c915ee90f6c6590cc182.parquet",
+    "hour=02/9291dd02ea6779db0af5c4e7338dff05d5a1b8a757bd1887d96e7dc5fa8e8be3.parquet",
+    "hour=03/f507657e54bd11a974d2d3360dfd20ea5a37720b2720060a20a62392d32fa838.parquet",
+    "hour=04/8f71e793b20221a35c9c068c7e1b5a2c92d20d3b6d07d7b6f14c96fa6e7b9b8a.parquet",
+    "hour=05/b75983817d2a7caa33652e907d87e0045d765613ff8912c75b6677460546c2a9.parquet",
+    "hour=06/1d1efb717db79a6012e21439d1d99583a844b489bf851514d3c17f25060c245d.parquet",
+    "hour=07/bdcf5c6a124a8427d6243ca1cb4dad21de091a9cc2f861bc31e68dc4ae0e8ee7.parquet",
+    "hour=08/0276dae1716f95233fc8cc45af8e0fab85a9c6c30f38b7b873633d3555316cec.parquet",
+    "hour=09/065a1008065c2274e24202136e72b152d6b04d780a854c04dee3765d68357508.parquet",
+    "hour=10/a1f035bf84ffc505ea57fda0c373c18633dbf65c2b4686c9326d63170026f88c.parquet",
+    "hour=11/819729c9892253012b62bb3a28dc5c3a05c3b66b1836533f44065a330a116e3b.parquet",
+    "hour=12/c215309e4986c3414dbc5570af8e35d14d13324c8025301fbec2a5346c9b8f8b.parquet",
+    "hour=13/4e8e9fa304aa7077c79f235570515987684b758e2c3faa7b70e90590c90e7c98.parquet",
+    "hour=14/996a62335449379e3495e840958d5d11b7833c4c5e77490ec69f1acf1f2d393c.parquet",
+    "hour=15/c17354f4d79805d27549fe6b1008cc8b1bdf70b6f801b68c9b844e27ef5a8c78.parquet",
+    "hour=16/11044bc252e2f74cd4a8b1cccee37f09fa7c7f0805e9c5951e3e003cbf9b0508.parquet",
+    "hour=17/7561d13554b77359f734feab412d997b54ec77b75aad0cb0c88a42d544af4412.parquet",
+    "hour=18/d8a3189e9a0ccf1573d931c21a7a0406c624c795f64c0b78bddb255ddc5fbee9.parquet",
+    "hour=19/ebb4b2d8fd185c4a957629af8e777ef84cf979057fdaf7be998db4eeb7afed17.parquet",
+    "hour=20/1e9397d32125d44702131b572c3300c4da2dc65cde2ab324cfb13f2437d679d7.parquet",
+    "hour=21/73a3a11c68afafe8cd2e210f02ba138cc46f2983c954aeaf71bfe38f7c02454f.parquet",
+    "hour=22/71ec9881d8718156f855e4aeb9d23799bb8a5e92bd2c9d1b9ffe8ae00e41c4f7.parquet",
+    "hour=23/7aa81f763c2c76de75602fbe77ab9483e85cb4b94c4a81b6829787a70aef0945.parquet",
+)
 
 
 def scoped_repo_relative_paths() -> list[str]:
+    """Return the 53 repo-relative paths in the locked upload scope, sorted.
+
+    Raises
+    ------
+    RuntimeError
+        If the list does not have exactly ``EXPECTED_OBJECT_COUNT`` entries
+        or any path is missing on disk.
+    """
     raise NotImplementedError
 
 
 def run_git_lfs_pull(patterns: Sequence[str]) -> None:
+    """Fetch and check out LFS blobs for each include pattern.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If any ``git lfs pull`` call exits non-zero.
+    """
     raise NotImplementedError
 
 
 def read_scoped_bytes(repo_relative_path: str) -> bytes:
+    """Read a scoped file and refuse Git LFS pointer text.
+
+    Raises
+    ------
+    ValueError
+        If the file still starts with the Git LFS pointer header.
+    """
     raise NotImplementedError
 
 
 def sha256_hex(data: bytes) -> str:
+    """Return the lowercase hex SHA-256 digest of the bytes."""
     raise NotImplementedError
 
 
 def content_type_for(repo_relative_path: str) -> str:
+    """Return ``application/json`` for ``.json`` and ``application/octet-stream`` otherwise."""
     raise NotImplementedError
 
 
 def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:
+    """Upload bytes to the key equal to the path and confirm the remote SHA-256.
+
+    The object is re-downloaded after the upload. The S3 ETag is never used as
+    a content hash.
+
+    Returns
+    -------
+    dict
+        Inventory row with ``repo_relative_path``, ``s3_key``, ``bytes``, and
+        ``sha256``.
+
+    Raises
+    ------
+    RuntimeError
+        If the re-downloaded object differs in length or SHA-256.
+    """
     raise NotImplementedError
 
 
 def write_inventory(rows: list[dict], path: Path) -> None:
+    """Write the migration inventory JSON with rows sorted by repo-relative path."""
     raise NotImplementedError
 
 
 def main() -> None:
     paths = scoped_repo_relative_paths()
-    run_git_lfs_pull([])
-    s3 = S3("")
+    run_git_lfs_pull(LFS_INCLUDE_PATTERNS)
+    s3 = S3(BUCKET, region_name=REGION)
     rows = [upload_and_verify(s3, path, read_scoped_bytes(path)) for path in paths]
-    write_inventory(rows, Path())
+    write_inventory(rows, INVENTORY_PATH)
+    print(f"uploaded {len(rows)} objects to s3://{BUCKET}/")
 
 
 if __name__ == "__main__":

--- a/data_platform/scripts/verify_bluesky_s3_migration.py
+++ b/data_platform/scripts/verify_bluesky_s3_migration.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import json
 
+from botocore.exceptions import ClientError
+
 from data_platform.scripts.migrate_bluesky_lfs_to_s3 import (
     BUCKET,
     EXPECTED_OBJECT_COUNT,
@@ -30,13 +32,38 @@ def verify_inventory(inventory: dict, s3: S3) -> list[str]:
         One message per missing or mismatched object. Empty when every object
         matches.
     """
-    raise NotImplementedError
+    problems: list[str] = []
+    for row in inventory["objects"]:
+        key = row["s3_key"]
+        try:
+            remote = s3.get_bytes(key)
+        except ClientError as exc:
+            problems.append(f"missing {key}: {exc.response['Error']['Code']}")
+            continue
+        if len(remote) != row["bytes"]:
+            problems.append(f"length mismatch {key}: {len(remote)} != {row['bytes']}")
+        remote_sha256 = sha256_hex(remote)
+        if remote_sha256 != row["sha256"]:
+            problems.append(f"sha256 mismatch {key}: {remote_sha256} != {row['sha256']}")
+    return problems
 
 
 def main() -> None:
     inventory = json.loads(INVENTORY_PATH.read_text())
+    objects = inventory["objects"]
+    if inventory["object_count"] != EXPECTED_OBJECT_COUNT or len(objects) != EXPECTED_OBJECT_COUNT:
+        print(
+            f"FAIL: inventory lists {inventory['object_count']} objects with "
+            f"{len(objects)} rows, expected {EXPECTED_OBJECT_COUNT}"
+        )
+        raise SystemExit(1)
     problems = verify_inventory(inventory, S3(BUCKET, region_name=REGION))
-    raise SystemExit(1 if problems else 0)
+    if problems:
+        for problem in problems:
+            print(problem)
+        print(f"FAIL: {len(problems)} of {len(objects)} objects did not match")
+        raise SystemExit(1)
+    print(f"OK: {len(objects)}/{EXPECTED_OBJECT_COUNT} objects present with matching sha256")
 
 
 if __name__ == "__main__":

--- a/data_platform/scripts/verify_bluesky_s3_migration.py
+++ b/data_platform/scripts/verify_bluesky_s3_migration.py
@@ -9,15 +9,33 @@ Run from the repo root:
 
 from __future__ import annotations
 
+import json
+
+from data_platform.scripts.migrate_bluesky_lfs_to_s3 import (
+    BUCKET,
+    EXPECTED_OBJECT_COUNT,
+    INVENTORY_PATH,
+    REGION,
+    sha256_hex,
+)
 from lib.aws.s3 import S3
 
 
 def verify_inventory(inventory: dict, s3: S3) -> list[str]:
+    """Re-download every inventory object and report length or SHA-256 mismatches.
+
+    Returns
+    -------
+    list[str]
+        One message per missing or mismatched object. Empty when every object
+        matches.
+    """
     raise NotImplementedError
 
 
 def main() -> None:
-    problems = verify_inventory({}, S3(""))
+    inventory = json.loads(INVENTORY_PATH.read_text())
+    problems = verify_inventory(inventory, S3(BUCKET, region_name=REGION))
     raise SystemExit(1 if problems else 0)
 
 

--- a/data_platform/scripts/verify_bluesky_s3_migration.py
+++ b/data_platform/scripts/verify_bluesky_s3_migration.py
@@ -51,6 +51,9 @@ def verify_inventory(inventory: dict, s3: S3) -> list[str]:
 def main() -> None:
     inventory = json.loads(INVENTORY_PATH.read_text())
     objects = inventory["objects"]
+    if inventory["bucket"] != BUCKET or inventory["region"] != REGION:
+        print(f"FAIL: inventory targets {inventory['bucket']} in {inventory['region']}, expected {BUCKET} in {REGION}")
+        raise SystemExit(1)
     if inventory["object_count"] != EXPECTED_OBJECT_COUNT or len(objects) != EXPECTED_OBJECT_COUNT:
         print(
             f"FAIL: inventory lists {inventory['object_count']} objects with "

--- a/data_platform/scripts/verify_bluesky_s3_migration.py
+++ b/data_platform/scripts/verify_bluesky_s3_migration.py
@@ -1,0 +1,25 @@
+"""Check every object in the Bluesky S3 migration inventory against the bucket.
+
+Run from the repo root:
+
+    export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+    export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+    PYTHONPATH=. uv run python data_platform/scripts/verify_bluesky_s3_migration.py
+"""
+
+from __future__ import annotations
+
+from lib.aws.s3 import S3
+
+
+def verify_inventory(inventory: dict, s3: S3) -> list[str]:
+    raise NotImplementedError
+
+
+def main() -> None:
+    problems = verify_inventory({}, S3(""))
+    raise SystemExit(1 if problems else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/plans/2026-09-05_copy_bluesky_lfs_artifacts_to_s3_9877d3/plan.md
+++ b/docs/plans/2026-09-05_copy_bluesky_lfs_artifacts_to_s3_9877d3/plan.md
@@ -1,0 +1,44 @@
+# Copy the pinned Bluesky pipeline LFS artifacts to S3 with a hash inventory
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, frequent commits
+- Do not add or run automated tests. Use only the approved smoke checks in the step spec.
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+The Bluesky pipeline data for dataset `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` lives in Git LFS today. Later steps of epic #180 read that data from the `mirrorview-experimental-artifacts` S3 bucket, so the bytes have to exist there first. The plan copies the 53 scoped objects (28 pipeline files and 25 source dump files) to S3 at repo-relative keys, checks every object with SHA-256, and commits a JSON inventory of what was uploaded. Git LFS pointers stay in the repository unchanged, and no pipeline storage code changes.
+
+The plan is one PR for child issue #181 and does not depend on any sibling issue.
+
+## Happy flow
+
+An operator exports the lab AWS credentials, runs the migration script once, then runs the verify script once. The migration script pulls the LFS blobs, uploads each file, re-downloads it to compare hashes, and writes the inventory. The verify script re-reads the inventory and re-downloads every object to confirm the hashes still match.
+
+```mermaid
+flowchart LR
+    A[git lfs pull for the two scoped patterns] --> B[Read 53 local files and reject any LFS pointer text]
+    B --> C[SHA-256 each file and upload to the repo-relative S3 key]
+    C --> D[Re-download each object and compare SHA-256]
+    D --> E[Write s3_migration_inventory.json]
+    E --> F[verify_bluesky_s3_migration.py re-downloads every key and reports OK 53/53]
+```
+
+## Approach
+
+Keep the change to two small scripts and one committed JSON file. The migration script holds a frozen list of the 53 paths, so nothing outside the locked scope can be uploaded by accident. Both scripts wrap the existing `lib/aws/s3.py` helper instead of changing it, and both compare full-object SHA-256 digests rather than S3 ETags.
+
+## Steps
+
+### Step 1: Add the migration script, the verify script, and the committed inventory
+
+Write `data_platform/scripts/migrate_bluesky_lfs_to_s3.py` and `data_platform/scripts/verify_bluesky_s3_migration.py`, run them once against the live bucket, and commit `s3_migration_inventory.json` under the pinned dataset directory. The full spec is in `steps/step1.md`.
+
+## What "done" looks like
+
+1. All 53 scoped objects exist in `mirrorview-experimental-artifacts` at repo-relative keys that start with `data_platform/` and never with `data_platform/data_platform/`.
+2. `s3_migration_inventory.json` is committed under `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/` with 53 rows, and every row has a matching local and remote SHA-256.
+3. `verify_bluesky_s3_migration.py` prints `OK: 53/53 objects present with matching sha256`.
+4. `git lfs ls-files | grep "bluesky_7e2c4a91" | wc -l` still prints `25`, and no file under `lib/aws/`, `data_platform/utils/`, `.gitattributes`, or `.gitignore` changed.

--- a/docs/plans/2026-09-05_copy_bluesky_lfs_artifacts_to_s3_9877d3/steps/step1.md
+++ b/docs/plans/2026-09-05_copy_bluesky_lfs_artifacts_to_s3_9877d3/steps/step1.md
@@ -1,0 +1,214 @@
+# Step 1: Add the migration script, the verify script, and the committed inventory
+
+## Goal
+
+Upload the 53 scoped Bluesky files to `s3://mirrorview-experimental-artifacts/` at repo-relative keys, confirm each upload with a SHA-256 comparison, and commit `s3_migration_inventory.json`. Leave every Git LFS pointer in the repository unchanged.
+
+## Source of truth
+
+The epic step spec is `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step1.md`. Every locked value below is copied from it. If the two files disagree, the epic step spec wins and this file is wrong.
+
+## Main caller
+
+`data_platform/scripts/migrate_bluesky_lfs_to_s3.py` `main`.
+
+Happy path through the caller: build the 53 paths, pull LFS blobs, then for each path read bytes, reject pointer text, hash, upload, re-download and compare, and finally write the inventory and print the summary line.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step1.md` | Locked scope, keys, inventory shape, smoke commands |
+| `.gitattributes` | Confirms which Bluesky parquet paths are LFS |
+| `lib/aws/s3.py` | `S3(bucket, region_name=...)`, `upload_bytes`, `get_bytes` |
+| `lib/constants.py` | `REPO_ROOT` |
+| `lib/timestamp_utils.py` | `get_current_timestamp` for `uploaded_at` |
+| `data_platform/ingestion/data_dumps/bluesky/publish_dump_to_raw.py` | Existing script style, dataset id, raw run timestamp |
+| `AGENTS.md` | `PYTHONPATH=.` and AWS credential export pattern |
+
+## Files allowed to change
+
+- `data_platform/scripts/migrate_bluesky_lfs_to_s3.py` (new)
+- `data_platform/scripts/verify_bluesky_s3_migration.py` (new)
+- `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json` (new)
+
+Smoke output goes into the PR description, not into a committed file. `CHANGELOG.md` is edited only in a separate commit after the PR is open.
+
+## Files forbidden to change
+
+- `data_platform/utils/storage.py`
+- `lib/aws/s3.py`
+- `.gitattributes`
+- `.gitignore`
+- `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json`
+- `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/**`
+- `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/**`
+- `data_platform/ingestion/data_dumps/bluesky/data/**`
+- `data_platform/data/reddit/**`
+- Any file under `tests/`
+- Any file under `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/`
+
+Never `git add` a Bluesky parquet file. After `git lfs pull`, `git status` may list the pulled parquet files as modified even though `git diff` is empty. Stage files by explicit path only.
+
+## Locked values
+
+| Item | Value |
+|------|-------|
+| Bucket | `mirrorview-experimental-artifacts` |
+| Region | `us-east-2` |
+| Dataset id | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` |
+| Raw run | `2026_09_01-00:00:00` |
+| Preprocessed run | `2026_09_03-23:51:30` |
+| Key rule | The S3 key equals the repo-relative path with forward slashes. No `data_platform/data_platform/` prefix. |
+| Object count | 53 |
+| Hash | SHA-256 lowercase hex of the full object bytes. Never use the S3 ETag. |
+| Content types | `application/json` for `.json`, `application/octet-stream` for `.parquet` |
+| Inventory path | `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json` |
+| Inventory shape | `{"bucket","region","dataset_id","uploaded_at","object_count","objects":[{"repo_relative_path","s3_key","bytes","sha256"}]}` with `objects` sorted by `repo_relative_path` |
+| Pointer text | A file whose bytes start with `version https://git-lfs.github.com/spec/v1` is an LFS pointer and must not be uploaded |
+
+## The 53 paths
+
+Pipeline files (28) under `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/`:
+
+- `dataset.json`
+- `raw/2026_09_01-00:00:00/metadata.json`
+- `raw/2026_09_01-00:00:00/date=2026-09-01/hour=NN/<hash>.parquet` for the 24 hours listed below
+- `preprocessed/2026_09_03-23:51:30/metadata.json`
+- `preprocessed/2026_09_03-23:51:30/posts.parquet`
+
+Source dump files (25) under `data_platform/ingestion/data_dumps/bluesky/data/`:
+
+- `parquet/date=2026-09-01/hour=NN/<hash>.parquet` for the same 24 hours
+- `summary_statistics.json`
+
+The 24 hourly parquet file names are identical in the raw run and the dump tree. The script stores them once as a frozen tuple of `hour=NN/<hash>.parquet` segments and builds both trees from that tuple. Take the exact segments from `git lfs ls-files | grep "data_dumps/bluesky"` at implementation time. Assert the final path list has exactly 53 entries and that every entry exists on disk before any upload.
+
+## Contracts
+
+`data_platform/scripts/migrate_bluesky_lfs_to_s3.py`
+
+- Module constants: `BUCKET`, `REGION`, `DATASET_ID`, `RAW_RUN`, `PREPROCESSED_RUN`, `EXPECTED_OBJECT_COUNT = 53`, `LFS_POINTER_PREFIX`, `INVENTORY_PATH`, `LFS_INCLUDE_PATTERNS` (the two patterns from the smoke section), `HOURLY_PARQUET_SEGMENTS` (24 entries).
+- `scoped_repo_relative_paths() -> list[str]` returns the 53 paths sorted.
+- `run_git_lfs_pull(patterns: Sequence[str]) -> None` runs `git lfs pull --include <pattern>` once per pattern from `REPO_ROOT` and raises `subprocess.CalledProcessError` on failure.
+- `read_scoped_bytes(repo_relative_path: str) -> bytes` reads the file under `REPO_ROOT` and raises `ValueError` when the bytes start with `LFS_POINTER_PREFIX`.
+- `sha256_hex(data: bytes) -> str`.
+- `content_type_for(repo_relative_path: str) -> str`.
+- `upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict` uploads to the key equal to the path, re-downloads the object, raises `RuntimeError` when the remote SHA-256 or length differs, and returns the inventory row.
+- `write_inventory(rows: list[dict], path: Path) -> None` writes the JSON shape above with two-space indent and a trailing newline.
+- `main() -> None` runs the caller path and prints `uploaded 53 objects to s3://mirrorview-experimental-artifacts/` as the last line.
+
+`data_platform/scripts/verify_bluesky_s3_migration.py`
+
+- Imports `BUCKET`, `REGION`, `EXPECTED_OBJECT_COUNT`, `INVENTORY_PATH`, and `sha256_hex` from the migration module.
+- `verify_inventory(inventory: dict, s3: S3) -> list[str]` re-downloads every listed key and returns one message per mismatch or missing object. An empty list means every object matched.
+- `main() -> None` loads the inventory, fails when `object_count` or `len(objects)` is not 53, prints `OK: 53/53 objects present with matching sha256` and exits 0 on success, or prints each problem and exits 1.
+
+Both scripts use `S3(BUCKET, region_name=REGION)` from `lib/aws/s3.py` without modifying it. Neither script calls `HeadObject`, because the re-download check already covers existence, length, and content.
+
+## Smoke checks (the executable spec)
+
+There are no automated tests. The verify script is the executable spec, and the commands below are the acceptance run.
+
+Given the 25 scoped parquet files are LFS pointers on disk, when `git lfs pull` runs for the two include patterns, then `posts.parquet` starts with the bytes `PAR1` and is 68,290,757 bytes.
+
+Given the pulled files, when the migration script runs, then it uploads 53 objects, every remote SHA-256 equals the local SHA-256, the inventory has 53 sorted rows, and the last stdout line is `uploaded 53 objects to s3://mirrorview-experimental-artifacts/`.
+
+Given the committed inventory, when the verify script runs, then it prints `OK: 53/53 objects present with matching sha256` and exits 0.
+
+Given a scoped file that is still pointer text, when `read_scoped_bytes` reads it, then `ValueError` is raised and nothing is uploaded for that file. Check the pointer rejection by hand once with a pointer file under `/tmp`, not with a committed test.
+
+## Ordered work
+
+Each item is one commit.
+
+1. Scaffold both scripts with stub bodies (`raise NotImplementedError`) and a wired `main` in each.
+2. Fill in the contracts above (constants, signatures, docstrings), bodies still stubs.
+3. Implement `verify_bluesky_s3_migration.py` in full. It is the executable check and fails before the migration runs because the inventory file does not exist yet.
+4. Implement `scoped_repo_relative_paths` and `content_type_for`. Print the count and confirm 53.
+5. Implement `run_git_lfs_pull`, `read_scoped_bytes`, and `sha256_hex`.
+6. Implement `upload_and_verify`, `write_inventory`, and `main`.
+7. Run the live smoke commands below and commit the inventory file.
+
+## Live smoke commands
+
+From the repo root. Export credentials first:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+PYTHONPATH=. uv run python -c "import boto3; print(boto3.client('sts').get_caller_identity()['Arn'])"
+```
+
+Expected: an ARN for the lab IAM user, exit code 0. The `aws` CLI is not installed in the Cloud Agent environment, so boto3 replaces `aws sts get-caller-identity` and `aws s3api head-object` here.
+
+```bash
+git lfs pull --include "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**"
+git lfs pull --include "data_platform/ingestion/data_dumps/bluesky/data/parquet/**"
+head -c 4 data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet | od -c | head -1
+```
+
+Expected: exit code 0 and the line `0000000   P   A   R   1`.
+
+```bash
+PYTHONPATH=. uv run python data_platform/scripts/migrate_bluesky_lfs_to_s3.py
+```
+
+Expected: last stdout line `uploaded 53 objects to s3://mirrorview-experimental-artifacts/`, exit code 0.
+
+```bash
+PYTHONPATH=. uv run python data_platform/scripts/verify_bluesky_s3_migration.py
+```
+
+Expected: `OK: 53/53 objects present with matching sha256`, exit code 0.
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import boto3
+s3 = boto3.client("s3", region_name="us-east-2")
+for key in [
+    "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet",
+    "data_platform/ingestion/data_dumps/bluesky/data/parquet/date=2026-09-01/hour=00/87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef.parquet",
+]:
+    head = s3.head_object(Bucket="mirrorview-experimental-artifacts", Key=key)
+    print(head["ResponseMetadata"]["HTTPStatusCode"], head["ContentLength"], key)
+PY
+```
+
+Expected: two lines starting with `200` and a non-zero length.
+
+```bash
+git lfs ls-files | grep "bluesky_7e2c4a91" | wc -l
+```
+
+Expected: `25`.
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import json
+from pathlib import Path
+inv = json.loads(Path("data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json").read_text())
+assert inv["object_count"] == 53
+assert len(inv["objects"]) == 53
+assert inv["objects"][0]["s3_key"].startswith("data_platform/")
+assert "data_platform/data_platform/" not in inv["objects"][0]["s3_key"]
+print("inventory ok", inv["uploaded_at"])
+PY
+```
+
+Expected: `inventory ok` plus a timestamp, exit code 0.
+
+## Must pass
+
+- 53 objects in S3 at repo-relative keys, none starting with `data_platform/data_platform/`.
+- Every inventory row has matching local and remote SHA-256.
+- The inventory file is committed under the pinned dataset directory.
+- `git lfs ls-files | grep "bluesky_7e2c4a91" | wc -l` prints `25`.
+- `git diff --stat origin/main -- lib/aws/s3.py data_platform/utils/storage.py .gitattributes .gitignore` prints nothing.
+
+## Must fail
+
+- Any script accepts an ETag as a content hash.
+- Any 133-byte pointer file is uploaded.
+- The object count is not 53.
+- Any Reddit or non-Bluesky path appears in the inventory.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Later S3 readers and feature runs need the pinned Bluesky dataset bytes in the `mirrorview-experimental-artifacts` S3 bucket with a verifiable record before they can depend on them. The dataset `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` (raw run `2026_09_01-00:00:00`, preprocessed run `2026_09_03-23:51:30`) and its source dump only exist as Git LFS objects today.

## Solution

Two scripts under `data_platform/scripts/` copy the 53 scoped files to S3 and check them.

`migrate_bluesky_lfs_to_s3.py` holds a frozen list of the 53 repo-relative paths. It runs `git lfs pull` for the two scoped include patterns. It refuses any file that is still LFS pointer text. It uploads each file to the S3 key equal to its repo-relative path. It re-downloads the object and compares full-object SHA-256 digests. It then writes `s3_migration_inventory.json` under the pinned dataset directory. The inventory has 53 sorted rows with path, key, byte count, and SHA-256.

`verify_bluesky_s3_migration.py` re-reads that inventory and re-downloads every object to confirm the hashes still match.

Neither script uses the S3 ETag as a content hash.

## Purpose

The migration ran once from this branch and the inventory in this pull request is the committed result. Git LFS pointers stay in the repository. `lib/aws/s3.py` and `data_platform/utils/storage.py` are unchanged. No Reddit or other path was uploaded. Removing the LFS copies and switching the pipeline to read from S3 are out of scope here (issue #183 and issue #182). The pull request adds no pytest files. Verification is the live commands below plus the existing test suite.

## How to run

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"

# Re-upload and re-verify. Safe to repeat. Rewrites the inventory timestamp.
PYTHONPATH=. uv run python data_platform/scripts/migrate_bluesky_lfs_to_s3.py
# last line: uploaded 53 objects to s3://mirrorview-experimental-artifacts/

# Verify the committed inventory against the bucket
PYTHONPATH=. uv run python data_platform/scripts/verify_bluesky_s3_migration.py
# OK: 53/53 objects present with matching sha256

# LFS pointers still tracked for the pinned dataset
git lfs ls-files | grep "bluesky_7e2c4a91" | wc -l
# 25
```

Observed on this branch on 2026-09-05:

- The migration printed `uploaded 53 objects to s3://mirrorview-experimental-artifacts/` and exited 0.
- The verifier printed `OK: 53/53 objects present with matching sha256` and exited 0.
- `head_object` on `preprocessed/2026_09_03-23:51:30/posts.parquet` returned 200 with 68,290,757 bytes and content type `application/octet-stream`.
- The bucket lists exactly 53 keys under `data_platform/`. None start with `data_platform/data_platform/` and none contain `reddit`.
- `git lfs ls-files | grep "bluesky_7e2c4a91" | wc -l` prints `25`.
- `lib/aws/s3.py`, `data_platform/utils/storage.py`, `.gitattributes`, and `.gitignore` have no diff against `main`.
- The existing pytest suite passes (631 passed).

Plan document: `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step1.md`, `docs/plans/2026-09-05_copy_bluesky_lfs_artifacts_to_s3_9877d3/`

Fixes #181
Part of #180
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07377-f9f2-70e3-a529-c0f524b4d983?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07377-f9f2-70e3-a529-c0f524b4d983&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an inventory for the Bluesky dataset in S3, including object locations, sizes, timestamps, and integrity checksums.
  - Added automated migration support for transferring the dataset’s files to S3 while validating file contents and expected scope.
  - Added verification checks to confirm that all recorded objects are available and match their expected sizes and checksums.

- **Documentation**
  - Added migration metadata to improve dataset traceability and auditability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->