### PR TITLE
Default data platform storage to S3 and drop Bluesky pipeline LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 data_platform/ingestion/data_dumps/bluesky/data/parquet/**/*.parquet filter=lfs diff=lfs merge=lfs -text
 data_platform/ingestion/data_dumps/reddit/filtered/*.parquet filter=lfs diff=lfs merge=lfs -text
-data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**/*.parquet filter=lfs diff=lfs merge=lfs -text
 data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/**/*.parquet filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ analysis/data/*.csv
 test_data/*.csv
 *.csv
 data_platform/data/**
-# Pinned Bluesky dataset: only JSON manifests stay in git; parquet lives in S3.
+# Pinned Bluesky dataset. Only the JSON manifests stay in git, and the parquet files live in S3.
 !data_platform/data/bluesky/
 !data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/
 !data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**/

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,11 @@ analysis/data/*.csv
 test_data/*.csv
 *.csv
 data_platform/data/**
+# Pinned Bluesky dataset: only JSON manifests stay in git; parquet lives in S3.
 !data_platform/data/bluesky/
 !data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/
-!data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**
+!data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**/
+!data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**/*.json
 !data_platform/data/reddit/
 !data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/
 !data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2026-09-06
+
+1. Pipeline storage now reads and writes the `mirrorview-experimental-artifacts` S3 bucket by default, and `DATA_PLATFORM_STORAGE_BACKEND=local` switches a developer back to local disk. The 25 parquet files of the pinned Bluesky dataset are no longer tracked by git or Git LFS, while its JSON manifests stay in git, and every test is pinned to local disk and a fake bucket so the suite cannot touch production. [Issue #183](https://github.com/METResearchGroup/mirrorView-task/issues/183)
+
 ## 2026-09-05
 
 1. The LLM toxicity feature test now expects the OpenAI Batch engine, matching the registry after LLM features moved off LangChain. [PR #177](https://github.com/METResearchGroup/mirrorView-task/pull/177)

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d267201de22378e2d5e1a2c9eb4eae4ab3bc174aca5a134233caa54df3578fe
-size 68290757

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=00/87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=00/87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:87e175daae2e2a8367e353ab2018088747e1f1deaa9b052889d9fd276297b2ef
-size 11740620

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=01/07a13b46f6e914e3fbfd0c87ef4ebdcf9c2d4f634322c915ee90f6c6590cc182.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=01/07a13b46f6e914e3fbfd0c87ef4ebdcf9c2d4f634322c915ee90f6c6590cc182.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07a13b46f6e914e3fbfd0c87ef4ebdcf9c2d4f634322c915ee90f6c6590cc182
-size 11404734

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=02/9291dd02ea6779db0af5c4e7338dff05d5a1b8a757bd1887d96e7dc5fa8e8be3.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=02/9291dd02ea6779db0af5c4e7338dff05d5a1b8a757bd1887d96e7dc5fa8e8be3.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9291dd02ea6779db0af5c4e7338dff05d5a1b8a757bd1887d96e7dc5fa8e8be3
-size 10688027

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=03/f507657e54bd11a974d2d3360dfd20ea5a37720b2720060a20a62392d32fa838.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=03/f507657e54bd11a974d2d3360dfd20ea5a37720b2720060a20a62392d32fa838.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f507657e54bd11a974d2d3360dfd20ea5a37720b2720060a20a62392d32fa838
-size 10671055

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=04/8f71e793b20221a35c9c068c7e1b5a2c92d20d3b6d07d7b6f14c96fa6e7b9b8a.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=04/8f71e793b20221a35c9c068c7e1b5a2c92d20d3b6d07d7b6f14c96fa6e7b9b8a.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f71e793b20221a35c9c068c7e1b5a2c92d20d3b6d07d7b6f14c96fa6e7b9b8a
-size 9343254

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=05/b75983817d2a7caa33652e907d87e0045d765613ff8912c75b6677460546c2a9.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=05/b75983817d2a7caa33652e907d87e0045d765613ff8912c75b6677460546c2a9.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b75983817d2a7caa33652e907d87e0045d765613ff8912c75b6677460546c2a9
-size 8913253

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=06/1d1efb717db79a6012e21439d1d99583a844b489bf851514d3c17f25060c245d.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=06/1d1efb717db79a6012e21439d1d99583a844b489bf851514d3c17f25060c245d.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d1efb717db79a6012e21439d1d99583a844b489bf851514d3c17f25060c245d
-size 9377626

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=07/bdcf5c6a124a8427d6243ca1cb4dad21de091a9cc2f861bc31e68dc4ae0e8ee7.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=07/bdcf5c6a124a8427d6243ca1cb4dad21de091a9cc2f861bc31e68dc4ae0e8ee7.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bdcf5c6a124a8427d6243ca1cb4dad21de091a9cc2f861bc31e68dc4ae0e8ee7
-size 9470376

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=08/0276dae1716f95233fc8cc45af8e0fab85a9c6c30f38b7b873633d3555316cec.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=08/0276dae1716f95233fc8cc45af8e0fab85a9c6c30f38b7b873633d3555316cec.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0276dae1716f95233fc8cc45af8e0fab85a9c6c30f38b7b873633d3555316cec
-size 10062784

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=09/065a1008065c2274e24202136e72b152d6b04d780a854c04dee3765d68357508.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=09/065a1008065c2274e24202136e72b152d6b04d780a854c04dee3765d68357508.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:065a1008065c2274e24202136e72b152d6b04d780a854c04dee3765d68357508
-size 11035625

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=10/a1f035bf84ffc505ea57fda0c373c18633dbf65c2b4686c9326d63170026f88c.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=10/a1f035bf84ffc505ea57fda0c373c18633dbf65c2b4686c9326d63170026f88c.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a1f035bf84ffc505ea57fda0c373c18633dbf65c2b4686c9326d63170026f88c
-size 12357796

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=11/819729c9892253012b62bb3a28dc5c3a05c3b66b1836533f44065a330a116e3b.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=11/819729c9892253012b62bb3a28dc5c3a05c3b66b1836533f44065a330a116e3b.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:819729c9892253012b62bb3a28dc5c3a05c3b66b1836533f44065a330a116e3b
-size 13858534

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=12/c215309e4986c3414dbc5570af8e35d14d13324c8025301fbec2a5346c9b8f8b.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=12/c215309e4986c3414dbc5570af8e35d14d13324c8025301fbec2a5346c9b8f8b.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c215309e4986c3414dbc5570af8e35d14d13324c8025301fbec2a5346c9b8f8b
-size 15732460

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=13/4e8e9fa304aa7077c79f235570515987684b758e2c3faa7b70e90590c90e7c98.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=13/4e8e9fa304aa7077c79f235570515987684b758e2c3faa7b70e90590c90e7c98.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e8e9fa304aa7077c79f235570515987684b758e2c3faa7b70e90590c90e7c98
-size 16707580

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=14/996a62335449379e3495e840958d5d11b7833c4c5e77490ec69f1acf1f2d393c.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=14/996a62335449379e3495e840958d5d11b7833c4c5e77490ec69f1acf1f2d393c.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:996a62335449379e3495e840958d5d11b7833c4c5e77490ec69f1acf1f2d393c
-size 17463736

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=15/c17354f4d79805d27549fe6b1008cc8b1bdf70b6f801b68c9b844e27ef5a8c78.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=15/c17354f4d79805d27549fe6b1008cc8b1bdf70b6f801b68c9b844e27ef5a8c78.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c17354f4d79805d27549fe6b1008cc8b1bdf70b6f801b68c9b844e27ef5a8c78
-size 17344905

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=16/11044bc252e2f74cd4a8b1cccee37f09fa7c7f0805e9c5951e3e003cbf9b0508.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=16/11044bc252e2f74cd4a8b1cccee37f09fa7c7f0805e9c5951e3e003cbf9b0508.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:11044bc252e2f74cd4a8b1cccee37f09fa7c7f0805e9c5951e3e003cbf9b0508
-size 16706456

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=17/7561d13554b77359f734feab412d997b54ec77b75aad0cb0c88a42d544af4412.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=17/7561d13554b77359f734feab412d997b54ec77b75aad0cb0c88a42d544af4412.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7561d13554b77359f734feab412d997b54ec77b75aad0cb0c88a42d544af4412
-size 15775445

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=18/d8a3189e9a0ccf1573d931c21a7a0406c624c795f64c0b78bddb255ddc5fbee9.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=18/d8a3189e9a0ccf1573d931c21a7a0406c624c795f64c0b78bddb255ddc5fbee9.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8a3189e9a0ccf1573d931c21a7a0406c624c795f64c0b78bddb255ddc5fbee9
-size 15066164

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=19/ebb4b2d8fd185c4a957629af8e777ef84cf979057fdaf7be998db4eeb7afed17.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=19/ebb4b2d8fd185c4a957629af8e777ef84cf979057fdaf7be998db4eeb7afed17.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebb4b2d8fd185c4a957629af8e777ef84cf979057fdaf7be998db4eeb7afed17
-size 14583727

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=20/1e9397d32125d44702131b572c3300c4da2dc65cde2ab324cfb13f2437d679d7.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=20/1e9397d32125d44702131b572c3300c4da2dc65cde2ab324cfb13f2437d679d7.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e9397d32125d44702131b572c3300c4da2dc65cde2ab324cfb13f2437d679d7
-size 14261458

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=21/73a3a11c68afafe8cd2e210f02ba138cc46f2983c954aeaf71bfe38f7c02454f.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=21/73a3a11c68afafe8cd2e210f02ba138cc46f2983c954aeaf71bfe38f7c02454f.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73a3a11c68afafe8cd2e210f02ba138cc46f2983c954aeaf71bfe38f7c02454f
-size 13811652

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=22/71ec9881d8718156f855e4aeb9d23799bb8a5e92bd2c9d1b9ffe8ae00e41c4f7.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=22/71ec9881d8718156f855e4aeb9d23799bb8a5e92bd2c9d1b9ffe8ae00e41c4f7.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71ec9881d8718156f855e4aeb9d23799bb8a5e92bd2c9d1b9ffe8ae00e41c4f7
-size 13253841

--- a/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=23/7aa81f763c2c76de75602fbe77ab9483e85cb4b94c4a81b6829787a70aef0945.parquet
+++ b/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/date=2026-09-01/hour=23/7aa81f763c2c76de75602fbe77ab9483e85cb4b94c4a81b6829787a70aef0945.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7aa81f763c2c76de75602fbe77ab9483e85cb4b94c4a81b6829787a70aef0945
-size 12541834

--- a/data_platform/utils/object_store.py
+++ b/data_platform/utils/object_store.py
@@ -2,7 +2,7 @@
 
 Keys are paths relative to ``data_platform/data``, so the same key names a
 file under the local data root and an object under the S3 prefix. The env var
-``DATA_PLATFORM_STORAGE_BACKEND`` picks the backend and defaults to S3; set it
+``DATA_PLATFORM_STORAGE_BACKEND`` picks the backend and defaults to S3. Set it
 to ``local`` to work from local disk.
 """
 

--- a/data_platform/utils/object_store.py
+++ b/data_platform/utils/object_store.py
@@ -2,7 +2,8 @@
 
 Keys are paths relative to ``data_platform/data``, so the same key names a
 file under the local data root and an object under the S3 prefix. The env var
-``DATA_PLATFORM_STORAGE_BACKEND`` picks the backend and defaults to local disk.
+``DATA_PLATFORM_STORAGE_BACKEND`` picks the backend and defaults to S3; set it
+to ``local`` to work from local disk.
 """
 
 from __future__ import annotations
@@ -246,16 +247,16 @@ def _content_type_for(key: str) -> str:
 def resolve_object_store(*, local_root: Path) -> ObjectStore:
     """Return the store selected by ``DATA_PLATFORM_STORAGE_BACKEND``.
 
-    Unset or ``local`` returns a ``LocalObjectStore`` over ``local_root``.
-    ``s3`` returns an ``S3ObjectStore`` over ``DATA_PLATFORM_S3_BUCKET``
-    (default ``mirrorview-experimental-artifacts``).
+    Unset or ``s3`` returns an ``S3ObjectStore`` over ``DATA_PLATFORM_S3_BUCKET``
+    (default ``mirrorview-experimental-artifacts``). ``local`` returns a
+    ``LocalObjectStore`` over ``local_root``.
 
     Raises
     ------
     ValueError
         When the backend value is not ``local`` or ``s3``.
     """
-    backend = os.environ.get(STORAGE_BACKEND_ENV_VAR, LOCAL_BACKEND).strip().lower()
+    backend = os.environ.get(STORAGE_BACKEND_ENV_VAR, S3_BACKEND).strip().lower()
     if backend == LOCAL_BACKEND:
         return LocalObjectStore(local_root)
     if backend == S3_BACKEND:

--- a/docs/plans/2026-09-06_s3_default_backend_drop_bluesky_lfs_efbd19/plan.md
+++ b/docs/plans/2026-09-06_s3_default_backend_drop_bluesky_lfs_efbd19/plan.md
@@ -9,11 +9,11 @@
 
 ## Overview
 
-The data platform can already read and write the `mirrorview-experimental-artifacts` S3 bucket when `DATA_PLATFORM_STORAGE_BACKEND=s3`, and every object of the pinned Bluesky dataset is in that bucket with a verified SHA-256. Local disk is still the default backend, and the 25 parquet files of the pinned Bluesky dataset are still tracked by Git LFS. This plan flips the default backend to S3, keeps `DATA_PLATFORM_STORAGE_BACKEND=local` as the developer override, and removes the 25 parquet files from git and Git LFS tracking without rewriting history. The four JSON manifests of the dataset stay in git as ordinary text files.
+The data platform can already read and write the `mirrorview-experimental-artifacts` S3 bucket when `DATA_PLATFORM_STORAGE_BACKEND=s3`, and every object of the pinned Bluesky dataset is in that bucket with a verified SHA-256. Local disk is still the default backend, and the 25 parquet files of the pinned Bluesky dataset are still tracked by Git LFS. The plan flips the default backend to S3, keeps `DATA_PLATFORM_STORAGE_BACKEND=local` as the developer override, and removes the 25 parquet files from git and Git LFS tracking without rewriting history. The four JSON manifests of the dataset stay in git as ordinary text files.
 
-The test suite never sets the backend variable today, so the flip alone would send 106 existing tests to S3. On a machine with AWS credentials, those tests would write fixture data into the production bucket. The plan therefore pins every test under `tests/data_platform/` to local disk and to a fake bucket name before the default changes. No test outside `tests/data_platform/` builds a storage manager or resolves an object store.
+The test suite never sets the backend variable today, so the flip alone would send 106 existing tests to S3. On a machine with AWS credentials, those tests would write fixture data into the production bucket. The plan therefore pins every test under `tests/data_platform/` to local disk and to a fake bucket name before the default changes. No test outside `tests/data_platform/` builds a storage manager or resolves an object store, so one fixture in that directory covers the whole suite.
 
-The plan is one PR for child issue #183 of epic #180. It depends on the merged work of issues #181 and #182, which sit below it in the same branch stack.
+The plan is one PR for child issue #183 of epic #180. It builds on the work of issues #181 and #182, which are the two branches beneath this one.
 
 ## Happy flow
 
@@ -31,7 +31,7 @@ flowchart LR
 
 ## Approach
 
-Change one default value, add one test fixture, and edit two git config files. The default flip lives in `resolve_object_store` alone, so the S3 store, the local store, and `StorageManager` do not change. The fixture lands before the flip, so no commit on the branch leaves the suite pointed at the production bucket. The parquet files leave the git index with `git rm --cached`, the Bluesky pipeline LFS rule leaves `.gitattributes`, and `.gitignore` stops un-ignoring the parquet paths while it keeps the JSON manifests tracked. The working tree copies stay on disk so the local override keeps working for anyone who already pulled the LFS blobs. Reddit and Bluesky dump LFS rules are untouched, and history is not rewritten.
+Change one default value, add one test fixture, and edit two git config files. The default flip lives in `resolve_object_store` alone, so the S3 store, the local store, and `StorageManager` do not change. The fixture lands before the flip, so no commit on the branch leaves the suite pointed at the production bucket. The parquet files leave the git index with `git rm --cached`, the Bluesky pipeline LFS rule leaves `.gitattributes`, and `.gitignore` ignores the parquet paths again while it keeps the JSON manifests tracked. The working tree copies stay on disk, so the local override keeps working for anyone who already pulled the LFS blobs. The tracked JSON files already keep every needed directory in git, so no placeholder file is added. Reddit and Bluesky dump LFS rules are untouched, and history is not rewritten.
 
 ## Steps
 

--- a/docs/plans/2026-09-06_s3_default_backend_drop_bluesky_lfs_efbd19/plan.md
+++ b/docs/plans/2026-09-06_s3_default_backend_drop_bluesky_lfs_efbd19/plan.md
@@ -1,0 +1,50 @@
+# Make S3 the default data platform storage backend and drop the Bluesky pipeline parquet files from Git LFS
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, frequent commits
+- Do not add or run new automated tests. Use the approved live smoke checks in the step spec, and run the existing `uv run pytest -q` suite as described there.
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+The data platform can already read and write the `mirrorview-experimental-artifacts` S3 bucket when `DATA_PLATFORM_STORAGE_BACKEND=s3`, and every object of the pinned Bluesky dataset is in that bucket with a verified SHA-256. Local disk is still the default backend, and the 25 parquet files of the pinned Bluesky dataset are still tracked by Git LFS. This plan flips the default backend to S3, keeps `DATA_PLATFORM_STORAGE_BACKEND=local` as the developer override, and removes the 25 parquet files from git and Git LFS tracking without rewriting history. The four JSON manifests of the dataset stay in git as ordinary text files.
+
+The test suite never sets the backend variable today, so the flip alone would send 106 existing tests to S3. On a machine with AWS credentials, those tests would write fixture data into the production bucket. The plan therefore pins every test under `tests/data_platform/` to local disk and to a fake bucket name before the default changes. No test outside `tests/data_platform/` builds a storage manager or resolves an object store.
+
+The plan is one PR for child issue #183 of epic #180. It depends on the merged work of issues #181 and #182, which sit below it in the same branch stack.
+
+## Happy flow
+
+An operator with AWS credentials and no `DATA_PLATFORM_STORAGE_BACKEND` variable builds the Bluesky preprocessed storage manager and loads the latest run. The storage manager resolves the S3 store, downloads the pinned `posts.parquet` object, and returns 200,000 rows. A developer who sets the variable to `local` and has the parquet files on disk gets the same rows from the local copy.
+
+```mermaid
+flowchart LR
+    A[StorageManager builds its object store] --> B{DATA_PLATFORM_STORAGE_BACKEND}
+    B -->|unset or s3| C[S3ObjectStore over mirrorview-experimental-artifacts]
+    B -->|local| D[LocalObjectStore over data_platform/data]
+    E[pytest autouse fixture] -->|sets local and a fake bucket name| B
+    C --> F[200,000 pinned rows]
+    D --> F
+```
+
+## Approach
+
+Change one default value, add one test fixture, and edit two git config files. The default flip lives in `resolve_object_store` alone, so the S3 store, the local store, and `StorageManager` do not change. The fixture lands before the flip, so no commit on the branch leaves the suite pointed at the production bucket. The parquet files leave the git index with `git rm --cached`, the Bluesky pipeline LFS rule leaves `.gitattributes`, and `.gitignore` stops un-ignoring the parquet paths while it keeps the JSON manifests tracked. The working tree copies stay on disk so the local override keeps working for anyone who already pulled the LFS blobs. Reddit and Bluesky dump LFS rules are untouched, and history is not rewritten.
+
+## Steps
+
+### Step 1: Pin tests to local disk, flip the default backend to S3, and untrack the pinned Bluesky parquet files
+
+Add an autouse fixture in the data platform test conftest, change the default backend in `resolve_object_store`, update `.gitattributes` and `.gitignore`, and remove the 25 parquet files from the index. Verify with the live smoke commands and the three production safety checks in `steps/step1.md`.
+
+## What "done" looks like
+
+1. With `DATA_PLATFORM_STORAGE_BACKEND` unset and AWS credentials present, `BlueskyStorageManager(StorageStage.PREPROCESSED, "bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73").load_records(latest=True)` returns 200,000 rows from S3.
+2. With `DATA_PLATFORM_STORAGE_BACKEND=local`, `resolve_object_store` returns a `LocalObjectStore`.
+3. `git lfs ls-files` lists no path under `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/`, and `git ls-files` lists no parquet file under that directory.
+4. `dataset.json`, both `metadata.json` files, and `s3_migration_inventory.json` under that directory stay tracked as ordinary files.
+5. The Reddit and Bluesky dump LFS rules and files are unchanged, and no history is rewritten.
+6. `uv run pytest -q` passes with 631 tests, both with AWS credentials present and with credentials stripped, and the bucket listing under `data_platform/data/` after the run matches the 28 inventory keys under that prefix exactly.
+7. `data_platform/scripts/verify_bluesky_s3_migration.py` still reports 53 of 53 objects present.

--- a/docs/plans/2026-09-06_s3_default_backend_drop_bluesky_lfs_efbd19/steps/step1.md
+++ b/docs/plans/2026-09-06_s3_default_backend_drop_bluesky_lfs_efbd19/steps/step1.md
@@ -1,0 +1,270 @@
+# Step 1: Pin tests to local disk, flip the default backend to S3, and untrack the pinned Bluesky parquet files
+
+## Goal
+
+Make `resolve_object_store` return the S3 store when `DATA_PLATFORM_STORAGE_BACKEND` is unset, keep `local` as the explicit override, and remove the 25 parquet files of the pinned Bluesky dataset from git and Git LFS tracking. Keep the four JSON manifests tracked. Make sure no test can reach the production bucket before the default changes.
+
+## Source of truth
+
+The epic step spec is `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step3.md`. Every locked value below is copied from it, plus one amendment from the epic manager: `tests/data_platform/conftest.py` may change for a fixture-only edit with no new test cases. If the two files disagree on anything else, the epic step spec wins and this file is wrong.
+
+## Main caller
+
+`data_platform/utils/storage.py` `StorageManager.__init__`, which calls `data_platform/utils/object_store.py` `resolve_object_store(local_root=DATA_ROOT)`.
+
+Happy path through the caller: read `DATA_PLATFORM_STORAGE_BACKEND`, treat an unset value as `s3`, read `DATA_PLATFORM_S3_BUCKET` with its default, and return an `S3ObjectStore`. `load_records(latest=True)` then downloads the pinned `posts.parquet` and returns 200,000 rows.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/steps/step3.md` | Locked contracts, smoke commands, forbidden files |
+| `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/campaign_contract.md` | Bucket, region, and prefix shared by later steps |
+| `data_platform/utils/storage.py` | `StorageManager.__init__` calls `resolve_object_store`; `latest_run_dir` still lists the local run directory |
+| `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json` | The 53 S3 keys and hashes; 28 of them sit under `data_platform/data/` |
+| `data_platform/scripts/verify_bluesky_s3_migration.py` | Post-change inventory check |
+| `tests/data_platform/utils/conftest.py` | The `bluesky_storage` fixture builds a `BlueskyStorageManager` and must keep working |
+| `AGENTS.md` | `PYTHONPATH=.` and AWS credential export pattern |
+
+## Files allowed to change
+
+- `data_platform/utils/object_store.py` (default backend flip and the two docstrings that state the default; nothing else)
+- `tests/data_platform/conftest.py` (one autouse fixture; no new test cases)
+- `.gitattributes` (delete the Bluesky pipeline parquet LFS line only)
+- `.gitignore` (replace the pinned Bluesky dataset un-ignore lines so only JSON manifests stay tracked)
+- Git index only, for removal from tracking of the 25 parquet files under `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/`
+
+`CHANGELOG.md` is edited only in a separate commit after implementation. No smoke artifacts are committed; smoke output goes into the PR description.
+
+## Files forbidden to change
+
+- `data_platform/utils/storage.py` (its class docstring still says local disk is the default; the epic step spec does not allow this file, so leave it and note it in the PR)
+- `data_platform/scripts/migrate_bluesky_lfs_to_s3.py`
+- `data_platform/scripts/verify_bluesky_s3_migration.py`
+- `data_platform/ingestion/data_dumps/bluesky/data/**` (dump LFS stays)
+- `data_platform/data/reddit/**`
+- `.gitattributes` lines for Reddit or dump parquet
+- `data_platform/generate_features/**`, `data_platform/preprocessing/**`, `data_platform/ingestion/sync_bluesky.py`
+- `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json`, both `metadata.json` files, and `s3_migration_inventory.json` (content stays; they remain tracked)
+- Any file under `tests/` other than `tests/data_platform/conftest.py`
+- Any file under `docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/`, `docs/plans/2026-09-05_copy_bluesky_lfs_artifacts_to_s3_9877d3/`, or `docs/plans/2026-09-05_s3_object_store_storage_backend_d13173/`
+- Any git history rewrite (`git filter-repo`, `git lfs migrate`, force push, amend of a pushed commit)
+- Any S3 write or delete
+
+Stage files by explicit path only. Never run `git add -A` or `git add .`. `git status` lists the pulled parquet files as modified even though `git diff` is empty; `git rm --cached` on those exact paths is the only index operation that touches them.
+
+## Locked values
+
+| Item | Value |
+|------|-------|
+| Production default backend | `s3` when `DATA_PLATFORM_STORAGE_BACKEND` is unset |
+| Local override | `DATA_PLATFORM_STORAGE_BACKEND=local` |
+| Invalid backend value | Still raises `ValueError` |
+| Bucket | `mirrorview-experimental-artifacts` |
+| Region | `us-east-2` |
+| S3 key prefix | `data_platform/data/` |
+| Test backend pin | Autouse fixture sets `DATA_PLATFORM_STORAGE_BACKEND=local` and `DATA_PLATFORM_S3_BUCKET=mirrorview-tests-must-not-touch-s3` for every test under `tests/data_platform/` |
+| Parquet removed from git | Exactly 25 files: 24 under `raw/2026_09_01-00:00:00/date=2026-09-01/hour=*/` and `preprocessed/2026_09_03-23:51:30/posts.parquet` |
+| JSON kept in git | `dataset.json`, `raw/2026_09_01-00:00:00/metadata.json`, `preprocessed/2026_09_03-23:51:30/metadata.json`, `s3_migration_inventory.json` |
+| `.gitattributes` change | Delete the line `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**/*.parquet filter=lfs diff=lfs merge=lfs -text` |
+| Dump LFS untouched | `data_platform/ingestion/data_dumps/bluesky/data/parquet/**` remains LFS |
+| Reddit LFS untouched | All `data_platform/data/reddit/**` rules and files unchanged |
+| Directory placeholder | The tracked `dataset.json` and the two `metadata.json` files keep every needed directory in git, so no `.gitkeep` is added |
+| History | No force push, no LFS history rewrite, no `git filter-repo` |
+
+## Contracts
+
+`data_platform/utils/object_store.py`:
+
+- `resolve_object_store(*, local_root: Path) -> ObjectStore` keeps its signature. The lookup becomes `os.environ.get(STORAGE_BACKEND_ENV_VAR, S3_BACKEND)`. `local` returns `LocalObjectStore(local_root)`, `s3` returns `S3ObjectStore(bucket)` with `bucket` from `DATA_PLATFORM_S3_BUCKET` or `DEFAULT_S3_BUCKET`, and any other value raises `ValueError`.
+- The module docstring and the `resolve_object_store` docstring say that the variable defaults to S3.
+- No other symbol changes.
+
+`tests/data_platform/conftest.py`:
+
+- Adds `local_storage_backend`, an autouse fixture that takes `monkeypatch` and sets `STORAGE_BACKEND_ENV_VAR` to `LOCAL_BACKEND` and `S3_BUCKET_ENV_VAR` to `mirrorview-tests-must-not-touch-s3`, importing those names from `data_platform.utils.object_store`. Its docstring states in one or two sentences that the production default is S3 and that the fake bucket keeps even a deliberate `s3` test away from the production bucket.
+- The existing `data_root` fixture and helpers do not change.
+
+`.gitignore`:
+
+- The three lines under `data_platform/data/**` that un-ignore `data_platform/data/bluesky/`, the dataset directory, and the dataset directory `**` become lines that un-ignore `data_platform/data/bluesky/`, the dataset directory, every subdirectory of the dataset directory, and `*.json` at any depth under the dataset directory. Parquet files under the dataset directory fall back to the `data_platform/data/**` ignore rule. The Reddit lines directly below do not change.
+
+`.gitattributes`:
+
+- Only the Bluesky pipeline line is deleted. The file keeps the dump line, the Reddit dump line, and the Reddit pipeline line.
+
+## Check design
+
+No pytest files are added. The scenarios below are the executable spec, and each maps to one command in the next section. The autouse fixture is the only test change, and it lands before the default flips so no commit on the branch leaves the suite pointed at the production bucket.
+
+```text
+given AWS credentials and no DATA_PLATFORM_STORAGE_BACKEND
+when BlueskyStorageManager(PREPROCESSED, dataset).load_records(latest=True)
+then the dataframe has 200000 rows
+
+given DATA_PLATFORM_STORAGE_BACKEND=local
+when resolve_object_store(local_root=DATA_ROOT)
+then a LocalObjectStore is returned
+
+given the full test suite with the flipped default and AWS credentials stripped
+when uv run pytest -q
+then 631 passed and zero NoCredentialsError
+
+given the full test suite with the flipped default and AWS credentials present
+when uv run pytest -q and then a listing of s3://mirrorview-experimental-artifacts/data_platform/data/
+then 631 passed and the listing equals the 28 inventory keys under that prefix
+
+given the updated .gitignore and .gitattributes
+when git lfs ls-files, git ls-files, and git check-ignore run on the dataset directory
+then no LFS path under the dataset, no tracked parquet under the dataset, the four JSON files tracked and not ignored, and each parquet path ignored
+```
+
+## Ordered implementation work
+
+1. Add the autouse fixture to `tests/data_platform/conftest.py`. Run `uv run pytest -q` and expect 631 passed. Commit.
+2. Change the default in `resolve_object_store` to `S3_BACKEND` and update the two docstrings in `object_store.py`. Commit.
+3. Delete the Bluesky pipeline line from `.gitattributes`, rewrite the pinned dataset un-ignore lines in `.gitignore`, and run `git rm --cached` on the 25 parquet paths. Stage `.gitattributes` and `.gitignore` by path. Confirm the four JSON files are still tracked. Commit.
+4. Run every command in the next section.
+
+## Live smoke and basic check commands
+
+Export AWS credentials first:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+```
+
+**Default backend is S3**
+
+```bash
+unset DATA_PLATFORM_STORAGE_BACKEND
+PYTHONPATH=. uv run python - <<'PY'
+from data_platform.utils.storage import BlueskyStorageManager, StorageStage
+storage = BlueskyStorageManager(StorageStage.PREPROCESSED, "bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73")
+df = storage.load_records(latest=True)
+assert len(df) == 200000
+print("default s3 backend ok", len(df))
+PY
+```
+
+Expected stdout: `default s3 backend ok 200000`, exit code 0.
+
+**Local override still works**
+
+```bash
+DATA_PLATFORM_STORAGE_BACKEND=local \
+PYTHONPATH=. uv run python - <<'PY'
+from data_platform.utils.storage import DATA_ROOT
+from data_platform.utils.object_store import resolve_object_store
+assert resolve_object_store(local_root=DATA_ROOT).__class__.__name__ == "LocalObjectStore"
+print("local override ok")
+PY
+```
+
+Expected stdout: `local override ok`.
+
+**Migration inventory still valid**
+
+```bash
+PYTHONPATH=. uv run python data_platform/scripts/verify_bluesky_s3_migration.py
+```
+
+Expected stdout: `OK: 53/53 objects present with matching sha256`.
+
+**No Bluesky pipeline parquet in LFS or in git**
+
+```bash
+git lfs ls-files | grep "data_platform/data/bluesky/bluesky_7e2c4a91" || echo "no bluesky pipeline lfs"
+git ls-files "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**/*.parquet" | wc -l
+```
+
+Expected stdout: `no bluesky pipeline lfs` and then `0`.
+
+**JSON manifests still tracked and not ignored**
+
+```bash
+git ls-files "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/*.json" "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**/metadata.json"
+git check-ignore -v --no-index data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/metadata.json || echo "json not ignored"
+```
+
+Expected stdout: the four JSON paths (`dataset.json`, `s3_migration_inventory.json`, and both `metadata.json`), then `json not ignored`.
+
+**Parquet paths are ignored on disk**
+
+```bash
+git check-ignore -q data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/preprocessed/2026_09_03-23:51:30/posts.parquet && echo "parquet ignored"
+git status --short data_platform/data/bluesky/ | wc -l
+```
+
+Expected stdout: `parquet ignored` and then `0`.
+
+**Dump and Reddit LFS unchanged**
+
+```bash
+git lfs ls-files | grep -E "data_dumps/bluesky|data/reddit" | wc -l
+git diff cursor/epic-180-182-s3-storage-support-d983...HEAD -- .gitattributes
+```
+
+Expected: `27`, and a diff that deletes only the one Bluesky pipeline line.
+
+**Production safety check (a): suite with credentials stripped**
+
+```bash
+env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN AWS_EC2_METADATA_DISABLED=true uv run pytest -q 2>&1 | tee /tmp/pytest_no_creds.txt | tail -1
+grep -c NoCredentialsError /tmp/pytest_no_creds.txt
+```
+
+Expected: `631 passed` and then `0`.
+
+**Production safety check (b): suite with credentials present**
+
+```bash
+uv run pytest -q | tail -1
+```
+
+Expected: `631 passed`.
+
+**Production safety check (c): bucket listing unchanged after (b)**
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import json, boto3
+inventory = json.load(open("data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/s3_migration_inventory.json"))
+expected = {o["s3_key"] for o in inventory["objects"] if o["s3_key"].startswith("data_platform/data/")}
+s3 = boto3.client("s3", region_name="us-east-2")
+keys = set()
+for page in s3.get_paginator("list_objects_v2").paginate(Bucket="mirrorview-experimental-artifacts", Prefix="data_platform/data/"):
+    keys.update(o["Key"] for o in page.get("Contents", []))
+print("listed", len(keys), "expected", len(expected))
+print("extra", sorted(keys - expected))
+print("missing", sorted(expected - keys))
+PY
+```
+
+Expected stdout: `listed 28 expected 28`, `extra []`, `missing []`. Any extra key means a test wrote to production. Stop and report it. Do not delete anything.
+
+## Acceptance criteria
+
+- The default backend smoke prints `default s3 backend ok 200000`.
+- The local override smoke prints `local override ok`.
+- The inventory check prints `OK: 53/53 objects present with matching sha256`.
+- No path under the pinned dataset appears in `git lfs ls-files`, and no parquet under it appears in `git ls-files`.
+- The four JSON files are tracked and not ignored; the parquet paths are ignored and `git status` is clean under `data_platform/data/bluesky/`.
+- The dump and Reddit LFS count is 27 and the `.gitattributes` diff deletes one line.
+- Safety checks (a), (b), and (c) pass with the expected output.
+
+## Failure conditions
+
+- Any pinned Bluesky parquet remains in `git lfs ls-files` or `git ls-files`.
+- A JSON manifest is removed from git or becomes ignored.
+- A Reddit or dump LFS rule changes.
+- The default backend remains `local`, or the local override stops working.
+- Any test reaches S3 without credentials, or any key appears in the bucket listing that is not in the inventory.
+- Git history is rewritten or force-pushed.
+
+## Commit rules
+
+- Three implementation commits in the order above: fixture, default flip, git tracking changes.
+- Stage files by explicit path. Never stage a parquet file.
+- PR title: `Default data platform storage to S3 and drop Bluesky pipeline LFS`.

--- a/docs/plans/2026-09-06_s3_default_backend_drop_bluesky_lfs_efbd19/steps/step1.md
+++ b/docs/plans/2026-09-06_s3_default_backend_drop_bluesky_lfs_efbd19/steps/step1.md
@@ -185,10 +185,10 @@ Expected stdout: `no bluesky pipeline lfs` and then `0`.
 
 ```bash
 git ls-files "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/*.json" "data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/**/metadata.json"
-git check-ignore -v --no-index data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/dataset.json data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/raw/2026_09_01-00:00:00/metadata.json || echo "json not ignored"
+for f in $(git ls-files data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 | grep '\.json$'); do git check-ignore -q --no-index "$f" && echo "IGNORED $f" || echo "not ignored $f"; done
 ```
 
-Expected stdout: the four JSON paths (`dataset.json`, `s3_migration_inventory.json`, and both `metadata.json`), then `json not ignored`.
+Expected stdout: the four JSON paths (`dataset.json`, `s3_migration_inventory.json`, and both `metadata.json`) from the first command, then four `not ignored` lines and no `IGNORED` line. `check-ignore -q` exits 0 only when a path is ignored, so `--no-index` makes the rule check apply to tracked files too.
 
 **Parquet paths are ignored on disk**
 

--- a/tests/data_platform/conftest.py
+++ b/tests/data_platform/conftest.py
@@ -9,6 +9,11 @@ import pytest
 
 import data_platform.utils.dataset as dataset_mod
 import data_platform.utils.storage as storage_mod
+from data_platform.utils.object_store import (
+    LOCAL_BACKEND,
+    S3_BUCKET_ENV_VAR,
+    STORAGE_BACKEND_ENV_VAR,
+)
 from tests.data_platform.constants import (
     LABEL_TIMESTAMP,
     SAMPLE_INGESTION_ROW,
@@ -16,6 +21,23 @@ from tests.data_platform.constants import (
     URI_POST_B,
     expected_bluesky_record_id,
 )
+
+FAKE_TEST_S3_BUCKET = "mirrorview-tests-must-not-touch-s3"
+
+
+@pytest.fixture(autouse=True)
+def local_storage_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep every test on local disk storage and away from the production bucket.
+
+    The data platform defaults to the S3 backend when
+    ``DATA_PLATFORM_STORAGE_BACKEND`` is unset, so an unpinned test would read
+    and write ``mirrorview-experimental-artifacts`` whenever AWS credentials are
+    present. The fake bucket name means a test that sets the backend to ``s3``
+    on purpose still cannot reach the production bucket.
+    """
+    monkeypatch.setenv(STORAGE_BACKEND_ENV_VAR, LOCAL_BACKEND)
+    monkeypatch.setenv(S3_BUCKET_ENV_VAR, FAKE_TEST_S3_BUCKET)
+
 
 @pytest.fixture
 def data_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #198 and #197. Merge those first.

## Problem

Local disk remained the default data platform storage backend, and the 25 parquet files of the pinned Bluesky dataset were still tracked by Git LFS. Every clone paid for those blobs even though, after #182, the same bytes were in S3 with verified hashes (#181). The test suite also never set the backend variable, so a plain flip of the default would have sent 106 tests to S3. On any machine with AWS credentials, those tests would have written test fixture data into the production bucket.

## Solution

`resolve_object_store` now returns the S3 store when `DATA_PLATFORM_STORAGE_BACKEND` is unset. `DATA_PLATFORM_STORAGE_BACKEND=local` still selects local disk, and any other value still raises `ValueError`. An autouse fixture in `tests/data_platform/conftest.py` pins every test to `local` and sets `DATA_PLATFORM_S3_BUCKET=mirrorview-tests-must-not-touch-s3`. A test cannot reach the production bucket even if it sets the backend to `s3` on purpose. The 25 pinned Bluesky parquet files are removed from the git index with `git rm --cached`. The Bluesky pipeline rule is deleted from `.gitattributes`, and `.gitignore` now un-ignores only directories and `*.json` under the dataset folder. `dataset.json`, both `metadata.json` files, and `s3_migration_inventory.json` stay tracked as ordinary files. Working tree copies stay on disk and are ignored. History is not rewritten.

## Purpose

Production reads of the pinned dataset come from S3 so the seven feature generation issues (#188 to #194) do not depend on LFS blobs. The fixture landed in its own commit before the default flip, so no commit on this branch leaves the suite pointed at production. Out of scope: updating the `StorageManager` class docstring in `data_platform/utils/storage.py` (it still says local disk is the default), S3 lifecycle rules, and any change to Reddit or Bluesky dump LFS.

## How to run

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
unset DATA_PLATFORM_STORAGE_BACKEND

# Default backend reads the pinned run from S3 (expect: default s3 backend ok 200000)
PYTHONPATH=. uv run python - <<'PY'
from data_platform.utils.storage import BlueskyStorageManager, StorageStage
df = BlueskyStorageManager(StorageStage.PREPROCESSED, "bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73").load_records(latest=True)
assert len(df) == 200000
print("default s3 backend ok", len(df))
PY

# Local override (expect: local override ok)
DATA_PLATFORM_STORAGE_BACKEND=local PYTHONPATH=. uv run python -c "from data_platform.utils.storage import DATA_ROOT; from data_platform.utils.object_store import resolve_object_store; assert type(resolve_object_store(local_root=DATA_ROOT)).__name__ == 'LocalObjectStore'; print('local override ok')"

# Inventory (expect: OK: 53/53 objects present with matching sha256)
PYTHONPATH=. uv run python data_platform/scripts/verify_bluesky_s3_migration.py

# LFS and git tracking
git lfs ls-files | grep "data_platform/data/bluesky/bluesky_7e2c4a91" || echo "no bluesky pipeline lfs"
git ls-files data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73

# Suite (expect 631 passed in both modes)
env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN AWS_EC2_METADATA_DISABLED=true uv run pytest -q
uv run pytest -q
```

A fresh clone no longer has the parquet files on disk, so `DATA_PLATFORM_STORAGE_BACKEND=local` only works for a checkout that already pulled the LFS blobs before this PR. Leave the variable unset to read from S3. `latest_run_dir()` still lists local run directories, which still exist on a fresh clone because each run's `metadata.json` stays tracked.

## Removed from git and Git LFS

All 25 files are under `data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/`: `preprocessed/2026_09_03-23:51:30/posts.parquet` and the 24 hourly files `raw/2026_09_01-00:00:00/date=2026-09-01/hour=00..23/<sha256>.parquet`. The full list is in the diff.

Bluesky dump LFS (`data_platform/ingestion/data_dumps/bluesky/data/parquet/**`) and Reddit LFS are unchanged. `git lfs ls-files | grep -E "data_dumps/bluesky|data/reddit" | wc -l` is 27 before and after. The `.gitattributes` diff deletes exactly one line.

## Observed

- Default backend smoke: `default s3 backend ok 200000`, exit 0.
- Local override smoke: `local override ok 200000` (also loaded the local parquet).
- Inventory: `OK: 53/53 objects present with matching sha256`.
- `git lfs ls-files | grep bluesky_7e2c4a91`: `no bluesky pipeline lfs` (25 before this PR, 0 after).
- `git ls-files` under the dataset: only `dataset.json`, `preprocessed/2026_09_03-23:51:30/metadata.json`, `raw/2026_09_01-00:00:00/metadata.json`, `s3_migration_inventory.json`. `git check-ignore -q --no-index` reports all four as not ignored. Every parquet path is ignored. `git status --short data_platform/data/bluesky/` is empty. 25 parquet files remain on disk.
- Dump and Reddit LFS count: 27 before and after.

Production safety checks:

- (a) `env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN AWS_EC2_METADATA_DISABLED=true uv run pytest -q` → `631 passed in 9.02s`, `NoCredentialsError` count 0. Before the fixture, the same command with the flipped default gave 106 failed / 460 passed, all `NoCredentialsError`.
- (b) `uv run pytest -q` with credentials present → `631 passed in 9.02s`.
- (c) boto3 `list_objects_v2` on `mirrorview-experimental-artifacts` prefix `data_platform/data/` after (b) → `listed 28 expected 28`, `extra []`, `missing []`, identical to the listing taken before any test run. The whole `data_platform/` prefix lists exactly the 53 inventory keys with nothing extra.
- Extra pin proof: with the outer environment set to `DATA_PLATFORM_STORAGE_BACKEND=s3` and credentials stripped, `tests/data_platform/utils/test_storage.py` passes 20/20, so the fixture overrides an inherited `s3` value.
- No test outside `tests/data_platform/` references `StorageManager`, `resolve_object_store`, or `S3ObjectStore`. `DATA_PLATFORM_STORAGE_BACKEND` is read only inside `resolve_object_store` at call time. No module in `data_platform/` or `lib/` builds an S3 client at import time.

Plan document: `docs/plans/2026-09-06_s3_default_backend_drop_bluesky_lfs_efbd19/`

Fixes #183
Part of #180
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07377-f9f2-70e3-a529-c0f524b4d983?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07377-f9f2-70e3-a529-c0f524b4d983&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

