### PR TITLE
Copy pinned Reddit preprocessed comments parquet to S3 with hash inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. Operators now have a Twitter table of 6,374 labeled posts with 21 columns, plus a MirrorView curated export that records political stance by toxicity tier. [PR #249](https://github.com/METResearchGroup/mirrorView-task/pull/249)
 2. Operators now have seven OpenAI Batch labels for all 6,374 pinned Twitter posts, with four batch objects and a run report per feature. [PR #240](https://github.com/METResearchGroup/mirrorView-task/pull/240)
 3. The pinned Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_06_192847_llm_features_v1`, run a ten-post disposable smoke, scale cost math to 6,374 rows, and print watcher status without writing to GitHub. [PR #238](https://github.com/METResearchGroup/mirrorView-task/pull/238)
+4. The pinned Reddit preprocessed comments parquet (400,000 comments, run `2026_09_03-23:39:28`) now exists in the `mirrorview-experimental-artifacts` S3 bucket at the repo-relative key, and a committed inventory records the SHA-256 of the single object. Git LFS still holds the local copy. [PR #230](https://github.com/METResearchGroup/mirrorView-task/pull/230)
 
 ## 2026-09-06
 

--- a/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/s3_preprocessed_inventory.json
+++ b/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/s3_preprocessed_inventory.json
@@ -1,0 +1,16 @@
+{
+  "bucket": "mirrorview-experimental-artifacts",
+  "region": "us-east-2",
+  "dataset_id": "reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079",
+  "preprocessed_run": "2026_09_03-23:39:28",
+  "uploaded_at": "2026_09_07-02:18:17",
+  "object_count": 1,
+  "objects": [
+    {
+      "repo_relative_path": "data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet",
+      "s3_key": "data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet",
+      "bytes": 129853683,
+      "sha256": "c81ff327c2bc5a612b0f38b9d799e618f9d03ea3d3c4aff2d0f2a5f52a06ea31"
+    }
+  ]
+}

--- a/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
@@ -154,6 +154,7 @@ def main() -> None:
     run_git_lfs_pull(LFS_INCLUDE_PATTERN)
     s3 = S3(BUCKET, region_name=REGION)
     row = upload_and_verify(s3, path, read_scoped_bytes(path))
+    print(f"verified s3://{BUCKET}/{row['s3_key']} ({row['bytes']} bytes)")
     write_inventory([row], INVENTORY_PATH)
     print(f"uploaded {EXPECTED_OBJECT_COUNT} object to s3://{BUCKET}/")
 

--- a/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
@@ -68,7 +68,10 @@ def read_scoped_bytes(repo_relative_path: str) -> bytes:
     ValueError
         If the file still starts with the Git LFS pointer header.
     """
-    raise NotImplementedError
+    data = (REPO_ROOT / repo_relative_path).read_bytes()
+    if data.startswith(LFS_POINTER_PREFIX):
+        raise ValueError(f"Git LFS pointer was not resolved to bytes: {repo_relative_path}")
+    return data
 
 
 def sha256_hex(data: bytes) -> str:

--- a/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
@@ -10,11 +10,13 @@ Run from the repo root:
 from __future__ import annotations
 
 import hashlib
+import json
 import subprocess
 from pathlib import Path
 
 from lib.aws.s3 import S3
 from lib.constants import REPO_ROOT
+from lib.timestamp_utils import get_current_timestamp
 
 BUCKET = "mirrorview-experimental-artifacts"
 REGION = "us-east-2"
@@ -133,7 +135,18 @@ def write_inventory(rows: list[dict], path: Path) -> None:
     RuntimeError
         If ``rows`` is not exactly ``EXPECTED_OBJECT_COUNT`` long.
     """
-    raise NotImplementedError
+    if len(rows) != EXPECTED_OBJECT_COUNT:
+        raise RuntimeError(f"expected {EXPECTED_OBJECT_COUNT} inventory rows, got {len(rows)}")
+    inventory = {
+        "bucket": BUCKET,
+        "region": REGION,
+        "dataset_id": DATASET_ID,
+        "preprocessed_run": PREPROCESSED_RUN,
+        "uploaded_at": get_current_timestamp(),
+        "object_count": EXPECTED_OBJECT_COUNT,
+        "objects": rows,
+    }
+    path.write_text(json.dumps(inventory, indent=2) + "\n")
 
 
 def main() -> None:

--- a/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
@@ -9,6 +9,7 @@ Run from the repo root:
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 from lib.aws.s3 import S3
@@ -52,7 +53,11 @@ def run_git_lfs_pull(pattern: str) -> None:
     subprocess.CalledProcessError
         If ``git lfs pull`` exits non-zero.
     """
-    raise NotImplementedError
+    subprocess.run(
+        ["git", "lfs", "pull", "--include", pattern],
+        cwd=REPO_ROOT,
+        check=True,
+    )
 
 
 def read_scoped_bytes(repo_relative_path: str) -> bytes:

--- a/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
@@ -1,0 +1,51 @@
+"""Copy the pinned Reddit preprocessed comments parquet from Git LFS to S3.
+
+Run from the repo root:
+
+    export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+    export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+    PYTHONPATH=. uv run python data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lib.aws.s3 import S3
+
+
+def scoped_repo_relative_path() -> str:
+    raise NotImplementedError
+
+
+def run_git_lfs_pull(pattern: str) -> None:
+    raise NotImplementedError
+
+
+def read_scoped_bytes(repo_relative_path: str) -> bytes:
+    raise NotImplementedError
+
+
+def sha256_hex(data: bytes) -> str:
+    raise NotImplementedError
+
+
+def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:
+    raise NotImplementedError
+
+
+def write_inventory(rows: list[dict], path: Path) -> None:
+    raise NotImplementedError
+
+
+def main() -> None:
+    path = scoped_repo_relative_path()
+    run_git_lfs_pull(path)
+    s3 = S3("unused")
+    row = upload_and_verify(s3, path, read_scoped_bytes(path))
+    write_inventory([row], Path("unused"))
+    print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
@@ -38,7 +38,10 @@ def scoped_repo_relative_path() -> str:
     RuntimeError
         If the path is missing on disk.
     """
-    raise NotImplementedError
+    path = COMMENTS_PARQUET_RELATIVE_PATH
+    if not (REPO_ROOT / path).is_file():
+        raise RuntimeError(f"scoped path missing on disk: {path}")
+    return path
 
 
 def run_git_lfs_pull(pattern: str) -> None:

--- a/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
@@ -80,6 +80,23 @@ def sha256_hex(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def _require_matching_remote(key: str, data: bytes, remote: bytes) -> None:
+    """Raise if re-downloaded bytes differ in length or SHA-256.
+
+    Raises
+    ------
+    RuntimeError
+        If length or SHA-256 does not match the local bytes.
+    """
+    local_sha256 = sha256_hex(data)
+    remote_sha256 = sha256_hex(remote)
+    if len(remote) != len(data) or remote_sha256 != local_sha256:
+        raise RuntimeError(
+            f"remote object differs for {key}: "
+            f"{len(remote)} bytes {remote_sha256} != {len(data)} bytes {local_sha256}"
+        )
+
+
 def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:
     """Upload bytes to the key equal to the path and confirm the remote SHA-256.
 
@@ -97,7 +114,15 @@ def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:
     RuntimeError
         If the re-downloaded object differs in length or SHA-256.
     """
-    raise NotImplementedError
+    key = repo_relative_path
+    s3.upload_bytes(key, data, content_type=PARQUET_CONTENT_TYPE)
+    _require_matching_remote(key, data, s3.get_bytes(key))
+    return {
+        "repo_relative_path": repo_relative_path,
+        "s3_key": key,
+        "bytes": len(data),
+        "sha256": sha256_hex(data),
+    }
 
 
 def write_inventory(rows: list[dict], path: Path) -> None:

--- a/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
@@ -12,39 +12,100 @@ from __future__ import annotations
 from pathlib import Path
 
 from lib.aws.s3 import S3
+from lib.constants import REPO_ROOT
+
+BUCKET = "mirrorview-experimental-artifacts"
+REGION = "us-east-2"
+DATASET_ID = "reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079"
+PREPROCESSED_RUN = "2026_09_03-23:39:28"
+EXPECTED_OBJECT_COUNT = 1
+LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1"
+PARQUET_CONTENT_TYPE = "application/octet-stream"
+
+DATASET_ROOT = f"data_platform/data/reddit/{DATASET_ID}"
+COMMENTS_PARQUET_RELATIVE_PATH = (
+    f"{DATASET_ROOT}/preprocessed/{PREPROCESSED_RUN}/comments.parquet"
+)
+INVENTORY_PATH = REPO_ROOT / DATASET_ROOT / "s3_preprocessed_inventory.json"
+LFS_INCLUDE_PATTERN = COMMENTS_PARQUET_RELATIVE_PATH
 
 
 def scoped_repo_relative_path() -> str:
+    """Return the locked repo-relative comments parquet path.
+
+    Raises
+    ------
+    RuntimeError
+        If the path is missing on disk.
+    """
     raise NotImplementedError
 
 
 def run_git_lfs_pull(pattern: str) -> None:
+    """Fetch and check out the Git LFS blob for one include pattern.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If ``git lfs pull`` exits non-zero.
+    """
     raise NotImplementedError
 
 
 def read_scoped_bytes(repo_relative_path: str) -> bytes:
+    """Read a scoped file and refuse Git LFS pointer text.
+
+    Raises
+    ------
+    ValueError
+        If the file still starts with the Git LFS pointer header.
+    """
     raise NotImplementedError
 
 
 def sha256_hex(data: bytes) -> str:
+    """Return the lowercase hex SHA-256 digest of the bytes."""
     raise NotImplementedError
 
 
 def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:
+    """Upload bytes to the key equal to the path and confirm the remote SHA-256.
+
+    The object is re-downloaded after the upload. The S3 ETag is never used as
+    a content hash.
+
+    Returns
+    -------
+    dict
+        Inventory row with ``repo_relative_path``, ``s3_key``, ``bytes``, and
+        ``sha256``.
+
+    Raises
+    ------
+    RuntimeError
+        If the re-downloaded object differs in length or SHA-256.
+    """
     raise NotImplementedError
 
 
 def write_inventory(rows: list[dict], path: Path) -> None:
+    """Write the inventory JSON with ``preprocessed_run`` and object count 1.
+
+    Raises
+    ------
+    RuntimeError
+        If ``rows`` is not exactly ``EXPECTED_OBJECT_COUNT`` long.
+    """
     raise NotImplementedError
 
 
 def main() -> None:
     path = scoped_repo_relative_path()
-    run_git_lfs_pull(path)
-    s3 = S3("unused")
+    run_git_lfs_pull(LFS_INCLUDE_PATTERN)
+    s3 = S3(BUCKET, region_name=REGION)
     row = upload_and_verify(s3, path, read_scoped_bytes(path))
-    write_inventory([row], Path("unused"))
-    print(path)
+    write_inventory([row], INVENTORY_PATH)
+    print(f"uploaded {EXPECTED_OBJECT_COUNT} object to s3://{BUCKET}/")
 
 
 if __name__ == "__main__":

--- a/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
@@ -100,16 +100,9 @@ def _require_matching_remote(key: str, data: bytes, remote: bytes) -> None:
 
 
 def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:
-    """Upload bytes to the key equal to the path and confirm the remote SHA-256.
+    """Upload bytes, re-download them, and return the inventory row.
 
-    The object is re-downloaded after the upload. The S3 ETag is never used as
-    a content hash.
-
-    Returns
-    -------
-    dict
-        Inventory row with ``repo_relative_path``, ``s3_key``, ``bytes``, and
-        ``sha256``.
+    SHA-256 is computed from full bytes. The S3 ETag is never the content hash.
 
     Raises
     ------
@@ -150,6 +143,7 @@ def write_inventory(rows: list[dict], path: Path) -> None:
 
 
 def main() -> None:
+    """Pull LFS, upload the pinned comments parquet, and write the inventory."""
     path = scoped_repo_relative_path()
     run_git_lfs_pull(LFS_INCLUDE_PATTERN)
     s3 = S3(BUCKET, region_name=REGION)

--- a/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
@@ -9,6 +9,7 @@ Run from the repo root:
 
 from __future__ import annotations
 
+import hashlib
 import subprocess
 from pathlib import Path
 
@@ -76,7 +77,7 @@ def read_scoped_bytes(repo_relative_path: str) -> bytes:
 
 def sha256_hex(data: bytes) -> str:
     """Return the lowercase hex SHA-256 digest of the bytes."""
-    raise NotImplementedError
+    return hashlib.sha256(data).hexdigest()
 
 
 def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:

--- a/data_platform/scripts/verify_reddit_preprocessed_s3.py
+++ b/data_platform/scripts/verify_reddit_preprocessed_s3.py
@@ -83,6 +83,7 @@ def _fail_if_wrong_run_or_count(inventory: dict) -> None:
 
 
 def main() -> None:
+    """Read the inventory and confirm every listed object matches SHA-256."""
     inventory = json.loads(INVENTORY_PATH.read_text())
     _fail_if_wrong_bucket(inventory)
     _fail_if_wrong_run_or_count(inventory)

--- a/data_platform/scripts/verify_reddit_preprocessed_s3.py
+++ b/data_platform/scripts/verify_reddit_preprocessed_s3.py
@@ -1,0 +1,25 @@
+"""Check the Reddit preprocessed S3 inventory against the bucket.
+
+Run from the repo root:
+
+    export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+    export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+    PYTHONPATH=. uv run python data_platform/scripts/verify_reddit_preprocessed_s3.py
+"""
+
+from __future__ import annotations
+
+from lib.aws.s3 import S3
+
+
+def verify_inventory(inventory: dict, s3: S3) -> list[str]:
+    raise NotImplementedError
+
+
+def main() -> None:
+    problems = verify_inventory({}, S3("unused"))
+    print(problems)
+
+
+if __name__ == "__main__":
+    main()

--- a/data_platform/scripts/verify_reddit_preprocessed_s3.py
+++ b/data_platform/scripts/verify_reddit_preprocessed_s3.py
@@ -9,16 +9,40 @@ Run from the repo root:
 
 from __future__ import annotations
 
+from data_platform.scripts.migrate_reddit_preprocessed_to_s3 import (
+    BUCKET,
+    EXPECTED_OBJECT_COUNT,
+    INVENTORY_PATH,
+    PREPROCESSED_RUN,
+    REGION,
+    sha256_hex,
+)
 from lib.aws.s3 import S3
 
 
 def verify_inventory(inventory: dict, s3: S3) -> list[str]:
+    """Re-download every inventory object and report length or SHA-256 mismatches.
+
+    Returns
+    -------
+    list[str]
+        One message per missing or mismatched object. Empty when every object
+        matches.
+    """
     raise NotImplementedError
 
 
 def main() -> None:
-    problems = verify_inventory({}, S3("unused"))
+    inventory = {"bucket": BUCKET, "region": REGION, "objects": []}
+    if inventory["bucket"] != BUCKET or inventory["region"] != REGION:
+        raise SystemExit(1)
+    if inventory.get("preprocessed_run") not in {None, PREPROCESSED_RUN}:
+        raise SystemExit(1)
+    problems = verify_inventory(inventory, S3(BUCKET, region_name=REGION))
     print(problems)
+    print(INVENTORY_PATH)
+    print(EXPECTED_OBJECT_COUNT)
+    print(sha256_hex)
 
 
 if __name__ == "__main__":

--- a/data_platform/scripts/verify_reddit_preprocessed_s3.py
+++ b/data_platform/scripts/verify_reddit_preprocessed_s3.py
@@ -9,6 +9,10 @@ Run from the repo root:
 
 from __future__ import annotations
 
+import json
+
+from botocore.exceptions import ClientError
+
 from data_platform.scripts.migrate_reddit_preprocessed_to_s3 import (
     BUCKET,
     EXPECTED_OBJECT_COUNT,
@@ -20,6 +24,22 @@ from data_platform.scripts.migrate_reddit_preprocessed_to_s3 import (
 from lib.aws.s3 import S3
 
 
+def _check_inventory_row(row: dict, s3: S3) -> list[str]:
+    """Re-download one inventory row and report length or SHA-256 mismatches."""
+    key = row["s3_key"]
+    try:
+        remote = s3.get_bytes(key)
+    except ClientError as exc:
+        return [f"missing {key}: {exc.response['Error']['Code']}"]
+    problems: list[str] = []
+    if len(remote) != row["bytes"]:
+        problems.append(f"length mismatch {key}: {len(remote)} != {row['bytes']}")
+    remote_sha256 = sha256_hex(remote)
+    if remote_sha256 != row["sha256"]:
+        problems.append(f"sha256 mismatch {key}: {remote_sha256} != {row['sha256']}")
+    return problems
+
+
 def verify_inventory(inventory: dict, s3: S3) -> list[str]:
     """Re-download every inventory object and report length or SHA-256 mismatches.
 
@@ -29,20 +49,51 @@ def verify_inventory(inventory: dict, s3: S3) -> list[str]:
         One message per missing or mismatched object. Empty when every object
         matches.
     """
-    raise NotImplementedError
+    problems: list[str] = []
+    for row in inventory["objects"]:
+        problems.extend(_check_inventory_row(row, s3))
+    return problems
+
+
+def _fail_if_wrong_bucket(inventory: dict) -> None:
+    """Exit when the inventory bucket or region does not match the locked values."""
+    if inventory["bucket"] != BUCKET or inventory["region"] != REGION:
+        print(
+            f"FAIL: inventory targets {inventory['bucket']} in {inventory['region']}, "
+            f"expected {BUCKET} in {REGION}"
+        )
+        raise SystemExit(1)
+
+
+def _fail_if_wrong_run_or_count(inventory: dict) -> None:
+    """Exit when preprocessed_run or object_count does not match the locked values."""
+    if inventory.get("preprocessed_run") != PREPROCESSED_RUN:
+        print(
+            f"FAIL: inventory preprocessed_run is {inventory.get('preprocessed_run')!r}, "
+            f"expected {PREPROCESSED_RUN!r}"
+        )
+        raise SystemExit(1)
+    objects = inventory["objects"]
+    if inventory["object_count"] != EXPECTED_OBJECT_COUNT or len(objects) != EXPECTED_OBJECT_COUNT:
+        print(
+            f"FAIL: inventory lists {inventory['object_count']} objects with "
+            f"{len(objects)} rows, expected {EXPECTED_OBJECT_COUNT}"
+        )
+        raise SystemExit(1)
 
 
 def main() -> None:
-    inventory = {"bucket": BUCKET, "region": REGION, "objects": []}
-    if inventory["bucket"] != BUCKET or inventory["region"] != REGION:
-        raise SystemExit(1)
-    if inventory.get("preprocessed_run") not in {None, PREPROCESSED_RUN}:
-        raise SystemExit(1)
+    inventory = json.loads(INVENTORY_PATH.read_text())
+    _fail_if_wrong_bucket(inventory)
+    _fail_if_wrong_run_or_count(inventory)
+    objects = inventory["objects"]
     problems = verify_inventory(inventory, S3(BUCKET, region_name=REGION))
-    print(problems)
-    print(INVENTORY_PATH)
-    print(EXPECTED_OBJECT_COUNT)
-    print(sha256_hex)
+    if problems:
+        for problem in problems:
+            print(problem)
+        print(f"FAIL: {len(problems)} of {len(objects)} objects did not match")
+        raise SystemExit(1)
+    print(f"OK: {len(objects)}/{EXPECTED_OBJECT_COUNT} objects present with matching sha256")
 
 
 if __name__ == "__main__":

--- a/docs/plans/2026-09-07_copy_reddit_preprocessed_comments_s3_8ee59a/plan.md
+++ b/docs/plans/2026-09-07_copy_reddit_preprocessed_comments_s3_8ee59a/plan.md
@@ -1,0 +1,61 @@
+# Copy the pinned Reddit preprocessed comments parquet to S3
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, frequent commits
+- Use only the approved live smoke checks. Do not add or run automated tests.
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Campaign workers for the Reddit LLM feature work need the pinned preprocessed comments file in the `mirrorview-experimental-artifacts` bucket. The file already lives in Git LFS under dataset `reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079` and preprocessed run `2026_09_03-23:39:28`. The work uploads that one parquet file, checks SHA-256 against the local bytes, and commits an inventory JSON under the dataset directory. Git LFS keeps the local copy. The dataset manifest, raw Reddit files, dumps, Bluesky files, and pipeline storage code stay unchanged.
+
+The package is one independently mergeable pull request for child issue [220](https://github.com/METResearchGroup/mirrorView-task/issues/220). The pull request is part of parent issue [218](https://github.com/METResearchGroup/mirrorView-task/issues/218). The parent issue stays open. Sibling issues stay out of the pull request.
+
+## Happy flow
+
+An operator pulls the Git LFS blob for the pinned comments parquet, runs the Reddit migrate script, then runs the Reddit verify script. The bucket holds one object at the repo-relative key. The inventory JSON lists that object, the pinned preprocessed run, and a SHA-256 of the full bytes. Git still tracks the parquet as an LFS pointer.
+
+```mermaid
+flowchart LR
+  A[Pull Git LFS blob for pinned comments parquet] --> B[Migrate script uploads one object]
+  B --> C[Re-download and compare SHA-256]
+  C --> D[Write inventory JSON under the dataset directory]
+  D --> E[Verify script re-downloads and checks the inventory]
+  E --> F[Commit scripts and inventory. Keep the LFS pointer]
+```
+
+## Approach
+
+Copy the Bluesky LFS to S3 migrate and verify scripts, then cut them down to one Reddit object. Reuse the existing S3 helper with no edits. The S3 key is the repo-relative path with forward slashes. Hash full object bytes with SHA-256. Never treat the S3 ETag as a content hash. Abort if the local file still starts with Git LFS pointer text after the scoped pull.
+
+Do not add a shared migrate library. Do not upload a second Reddit file. Do not change how the pipeline reads storage. Temporary smoke files under `experiments/reddit_s3_preprocessed_smoke_2026_09_07/` may exist during review and must be deleted before the last commit.
+
+## Decisions
+
+- Upload scope is one file: `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet`.
+- Bucket is `mirrorview-experimental-artifacts` in `us-east-2`.
+- Inventory path is `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/s3_preprocessed_inventory.json`. The JSON includes `preprocessed_run` set to `2026_09_03-23:39:28` and `object_count` set to 1.
+- Content type for the parquet upload is `application/octet-stream`.
+- After upload, the migrate script re-downloads the object and compares SHA-256. `HeadObject` is extra smoke in the AWS CLI, not the hash.
+- Live smoke matches the Bluesky copy in issue 180. The epic has no pytest. Do not add or run files under `tests/`.
+- Changelog is updated after the pull request exists.
+
+## Steps
+
+### Step 1: Add Reddit preprocessed migrate and verify scripts
+
+Add `data_platform/scripts/migrate_reddit_preprocessed_to_s3.py` and `data_platform/scripts/verify_reddit_preprocessed_s3.py`. The migrate script pulls LFS for the scoped path, rejects pointer text, uploads one object, re-downloads for SHA-256, and writes the inventory JSON. The verify script reads the inventory and re-downloads the listed key. See [steps/step1.md](steps/step1.md).
+
+### Step 2: Run live smoke and commit the inventory
+
+Export lab AWS credentials, pull the scoped LFS blob, confirm parquet magic, run migrate, run verify, run `HeadObject`, confirm the LFS pointer remains, and confirm the inventory JSON. Commit the inventory after a successful upload. Delete any temporary smoke directory before the last product commit. See [steps/step2.md](steps/step2.md).
+
+## What "done" looks like
+
+1. The pinned comments parquet exists at `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet`.
+2. `s3_preprocessed_inventory.json` is committed under the pinned dataset directory with `object_count` 1, `preprocessed_run` `2026_09_03-23:39:28`, and a 64-character lowercase SHA-256. The S3 key starts with `data_platform/` and does not contain `data_platform/data_platform/`.
+3. Git still tracks that parquet as an LFS pointer. `dataset.json`, raw Reddit files, dumps, Bluesky files, `.gitattributes`, and `StorageManager` are unchanged.
+4. Migrate stdout ends like `uploaded 1 object to s3://mirrorview-experimental-artifacts/`. Verify stdout is `OK: 1/1 objects present with matching sha256`.
+5. No automated test files were added or run.

--- a/docs/plans/2026-09-07_copy_reddit_preprocessed_comments_s3_8ee59a/steps/step1.md
+++ b/docs/plans/2026-09-07_copy_reddit_preprocessed_comments_s3_8ee59a/steps/step1.md
@@ -1,0 +1,124 @@
+# Step 1: Add Reddit preprocessed migrate and verify scripts
+
+## Scope
+
+- **Caller:** `data_platform/scripts/migrate_reddit_preprocessed_to_s3.py` `main`, then `data_platform/scripts/verify_reddit_preprocessed_s3.py` `main`.
+- **Task:** Add the two scripts that copy one pinned Reddit comments parquet to S3 and check SHA-256. Mirror `data_platform/scripts/migrate_bluesky_lfs_to_s3.py` and `data_platform/scripts/verify_bluesky_s3_migration.py`, cut down to one object.
+- **Out of scope:** Live upload (Step 2), changelog, pipeline storage, Bluesky paths, pytest, edits to the epic plan under `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/`.
+
+## Files to inspect
+
+- `data_platform/scripts/migrate_bluesky_lfs_to_s3.py`
+- `data_platform/scripts/verify_bluesky_s3_migration.py`
+- `lib/aws/s3.py`
+- `lib/constants.py`
+- `lib/timestamp_utils.py`
+- `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/dataset.json`
+- `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/metadata.json`
+- `.gitattributes`
+
+## Files allowed to change
+
+- `data_platform/scripts/migrate_reddit_preprocessed_to_s3.py` (new)
+- `data_platform/scripts/verify_reddit_preprocessed_s3.py` (new)
+
+## Files forbidden to change
+
+- `data_platform/utils/storage.py`
+- `lib/aws/s3.py`
+- `.gitattributes`
+- `.gitignore`
+- `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/dataset.json`
+- `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/raw/**`
+- `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/**`
+- `data_platform/data/bluesky/**`
+- `data_platform/ingestion/data_dumps/**`
+- `CHANGELOG.md`
+- Any file under `tests/`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/**`
+
+## Locked identities
+
+| Field | Value |
+| ----- | ----- |
+| Dataset id | `reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079` |
+| Preprocessed run | `2026_09_03-23:39:28` |
+| Bucket | `mirrorview-experimental-artifacts` |
+| Region | `us-east-2` |
+| Upload path | `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet` |
+| Inventory path | `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/s3_preprocessed_inventory.json` |
+| Expected object count | `1` |
+| Content type | `application/octet-stream` |
+| LFS pointer prefix | `version https://git-lfs.github.com/spec/v1` |
+
+## Contracts
+
+Inventory JSON shape:
+
+```json
+{
+  "bucket": "mirrorview-experimental-artifacts",
+  "region": "us-east-2",
+  "dataset_id": "reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079",
+  "preprocessed_run": "2026_09_03-23:39:28",
+  "uploaded_at": "<UTC from lib.timestamp_utils.get_current_timestamp>",
+  "object_count": 1,
+  "objects": [
+    {
+      "repo_relative_path": "data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet",
+      "s3_key": "data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet",
+      "bytes": 0,
+      "sha256": "<lowercase hex of full bytes>"
+    }
+  ]
+}
+```
+
+`uploaded_at` uses `lib.timestamp_utils.get_current_timestamp`. `bytes` is the real byte length after a successful upload. `sha256` is lowercase hex of full local bytes. Never use the S3 ETag as a content hash.
+
+Migrate stdout ends like `uploaded 1 object to s3://mirrorview-experimental-artifacts/`.
+
+Verifier stdout is `OK: 1/1 objects present with matching sha256`.
+
+Keep functions under 20 lines. Use named constants, not magic numbers. Numpy docstrings. Module docstrings include the `uv run python ...` command.
+
+Reuse `lib.aws.s3.S3` as-is: `upload_bytes` and `get_bytes`. Do not add `HeadObject` to the migrate hash path. Re-download is the content check.
+
+## Ordered units of work
+
+1. Named constants and the single frozen repo-relative path.
+2. `run_git_lfs_pull` for the scoped include path.
+3. `read_scoped_bytes` that aborts when the file still starts with the LFS pointer prefix.
+4. `sha256_hex` of full bytes.
+5. `upload_and_verify` that uploads with content type `application/octet-stream`, re-downloads, and compares length and SHA-256.
+6. `write_inventory` that includes `preprocessed_run` and `object_count` 1.
+7. Migrate `main`.
+8. Verifier `verify_inventory` and `main` that import constants and `sha256_hex` from the migrate script.
+
+Phase 4 for the epic is live smoke in Step 2, not pytest. Do not add files under `tests/`.
+
+## Must pass (after scripts exist, before live upload)
+
+```bash
+PYTHONPATH=. uv run python -c "import data_platform.scripts.migrate_reddit_preprocessed_to_s3 as m; print(m.COMMENTS_PARQUET_RELATIVE_PATH); print(m.EXPECTED_OBJECT_COUNT)"
+```
+
+Expected: the locked repo-relative comments path on one line, then `1`.
+
+```bash
+PYTHONPATH=. uv run python -c "from data_platform.scripts.verify_reddit_preprocessed_s3 import main; print(main.__name__)"
+```
+
+Expected: `main`.
+
+## Must fail
+
+- A migrate script that uploads `dataset.json`, `raw/**`, dumps, or Bluesky paths.
+- A hash that uses S3 ETag.
+- An S3 key that contains `data_platform/data_platform/`.
+- Inventory without `preprocessed_run` or with `object_count` other than 1.
+- Functions over 20 lines.
+
+## Done when
+
+Both scripts exist with contracts and stub-to-full behavior for the single-object path. Inventory file is not required until Step 2 succeeds.

--- a/docs/plans/2026-09-07_copy_reddit_preprocessed_comments_s3_8ee59a/steps/step2.md
+++ b/docs/plans/2026-09-07_copy_reddit_preprocessed_comments_s3_8ee59a/steps/step2.md
@@ -1,0 +1,84 @@
+# Step 2: Run live smoke and commit the inventory
+
+## Scope
+
+- **Caller:** same migrate and verify `main` functions from Step 1, run from the repo root with lab AWS credentials.
+- **Task:** Pull the scoped LFS blob, upload the one comments parquet, commit `s3_preprocessed_inventory.json`, and run every live smoke command below.
+- **Out of scope:** Script design (Step 1), changelog until the pull request exists, pytest, edits to pipeline storage.
+
+## Files to inspect
+
+- `data_platform/scripts/migrate_reddit_preprocessed_to_s3.py`
+- `data_platform/scripts/verify_reddit_preprocessed_s3.py`
+- `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet`
+
+## Files allowed to change
+
+- `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/s3_preprocessed_inventory.json` (new, after successful upload)
+- Temporary files under `experiments/reddit_s3_preprocessed_smoke_2026_09_07/` during review only. Delete that directory before the last product commit.
+
+## Files forbidden to change
+
+- `data_platform/scripts/migrate_reddit_preprocessed_to_s3.py` except for a correctness bug found during smoke
+- `data_platform/scripts/verify_reddit_preprocessed_s3.py` except for a correctness bug found during smoke
+- `data_platform/utils/storage.py`
+- `lib/aws/s3.py`
+- `.gitattributes`
+- `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/dataset.json`
+- `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/raw/**`
+- `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/**`
+- `data_platform/data/bluesky/**`
+- `CHANGELOG.md` (until after the pull request exists)
+- Any file under `tests/`
+
+## Live smoke (must actually run)
+
+From the repo root. Never print secrets.
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+aws sts get-caller-identity
+git lfs pull --include "data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet"
+python3 -c "from pathlib import Path; p=Path('data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet'); head=p.read_bytes()[:4]; assert head==b'PAR1', head; print('parquet magic ok', p.stat().st_size)"
+PYTHONPATH=. uv run python data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
+PYTHONPATH=. uv run python data_platform/scripts/verify_reddit_preprocessed_s3.py
+aws s3api head-object --bucket mirrorview-experimental-artifacts --key data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet --region us-east-2
+git lfs ls-files | grep reddit_3d8a2c41 | grep comments.parquet
+PYTHONPATH=. uv run python - <<'PY'
+import json
+from pathlib import Path
+inv = json.loads(Path("data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/s3_preprocessed_inventory.json").read_text())
+assert inv["object_count"] == 1
+assert len(inv["objects"]) == 1
+assert inv["objects"][0]["s3_key"].startswith("data_platform/")
+assert "data_platform/data_platform/" not in inv["objects"][0]["s3_key"]
+assert inv["preprocessed_run"] == "2026_09_03-23:39:28"
+print("inventory ok", inv["uploaded_at"])
+PY
+```
+
+## Expected results
+
+- `aws sts get-caller-identity` exits 0 and prints JSON with an `Arn`.
+- `git lfs pull` exits 0.
+- `parquet magic ok` plus a byte size well above 200.
+- Migrate stdout ends with `uploaded 1 object to s3://mirrorview-experimental-artifacts/` and exit code 0.
+- Verify stdout is `OK: 1/1 objects present with matching sha256` and exit code 0.
+- `head-object` returns HTTP 200 metadata with non-zero `ContentLength`.
+- `git lfs ls-files` shows one line for the preprocessed comments parquet.
+- Inventory check prints `inventory ok` plus a timestamp.
+
+## Must fail
+
+- Verification that accepts ETag instead of SHA-256.
+- Upload of LFS pointer text (about 133 bytes).
+- Object count other than 1.
+- S3 key starting with `data_platform/data_platform/`.
+- Bluesky paths, Reddit raw paths, or `dataset.json` in the inventory.
+- Git LFS pointer removed or rewritten.
+- Any automated test file added or run.
+
+## Done when
+
+The inventory JSON is committed. All live smoke commands above pass. The temporary smoke directory is gone if it was created. The parquet remains an LFS pointer.


### PR DESCRIPTION
Fixes #220
Part of #218

# Copy pinned Reddit preprocessed comments parquet to S3 with hash inventory

## Summary

Adds a migrate script that uploads the pinned Reddit preprocessed comments parquet to `mirrorview-experimental-artifacts`, and a verify script that re-downloads the object and checks SHA-256 against a committed inventory.

Operators run the two scripts from the repo root. The bucket then holds one object at the repo-relative key, and Git LFS still tracks the local parquet.

## Purpose

Campaign workers for the Reddit LLM feature work need the 400,000-comment parquet on S3. The file lives only in Git LFS today.

The pull request copies that one file and records SHA-256 in `s3_preprocessed_inventory.json`. Pipeline storage, Bluesky data, Reddit raw files, and `dataset.json` stay out of scope.

## Architecture

Components:

- `migrate_reddit_preprocessed_to_s3.py` pulls the scoped LFS blob and refuses pointer text. It uploads one object and re-downloads for SHA-256. It then writes the inventory.
- `verify_reddit_preprocessed_s3.py` reads the inventory and re-downloads listed keys. It compares length and SHA-256. The S3 ETag is never the content hash.
- `lib/aws/s3.py` is the existing S3 helper, and it is unchanged.
- `s3_preprocessed_inventory.json` is committed under the pinned dataset directory.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    Op1[Operator] --> LFS[Git LFS comments parquet]
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    Op2[Operator] --> Migrate[Migrate script]
    Migrate --> LFS2[Git LFS pull of scoped parquet]
    Migrate --> S3[(mirrorview-experimental-artifacts)]
    Migrate --> Inv[s3_preprocessed_inventory.json]
    Verify[Verify script] --> Inv
    Verify --> S3
  end
```

## Interfaces

### Inventory JSON

Path: `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/s3_preprocessed_inventory.json`

| Field | Type | Notes |
| ----- | ---- | ----- |
| `bucket` | string | `mirrorview-experimental-artifacts` |
| `region` | string | `us-east-2` |
| `dataset_id` | string | `reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079` |
| `preprocessed_run` | string | `2026_09_03-23:39:28` |
| `uploaded_at` | string | UTC from `get_current_timestamp` |
| `object_count` | int | `1` |
| `objects[].repo_relative_path` | string | Same as the S3 key |
| `objects[].s3_key` | string | Starts with `data_platform/`, never `data_platform/data_platform/` |
| `objects[].bytes` | int | Full object length |
| `objects[].sha256` | string | Lowercase hex of full bytes, not ETag |

### Configuration

- Bucket: `mirrorview-experimental-artifacts`
- Region: `us-east-2`
- Upload path: `data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet`
- Content type: `application/octet-stream`

## How to run

From the repo root:

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
git lfs pull --include "data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet"
PYTHONPATH=. uv run python data_platform/scripts/migrate_reddit_preprocessed_to_s3.py
PYTHONPATH=. uv run python data_platform/scripts/verify_reddit_preprocessed_s3.py
```

Expected: migrate reports `uploaded 1 object to s3://mirrorview-experimental-artifacts/`, verifier prints `OK: 1/1 objects present with matching sha256`, and the inventory lists one object with a 64-character SHA-256.

Plan: `docs/plans/2026-09-07_copy_reddit_preprocessed_comments_s3_8ee59a/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a preprocessed Reddit dataset inventory with storage location, metadata, file size, and integrity checksum.
  - Added tooling to migrate the dataset to cloud storage and verify uploaded data.

- **Bug Fixes**
  - Added validation to detect missing, incomplete, or altered dataset files during migration and verification.

- **Chores**
  - Added automated checks for expected storage configuration, preprocessing metadata, object count, byte size, and checksum consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->