### PR TITLE
Add docs/conventions for agent prose and GitHub text review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 
 Follow the conventions defined in https://github.com/mark-torres10/ai_tools/blob/main/conventions/vocabulary.md.
 
+For prose (issues, pull requests, runbooks, and plans), also follow [docs/conventions/](docs/conventions/README.md): plain-writing and Clarity review criteria plus GitHub-specific self-contained text rules.
+
 ## Cursor Cloud specific instructions
 
 The install step verifies that `uv` is available (`uv --version`) and then provisions the Python environment with `uv sync --frozen`, so `.venv` is ready and `uv run pytest` works without extra setup

--- a/docs/conventions/README.md
+++ b/docs/conventions/README.md
@@ -1,0 +1,32 @@
+# Conventions for agents
+
+This folder holds review criteria and best practices for prose written in this repository. Agents should use these documents when they draft, rewrite, or review GitHub issues, pull request descriptions, runbooks, plans, and other reader-facing text.
+
+## External references (read first for prose)
+
+| Resource | When to use it |
+| -------- | -------------- |
+| [Plain writing skill](/.cursor/skills/plain-writing/SKILL.md) | Default style for all prose written for this project. Sentence rules, word choice, punctuation, and patterns to avoid. Run `/plain-writing` or `/plain-writing deslopify` when the user asks for that style. |
+| [Clarity](https://clarity.addy.ie) (Addy Osmani) | Second pass after plain writing. Useful, clear, honest prose for a specific reader. Install with `npx skills add addyosmani/clarity` if you use Clarity modes (`/clarity rewrite`, `/clarity review`). |
+| [Write PR description skill](/.cursor/skills/write-pr-description/SKILL.md) | Structure for pull request bodies by type (experiment, feature, bug, default). Read the matching `types/<type>/guide.md` before drafting a PR description. |
+| [Vocabulary conventions](https://github.com/mark-torres10/ai_tools/blob/main/conventions/vocabulary.md) | Naming and domain terms (referenced from `AGENTS.md`). |
+
+## Documents in this folder
+
+| Document | Purpose |
+| -------- | ------- |
+| [prose-review.md](prose-review.md) | How to review any prose: layered criteria (plain writing, Clarity, fact discipline). |
+| [github-issues-and-prs.md](github-issues-and-prs.md) | Rules specific to issue and PR text: self-contained wording, structure, parallel issue families. |
+| [review-checklist.md](review-checklist.md) | Short checklist agents can run before posting or after rewriting. |
+
+## Recommended workflow
+
+1. Draft or rewrite the text using the [plain writing skill](/.cursor/skills/plain-writing/SKILL.md).
+2. For pull requests, shape the body with the [write PR description skill](/.cursor/skills/write-pr-description/SKILL.md).
+3. Apply [prose-review.md](prose-review.md) and, for GitHub items, [github-issues-and-prs.md](github-issues-and-prs.md).
+4. Optional second pass using [Clarity](https://clarity.addy.ie) criteria (see prose-review.md). Make the least invasive edit that fixes a real problem.
+5. Run [review-checklist.md](review-checklist.md) and fix any failing item before you publish.
+
+## Where these rules came from
+
+The GitHub-specific rules were distilled from a full rewrite of [issue #180](https://github.com/METResearchGroup/mirrorView-task/issues/180) and its sub-issues and implementation PRs (September 2026). That pass scrubbed planning shorthand, applied plain writing and PR-description outlines, and ran a separate Clarity review. The failures that QA caught (dropped facts, invented sentences, vague "later step" pointers) are encoded here so future agents do not repeat them.

--- a/docs/conventions/github-issues-and-prs.md
+++ b/docs/conventions/github-issues-and-prs.md
@@ -1,0 +1,111 @@
+# GitHub issues and pull requests
+
+Rules for issue descriptions and pull request bodies in this repository. Use together with [prose-review.md](prose-review.md) and the [plain writing](/.cursor/skills/plain-writing/SKILL.md) and [write PR description](/.cursor/skills/write-pr-description/SKILL.md) skills.
+
+## Self-contained text
+
+A reader who has GitHub access but did not read `docs/plans/` or attend the planning thread must understand the issue or PR from the body alone.
+
+### Remove or replace planning shorthand
+
+Do not leave these in issue or PR bodies:
+
+| Pattern | Replace with |
+| ------- | ------------ |
+| `Q44`, `Q12`, "question 44" | The **feature row schema**: `source_record_id`, `run_id`, `batch_id`, `request_id`, `attempt_count`, `label_timestamp`, and the feature's label column. After the first full list, you may write "the feature row schema". |
+| `Phase A`, `Phase B` | What the phase is: "the ten-post smoke run", "the full 200,000-post run". |
+| `Step 1`, `Step 4 of the epic`, `Steps 8 through 14` | The owning **issue** or **pull request** number, or a plain description ("the seven prerequisite implementation issues #181 to #187"). |
+| `epic`, `per the epic`, `per the plan`, `child plan`, `step spec` | Plain meaning, or delete if it adds nothing. |
+| `the user`, `user sign-off` | `the repository owner` on first mention, then `the owner`, when the text means the person who must approve production work. |
+| `later step`, `a later PR` | The issue or PR number (#185, #186) or "out of scope for this PR". |
+| `the approved ten-post smoke flow` | `the ten-post smoke run` |
+
+Plan file paths may stay in the repository, but the body must not depend on them. Move inline `Plan step: docs/plans/...` lines to a single trailing line:
+
+```markdown
+Plan document: `docs/plans/<campaign>/steps/stepN.md`, `docs/plans/<child-plan>/`
+```
+
+Put that line after the main content and before `Fixes #n` / `Part of #n` on pull requests. Parent tracking issues that never had a plan path do not need a fabricated one.
+
+### Keep GitHub-native links
+
+These are self-contained because GitHub resolves them:
+
+- `Fixes #181`, `Part of #180`
+- `Stacked on #200, #199, and #198. Merge those first.`
+- Issue lists in tracking PRs
+- Markdown links to issues and pull requests
+
+## Issue description shape
+
+Typical structure:
+
+1. Opening paragraph: what the issue produces or runs (lead with the outcome).
+2. Constraints (artifacts only, no product code changes, and so on) when true.
+3. `Done when:` bullet list with testable conditions.
+4. Approval or sign-off paragraph when production work is gated.
+5. `Ship as one PR. Do not bundle with sibling issues.` when the workflow requires it.
+6. `Plan document:` line when a plan exists (see above).
+
+### Parallel issue families
+
+When several issues are near copies (for example one feature per issue), keep identical structure and wording except for feature-specific facts (feature name, label column, accepted values, plan path). Run `diff` between siblings before you publish. Do not add a sentence to one sibling because it "should" match others unless every original had that sentence.
+
+### Opening verbs for smoke plus production runs
+
+Avoid `Run the ten-post smoke run and full 200,000-post ...` (repeated "run"). Prefer:
+
+```markdown
+Complete the ten-post smoke run and the full 200,000-post OpenAI Batch generation for `<feature>` only.
+```
+
+## Pull request description shape
+
+Classify the PR with the [write PR description skill](/.cursor/skills/write-pr-description/SKILL.md):
+
+| Type | Sections |
+| ---- | -------- |
+| Default (chore, infra, docs, migration) | Problem, Solution, Purpose, How to run |
+| Feature | Summary, Purpose, Architecture, Interfaces, How to run, Limitations or Risks when needed |
+| Bug | Summary, Purpose, Reproduction, Root cause, Fix, How to verify |
+| Experiment | Per `types/experiments/guide.md` |
+
+Shared rules:
+
+- Describe behavior and outcomes, not a file changelog.
+- Keep every command, expected result, and observed bullet from verification. Shorten only by removing repetition, not evidence.
+- Leave Mermaid diagram blocks unchanged unless the flow actually changed.
+- Put `Stacked on ...` immediately after the title block (before `## Summary` or `## Problem`).
+- End with `Plan document:` (if any), then `Fixes #n`, then `Part of #n`.
+
+Component lists may use `` `Name`: description `` instead of em-dash separators.
+
+Replace vague openings:
+
+| Avoid | Prefer |
+| ----- | ------ |
+| This PR adds... | The pull request adds... |
+| This change writes... | The pull request writes... |
+
+## Common QA failures (from issue #180 rewrite)
+
+Encode these as hard checks:
+
+1. **Dropped approval wording.** If the original gate says prerequisite PRs are "reviewed and approved", keep both words.
+2. **Invented actor.** Do not name who posts smoke estimates unless the original does.
+3. **Dropped verification facts.** Keep model names, post counts, "nothing written to S3", and full S3 prefix URLs in verification prose, not only in an Observed code block.
+4. **Invented scope sentence.** Do not add "documentation and run artifacts only" to an issue whose original lacked it.
+5. **Wrong stack order.** `Stacked on` belongs at the top of the PR body, not at the bottom.
+6. **Parallelism drift.** Seven feature issues must differ only in feature-specific fields.
+7. **Synonym scrub that loses meaning.** Replacing "Steps 3 and 2" with "later work" without naming #182 and #183 is a failure.
+
+## Automated grep before publish
+
+Run a pattern scan on the final markdown (allow hits only inside `` `docs/plans/...` `` paths or literal S3 object paths):
+
+```bash
+rg -n 'Q[0-9]+|Phase [AB]|—|–|\bStep [0-9]|\bepic\b|per the|child plan|step spec|\bthe user\b|later step|this step' <file>
+```
+
+Zero hits outside allowed paths is the target.

--- a/docs/conventions/prose-review.md
+++ b/docs/conventions/prose-review.md
@@ -1,0 +1,77 @@
+# Prose review criteria
+
+Use this document when you review or rewrite reader-facing text in this repository. It does not replace the linked skills. It tells you which skill to apply and adds repository-specific discipline on top.
+
+## Layer 1: Plain writing (required)
+
+Read and follow [.cursor/skills/plain-writing/SKILL.md](/.cursor/skills/plain-writing/SKILL.md) in full before you edit prose for this project.
+
+High-signal rules agents miss most often:
+
+- Use simple words. Avoid AI filler ("leverage", "robust", "delve", "landscape").
+- Write complete sentences. No fragments in prose.
+- Do not use em dashes, en dashes, or middle dots. Use a period, a comma, "and", or "to".
+- Do not use a colon to join two clauses. Use a colon only to introduce a list.
+- Do not start a sentence with "This", "That", or "These" when they point at a whole prior idea. Name the thing.
+- Do not write a sentence with three or more clauses. Split it.
+- Prefer one repeated word over a synonym swap for the same concept.
+- Straight quotes only. Sentence case in headings. No bold as decoration.
+
+For long explanations aimed at a reader with no project context, the user may ask for `/plain-writing deslopify`. That format starts with the main conclusion, then background, mechanism, evidence, and risks.
+
+## Layer 2: Clarity (recommended second pass)
+
+After plain writing, apply the ideas in [Clarity](https://clarity.addy.ie) by Addy Osmani. You can install the Clarity agent skill with `npx skills add addyosmani/clarity` and use `/clarity rewrite` or `/clarity review` on a named file.
+
+Use Clarity for documentation, issues, and PR descriptions as **guide** or **reference** prose, not as essays. Skip thesis hooks, authorial position-taking, and closing summaries.
+
+Criteria that matter most here:
+
+| Criterion | What to do |
+| --------- | ---------- |
+| Know what the reader brings and what they need | State the outcome before background. Do not assume the reader sat in the planning conversation. |
+| Decide what they take away | The first paragraph should say what the item does or changes. |
+| Make every sentence pay | Remove a sentence that repeats another in different words. |
+| Be specific enough to be wrong | Keep numbers, paths, commands, and column names. Do not blur a fact into a vague phrase. |
+| Put someone in the sentence | Name the component, script, or person when an inanimate subject is doing an action. |
+| Say the relation instead of implying it | Add "because", "so", "although", or "when" where two sentences only sit next to each other. |
+| Stop where the thought stops | No recap paragraph at the end. |
+
+Clarity safeguard: do not invent facts, quotes, or experience to sound clearer. If a sentence needs a detail the source does not have, ask the author or cut the sentence.
+
+## Layer 3: Fact discipline (required for rewrites)
+
+When you rewrite existing text, treat fact discipline as strict.
+
+- Every number, command, path, dataset id, observed result, gate, and constraint in the original must appear in the rewrite with the same force.
+- Do not add claims, commands, examples, or numbers that are not in the source unless the user explicitly asks for new content.
+- Do not drop verification evidence (model names, S3 prefixes, pytest counts, smoke output) to shorten a PR body.
+- Do not "improve" a gate by weakening it (for example changing "reviewed and approved" to "reviewed" only).
+- Do not invent who performs an action (for example "the repository owner must post estimates" when the original only says estimates "are posted").
+
+If you replace planning shorthand with issue or PR numbers, use the correct GitHub link target (#181, PR #197, and so on). Wrong cross-references are fact errors.
+
+## Layer 4: Medium-specific shape
+
+| Medium | Optimize for | Keep |
+| ------ | ------------ | ---- |
+| GitHub issue | What to do, done when, gates | Done when lists, ship-one-PR lines, approval gates |
+| Pull request | Behavior change, verification | Commands, expected output, observed results, Mermaid diagrams, `Fixes` / `Part of` lines |
+| Runbook | Correct completion | Headings, warnings, exact commands |
+| Plan document | Spec for implementers | May use step numbers inside `docs/plans/`; linked issues and PRs should still read standalone |
+
+Pull request bodies: classify with the [write PR description skill](/.cursor/skills/write-pr-description/SKILL.md) and use that type's outline. Do not invent a hybrid section list.
+
+## Review output format
+
+When you review prose for another agent or the user, report findings in this shape:
+
+```text
+Passage:   shortest quote that locates the issue
+Verdict:   keep | revise | ask-author | cut
+Rule:      plain-writing #N | Clarity: <criterion> | self-contained | fact | structure
+Why:       what the passage does wrong
+Fix:       exact replacement sentence, or what to ask the author
+```
+
+Group findings by severity: fact errors first, then non-self-contained references, then style.

--- a/docs/conventions/review-checklist.md
+++ b/docs/conventions/review-checklist.md
@@ -1,0 +1,62 @@
+# Review checklist for agents
+
+Run this checklist before you publish or hand off rewritten issue text, PR descriptions, or other project prose. For detail on any row, see [prose-review.md](prose-review.md) and [github-issues-and-prs.md](github-issues-and-prs.md).
+
+## Skills loaded
+
+- [ ] Read [.cursor/skills/plain-writing/SKILL.md](/.cursor/skills/plain-writing/SKILL.md) for this edit.
+- [ ] For a PR body, read [.cursor/skills/write-pr-description/SKILL.md](/.cursor/skills/write-pr-description/SKILL.md) and the matching `types/<type>/guide.md`.
+- [ ] Optional Clarity pass: [clarity.addy.ie](https://clarity.addy.ie) criteria applied with least-invasive edits.
+
+## Plain writing
+
+- [ ] No em dashes, en dashes, or middle dots.
+- [ ] No sentence with three or more clauses.
+- [ ] No sentence-initial vague "This" / "That" / "These".
+- [ ] No curly quotes.
+- [ ] Headings use sentence case.
+- [ ] Same word used for the same concept throughout.
+
+## Self-contained (issues and PRs)
+
+- [ ] No `Q<number>` labels; feature row schema spelled out or named once.
+- [ ] No `Phase A` / `Phase B`; plain run names instead.
+- [ ] No bare plan step numbers; issue or PR numbers or plain descriptions instead.
+- [ ] No `epic`, `per the plan`, or `the user` (use repository owner when needed).
+- [ ] No `later step` without an issue or PR number.
+- [ ] Plan paths only on a trailing `Plan document:` line (if applicable).
+- [ ] Opening paragraph states the main outcome before background.
+
+## Facts (rewrites only)
+
+- [ ] Side-by-side compare with the original: every number, command, path, gate, and observed result preserved.
+- [ ] No new claims, commands, or numbers added.
+- [ ] Approval gates not weakened.
+- [ ] Cross-references (`Fixes`, `Stacked on`, out-of-scope issues) point at the correct numbers.
+
+## Pull request structure
+
+- [ ] Correct type outline (default / feature / bug / experiment).
+- [ ] `Stacked on` line at the top when present.
+- [ ] `Fixes` / `Part of` at the bottom.
+- [ ] Commands, tables, Mermaid blocks, and Observed sections intact.
+- [ ] Verification prose includes paths and constraints that appeared in the original (not only in code blocks).
+
+## Parallel issues
+
+- [ ] Sibling issues differ only in feature-specific fields (if part of a family).
+- [ ] Shared phrases match ("the ten-post smoke run", "the full 200,000-post run", "the repository owner").
+
+## Markdown hygiene
+
+- [ ] Title line is `# <title>`; body starts after a blank line (for paste into GitHub).
+- [ ] Fenced code blocks balanced.
+- [ ] No Cursor agent footer or bot comment text in the body you publish.
+
+## Grep gate
+
+```bash
+rg -n 'Q[0-9]+|Phase [AB]|—|–|\bStep [0-9]|\bepic\b|per the|the user|later step' <file>
+```
+
+- [ ] No matches outside `` `docs/plans/` `` or S3 path literals.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Agents rewriting GitHub issues and pull requests had no single in-repo reference for prose style, fact discipline, or self-contained wording. Rules lived in the plain-writing skill, the write-pr-description skill, and external Clarity guidance, but the failures from the issue #180 description pass (planning shorthand, dropped verification facts, parallel issue drift) were not written down for the next agent.

## Solution

Adds `docs/conventions/` with four documents: an index (`README.md`), layered prose review criteria (`prose-review.md`), GitHub-specific rules (`github-issues-and-prs.md`), and a pre-publish checklist (`review-checklist.md`). `AGENTS.md` links to the folder under Conventions.

## Purpose

Future agents can review or rewrite issues, PRs, and other prose against one checklist that references the plain-writing skill and [Clarity](https://clarity.addy.ie), then applies repository rules distilled from the #180 rewrite (Q44 scrub, step-to-issue mapping, PR structure, fact discipline). No application code changes.

## How to run

Read `docs/conventions/README.md` and follow the recommended workflow. For a GitHub body rewrite, run the grep gate in `docs/conventions/review-checklist.md` on the final markdown before publish.

Expected: agents find the folder from `AGENTS.md` and use `review-checklist.md` as the last gate before posting text.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a074bb-69b1-768f-a6f1-534c61dba320?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a074bb-69b1-768f-a6f1-534c61dba320&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

