### PR TITLE
Add plan for seven OpenAI LLM features on 6,374 Twitter posts

### DIFF
--- a/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/campaign_contract.md
+++ b/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/campaign_contract.md
@@ -1,0 +1,243 @@
+# Twitter LLM features campaign contract
+
+A wrong bucket path or row count forces a full rerun, so every step file repeats only the values its pull request needs and this file holds the rest.
+
+## Pinned identities
+
+| Field | Value |
+|-------|-------|
+| Bucket | `mirrorview-experimental-artifacts` |
+| Region | `us-east-2` |
+| Platform | `twitter` |
+| Dataset id | `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` |
+| Dataset name | `mirrorview_2026-09-05` |
+| Ingest config | `data_platform/ingestion/configs/twitter/mirrorview_2026-09-05.yaml` |
+| Pinned preprocessed run | `2026_09_06-19:28:47` |
+| Preprocessed row count | `6374` posts (not comments) |
+| Preprocessed file | `posts.csv` |
+| Dataset format | `csv` (do not change `dataset.json`) |
+| Campaign id | `twitter_2026_09_06_192847_llm_features_v1` |
+| Batch size | `2000` |
+| Expected rows per feature | `6374` |
+| Batch count | `4` (`part-00000` through `part-00003`) |
+| Engine | OpenAI Batch |
+| Model id | `gpt-5.4-nano` |
+| Full run row constant | `FULL_RUN = 6374` |
+
+Preprocessed input object:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv`
+
+Copy to S3 policy: upload only `posts.csv`. Keep Git LFS for the local copy. Keep `dataset.json` in git with format `csv`. Do not upload raw `posts.csv`, `metadata.json`, or any Bluesky or Reddit path.
+
+Source pull requests: raw collection is pull request 213. Preprocess is pull request 215.
+
+## Campaign YAML
+
+Checked-in file:
+
+`data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml`
+
+Required fields:
+
+```yaml
+campaign_id: twitter_2026_09_06_192847_llm_features_v1
+platform: twitter
+dataset_id: twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547
+preprocessed_run: "2026_09_06-19:28:47"
+row_count: 6374
+batch_size: 2000
+engine_type: openai
+model_id: gpt-5.4-nano
+features:
+  - is_news_or_opinion
+  - is_political
+  - is_likely_spam
+  - is_self_contained
+  - is_structurally_complete
+  - political_stance
+  - llm_toxicity_tiered
+```
+
+Code reads this file for campaign id `twitter_2026_09_06_192847_llm_features_v1` only. Reject any other campaign id. Do not change `FEATURE_REGISTRY` defaults. Record `engine_type` on `manifest.json` and local `metadata.json`. Do not add an `engine_type` column to feature parquet output.
+
+Reuse registry prompts for all seven features.
+
+Feature order above is the serial run order. The interrupt-and-resume proof runs on `is_news_or_opinion` only.
+
+## S3 feature root and layout
+
+Feature root:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/`
+
+Per feature `{feature}` under that root:
+
+| Object | Path | Notes |
+|--------|------|-------|
+| Smoke input | `{feature}/smoke/input.parquet` | Ten-post sample input. Untagged. |
+| Smoke output | `{feature}/smoke/output.parquet` | Ten labeled rows with label metadata columns. Untagged. |
+| Smoke cost report | `{feature}/smoke/cost_report.json` | Token and pricing estimates. Untagged. |
+| Smoke resume evidence | `{feature}/smoke/resume_evidence.json` | Present for `is_news_or_opinion` only. Untagged. |
+| Active OpenAI state | `{feature}/active_openai_batch.json` | Mutable. Untagged. Conditional atomic replace. |
+| Batch parquet | `{feature}/batches/part-NNNNN.parquet` | Zero-based five-digit index. Immutable once written. Tagged `intermediate-artifact=true`. |
+| Final parquet | `{feature}/final.parquet` | One consolidated file per feature. Untagged. |
+| Manifest | `{feature}/manifest.json` | SHA-256 digests. Records `engine_type=openai`. Untagged. Conditional atomic replace. |
+| Progress | `{feature}/progress.jsonl` | Logical append via read, append, conditional replace. Untagged. One line per finished part. |
+| Errors | `{feature}/errors.jsonl` | Same append semantics when needed. Untagged. |
+| Watcher state | `{feature}/watcher.json` | Rolling comment id and last posted 10k milestone. Untagged. Conditional atomic replace. |
+
+Wide outputs under the same feature root:
+
+| Object | Path |
+|--------|-------|
+| Wide parquet | `wide/features.parquet` |
+| Wide manifest | `wide/manifest.json` |
+
+Forbidden layout elements:
+
+- No `campaigns/` prefix.
+- No `shards/` directory or `shard_*` object names.
+- No `final/` subdirectory.
+- No parquet copy of the dated preprocessed `posts.csv`.
+- No GitHub posting from repository code.
+
+## Smoke sample
+
+Shared by all seven features:
+
+1. Load pinned preprocessed run `2026_09_06-19:28:47`.
+2. Keep rows with non-empty `text`.
+3. Sort by ascending `source_record_id`.
+4. Take the first ten rows.
+
+Smoke never writes `batches/part-00000.parquet` or any other production batch object.
+
+Temporary Git copies of smoke evidence live under `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/{feature}/` during Step 2 Phase A and are deleted before merge. S3 smoke evidence under `{feature}/smoke/` remains.
+
+## Production batch schedule (after parent approval)
+
+| Part | Row composition |
+|------|-----------------|
+| `part-00000` | Ten unchanged smoke output rows (original smoke `batch_id` and `request_id` preserved) plus 1,990 new labeled rows |
+| `part-00001` | 2,000 new labeled rows |
+| `part-00002` | 2,000 new labeled rows |
+| `part-00003` | 374 new labeled rows |
+
+Total: 6,374 unique `source_record_id` values per feature. OpenAI Batch jobs: one smoke job of 10 rows per feature, then production jobs covering the remaining 6,364 rows (1,990 + 2,000 + 2,000 + 374). The existing campaign writer already folds `smoke/output.parquet` into `part-00000` through `_smoke_rows_by_id` in `generate_campaign_feature`.
+
+## Label row schema
+
+Every row in `smoke/output.parquet`, `batches/part-*.parquet`, and `final.parquet`:
+
+| Column | Meaning |
+|--------|---------|
+| `source_record_id` | Preprocessed tweet id |
+| `run_id` | `{campaign_id}:{feature}` |
+| `batch_id` | Provider batch id |
+| `request_id` | Provider request id |
+| `attempt_count` | 1–4 |
+| `label_timestamp` | UTC from `get_current_timestamp` |
+| `{label_field}` | Feature-specific column below |
+
+| Feature | Raw label column | Accepted values |
+|---------|------------------|-----------------|
+| `is_news_or_opinion` | `category` | `news`, `opinion`, `neither` |
+| `is_political` | `is_political` | boolean |
+| `is_likely_spam` | `is_likely_spam` | boolean |
+| `is_self_contained` | `is_self_contained` | boolean |
+| `is_structurally_complete` | `is_structurally_complete` | boolean |
+| `political_stance` | `political_stance` | `left`, `right`, `neutral`, `unclear` |
+| `llm_toxicity_tiered` | `toxicity_tier` | `low`, `medium`, `high` |
+
+## Wide table
+
+Wide output: exactly 21 columns in this order.
+
+Fourteen preprocessed columns:
+
+`tweet_id`, `record_id`, `url`, `username`, `author_handle`, `text`, `created_at`, `like_count`, `retweet_count`, `reply_count`, `quote_count`, `keyword`, `sync_timestamp`, `source_record_id`
+
+`username` is the public handle. `author_handle` on this corpus is a copy of `author_id` from Twitter preprocess.
+
+Seven aliased label columns:
+
+| Wide column | Source feature | Source column |
+|-------------|----------------|---------------|
+| `news_or_opinion_category` | `is_news_or_opinion` | `category` |
+| `is_political` | `is_political` | `is_political` |
+| `is_likely_spam` | `is_likely_spam` | `is_likely_spam` |
+| `is_self_contained` | `is_self_contained` | `is_self_contained` |
+| `is_structurally_complete` | `is_structurally_complete` | `is_structurally_complete` |
+| `political_stance` | `political_stance` | `political_stance` |
+| `llm_toxicity_tier` | `llm_toxicity_tiered` | `toxicity_tier` |
+
+Join on `CAST(source_record_id AS VARCHAR)`. Sort by `source_record_id` ascending. Left table is pinned `posts.csv`. Do not require a parquet copy of that file.
+
+Forbidden wide columns: `toxicity_tier`, `toxicity_prob`, `label_timestamp`, `run_id`, any Perspective column, `author_id` as an extra duplicate of `author_handle`.
+
+## Curation
+
+Rules file: `data_platform/curate/configs/twitter/mirrorview.yaml`. Do not change filter semantics.
+
+| Filter | Value |
+|--------|-------|
+| `news_or_opinion_category` | `opinion` |
+| `is_political` | `true` |
+| `is_likely_spam` | `false` |
+| `political_stance` | `left` or `right` |
+| `is_self_contained` | `true` |
+| `is_structurally_complete` | `true` |
+
+Write the filtered frame with `TwitterStorageManager("curated", dataset_id)`. Export stem comes from the YAML (`mirrorview.parquet`).
+
+## Pricing (smoke cost math)
+
+| Engine | Input USD per 1M tokens | Output USD per 1M tokens |
+|--------|-------------------------|--------------------------|
+| OpenAI Batch | `0.10` | `0.625` |
+
+Scale ten-post averages to `full_run_row_count=6374`. Do not use the Bluesky `FULL_RUN_POST_COUNT = 200000` default for this campaign.
+
+## Watcher
+
+CLI never posts to GitHub. `--once` is the only mode. Add `--platform` and `--dataset-id`. When omitted, keep today's Bluesky defaults so existing Bluesky commands still work. At 6,374 rows the 10,000-row milestone never fires. Still write `progress.jsonl` after each part.
+
+## GitHub stack and issue dependencies
+
+Three children, one GitHub stack, parent tracking only.
+
+| Child | Depends on | GitHub `blocked-by` | Notes |
+|-------|------------|---------------------|-------|
+| Step 1 | none | none | Product code. Mergeable without labeling 6,374 rows. |
+| Step 2 | Step 1 | Step 1 | Docs and run artifacts only. Phase A then parent sign-off then Phase B on the same stack pull request. |
+| Step 3 | Step 2 | Step 2 | Wide join and curation. |
+
+Parent-issue owner sign-off is not a GitHub `blocked-by`. Merged Step 1 is not permission to label 6,374 rows.
+
+## Parent issue body
+
+The campaign labels 6,374 pinned Twitter posts from pull request 215 with seven OpenAI Batch LLM features (`gpt-5.4-nano`). Operators upload preprocessed `posts.csv` to `mirrorview-experimental-artifacts` while Git LFS keeps the local copy. The campaign reuses the Bluesky S3 backend, OpenAI Batch resume, 2,000-row parquet writer, progress watcher, and 30-day lifecycle rule for tagged batch objects.
+
+Each feature writes four immutable 2,000-row parquet batch objects (last part 374 rows), a final feature parquet file, a hash manifest, progress records, and a permanent run report. Step 3 joins the seven outputs with fourteen preprocessed post columns and runs the MirrorView curation export.
+
+Dataset id is `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` and preprocessed run is `2026_09_06-19:28:47`. Campaign artifacts live under `s3://mirrorview-experimental-artifacts/data_platform/data/` with campaign id `twitter_2026_09_06_192847_llm_features_v1`. OpenAI features persist provider job IDs in `active_openai_batch.json` before polling and resume the existing provider job after interruption.
+
+Each child issue maps to one future pull request on a GitHub stack. The repository owner records production approval on the parent issue only. Do not start any 6,374-post feature run until Step 1 has merged, all seven smoke runs and per-feature cost estimates are posted, the aggregate estimate is posted here, and the repository owner signs off in a comment on the prerequisite pull request, smoke results, and aggregate cost.
+
+Plan: `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/plan.md`
+
+Done when:
+
+1. The pinned preprocessed `posts.csv` is available from S3 with a verified hash, and Git LFS still holds the local copy.
+2. Seven feature runs each produce exactly 6,374 unique, valid LLM labels across four batch objects and one permanent run report.
+3. OpenAI features resume without duplicate provider jobs or duplicate charges.
+4. Each feature writes progress per part and records estimated and actual cost.
+5. One wide parquet artifact contains the fourteen pinned post columns and all seven LLM feature outputs, and the MirrorView curation export is written from `data_platform/curate/configs/twitter/mirrorview.yaml`.
+6. Intermediate batches expire after 30 days under the existing lifecycle rule, while final artifacts and run metadata remain in S3.
+
+## Children
+
+- [ ] Step 1: Add Twitter campaign config, copy posts.csv to S3, and wire smoke tooling
+- [ ] Step 2: Smoke and generate seven LLM features for 6,374 Twitter posts
+- [ ] Step 3: Consolidate seven Twitter LLM features and write the MirrorView curated export

--- a/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/plan.md
+++ b/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/plan.md
@@ -1,0 +1,77 @@
+# Generate seven S3-backed LLM features for 6,374 Twitter posts
+
+Do not start any 6,374-row feature run until the repository owner signs off on the smoke cost in the parent GitHub issue. The dated Twitter collection is small next to Bluesky and Reddit, and it still needs the same human gate.
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY and YAGNI
+- Use only the approved smoke checks. Do not add or run automated tests.
+- Frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+The campaign labels the 6,374 preprocessed Twitter posts from pull request 215 with the same seven LLM features as Bluesky and Reddit. All seven features run on OpenAI Batch with `gpt-5.4-nano`. Operators upload only the pinned preprocessed `posts.csv` to `mirrorview-experimental-artifacts`. Git LFS keeps the local copy. `dataset.json` stays `format: csv`. Campaign outputs are parquet. Each feature writes four immutable batch objects, `final.parquet`, a SHA-256 manifest, progress records, and a permanent run report. Step 3 joins all seven outputs to fourteen preprocessed post columns and runs the existing MirrorView curation export.
+
+## Happy flow
+
+The operator merges Step 1 as the bottom of a GitHub stack. Step 2, stacked on Step 1, runs the seven ten-post smokes, posts costs on the parent issue, and stops. After an explicit owner comment on the parent, Step 2 continues on the same stack pull request and labels all 6,374 posts, one feature at a time. Step 3 stacks on Step 2, writes the 21-column wide table, and runs `twitter/mirrorview.yaml`.
+
+```mermaid
+flowchart TD
+    A[Step1 Config S3 copy wiring smoke tooling]
+    B[Step2 Phase A seven ten-post smokes]
+    C[Parent issue owner sign off]
+    D[Step2 Phase B seven serial production runs]
+    E[Step3 Wide join and MirrorView export]
+    A --> B --> C --> D --> E
+```
+
+## Approach
+
+Pin dataset `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` and preprocessed run `2026_09_06-19:28:47`. Record the input hash so a different dataset forces a new campaign id.
+
+Campaign artifacts live under `s3://mirrorview-experimental-artifacts/data_platform/data/` with campaign id `twitter_2026_09_06_192847_llm_features_v1` and one isolated prefix per feature. Reuse the Bluesky OpenAI Batch resume path, 2,000-row parquet writer, smoke fold into `part-00000`, and 30-day lifecycle rule for tagged batch objects. Do not convert the dated Twitter dataset to parquet. Do not drop Git LFS. Do not change global `FEATURE_REGISTRY` defaults.
+
+A Twitter campaign YAML names the campaign id, dataset, run, row count 6374, feature list, model, engine, and batch size. Code reads that file for this campaign id only.
+
+Smoke writes untagged evidence under `{feature}/smoke/` and never writes production `batches/part-*.parquet`. After parent approval, `part-00000` folds ten unchanged smoke rows with 1,990 new labels. `part-00001` and `part-00002` each add 2,000 new labels. `part-00003` adds 374 new labels.
+
+The repository owner records approval on the parent GitHub issue only. There is no `APPROVED.txt`. The three children ship as one GitHub stack. Watcher CLI prints prepared markdown and never posts to GitHub.
+
+See `campaign_contract.md` for identities, S3 layout, YAML shape, schemas, and the dependency graph.
+
+## Decisions
+
+- Pinned identities, S3 layout, YAML shape, schemas, and the dependency graph live in `campaign_contract.md`.
+- All seven LLM features use OpenAI Batch `gpt-5.4-nano`. Perspective `is_toxic_tiered` is out of scope.
+- Keep `posts.csv` as the Git LFS source of truth. Copy only that one object to S3.
+- One GitHub issue runs all seven feature smokes and, after sign-off, all seven production runs.
+- Sign-off is a parent-issue comment, not a GitHub `blocked-by` and not a fourth child.
+- Steps 2 and 3 use live smoke and runtime checks only. Do not add automated tests. Step 1 also uses smoke and runtime checks only.
+- The existing 30-day lifecycle rule already expires objects tagged `intermediate-artifact=true` under `data_platform/data/`. Do not open a new lifecycle issue.
+- Do not wait on the Reddit mixed-engine epic. This campaign is OpenAI only.
+
+## Steps
+
+### Step 1: Add Twitter campaign config, copy posts.csv to S3, and wire smoke tooling
+
+Upload pinned `posts.csv`, add the Twitter campaign YAML, wire `generate_twitter_features.py` campaign flags, add `smoke_twitter_campaign.py`, scale cost aggregation to 6,374 rows, and add watcher `--platform` and `--dataset-id`. No dependencies.
+
+### Step 2: Smoke and generate seven LLM features for 6,374 Twitter posts
+
+Run the ten-post smoke for all seven features in YAML order, interrupt and resume only `is_news_or_opinion`, post per-feature and aggregate cost on the parent issue, wait for owner sign-off, then run all seven production jobs serially. Depends on Step 1. Docs and run artifacts only.
+
+### Step 3: Consolidate seven Twitter LLM features and write the MirrorView curated export
+
+Join the seven verified feature outputs to fourteen preprocessed post columns on `source_record_id` through `consolidate_twitter_llm_campaign.py`. Require exactly 6,374 unique records with no missing feature values, publish the wide artifact, then run `data_platform/curate/configs/twitter/mirrorview.yaml`. Depends on Step 2.
+
+## What "done" looks like
+
+1. The pinned preprocessed `posts.csv` is available from S3 with a verified hash, and Git LFS still holds the local copy.
+2. Seven features each produce exactly 6,374 unique, valid LLM labels across four batch objects and one permanent run report.
+3. OpenAI features resume without duplicate provider jobs or duplicate charges. The ten smoke rows keep their original `batch_id` and `request_id` inside `part-00000`.
+4. Each feature writes `progress.jsonl` per part. Cost estimates and actuals are recorded.
+5. One wide parquet artifact contains the fourteen pinned post columns and all seven LLM feature outputs, and the MirrorView curation export is written from `twitter/mirrorview.yaml`.
+6. Intermediate batches expire after 30 days under the existing lifecycle rule, while final artifacts and run metadata remain in S3.

--- a/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step1.md
+++ b/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step1.md
@@ -1,0 +1,298 @@
+# Step 1: Add Twitter campaign config, copy posts.csv to S3, and wire smoke tooling
+
+## Goal
+
+Campaign workers need the pinned Twitter csv on S3, a campaign YAML, Twitter campaign CLI, a ten-post smoke caller, cost math scaled to 6,374 rows, and watcher flags that resolve Twitter `FeaturePaths`. This pull request ships that product code. It does not label all 6,374 posts.
+
+## Dependencies
+
+None. Later steps use these identities:
+
+| Field | Value |
+|-------|-------|
+| Platform | `twitter` |
+| Dataset id | `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` |
+| Pinned preprocessed run | `2026_09_06-19:28:47` |
+| Preprocessed row count | `6374` |
+| Campaign id | `twitter_2026_09_06_192847_llm_features_v1` |
+| Batch size | `2000` |
+
+Requires Git LFS, AWS credentials with `s3:PutObject`, `s3:GetObject`, and `s3:HeadObject` on `mirrorview-experimental-artifacts`, and `LAB_AWS_ACCESS_KEY_ID` / `LAB_AWS_ACCESS_KEY_SECRET` exported as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.
+
+## Main caller and implementation scope
+
+**Upload caller:** `data_platform/scripts/migrate_twitter_preprocessed_to_s3.py` `main`.
+
+**Verifier:** `data_platform/scripts/verify_twitter_preprocessed_s3.py` `main`.
+
+**Campaign caller after this PR merges:**
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/generate_twitter_features.py \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --features is_news_or_opinion \
+  --batch-size 2000
+```
+
+**Smoke caller after this PR merges:**
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_twitter_campaign.py \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --feature is_news_or_opinion \
+  --smoke-prefix s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/twitter_step1_campaign_smoke/ \
+  --output-dir docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/_step1_disposable
+```
+
+**One implementation scope:** upload the one pinned `posts.csv`, write inventory JSON, add the campaign YAML and a loader that accepts only this campaign id, wire `generate_twitter_features.py` campaign flags and Python API like `generate_bluesky_features.py`, add `smoke_twitter_campaign.py` sharing helpers with `smoke_bluesky_campaign.py`, extend the ten-row sample loader to accept `TWITTER_SPEC`, extend `campaign_cost_report.py` with `--full-run-row-count` so Twitter can pass `6374` without changing the Bluesky default of `200000`, and add watcher `--platform` and `--dataset-id` that call `FeaturePaths.for_campaign`. Replace `FeaturePaths.canonical` calls in the watcher with `FeaturePaths.for_campaign`. Default omitted watcher flags to today's Bluesky platform and dataset id.
+
+**Out of scope:** labeling all 6,374 rows, posting to GitHub from repository code, wide join, curation, lifecycle rules, converting csv to parquet, dropping Git LFS, changing `FEATURE_REGISTRY`, and the official seven-feature smoke on the primary campaign prefix (Step 2).
+
+Optional live proof uses only the disposable S3 prefix above. Delete that prefix before merge. Do not write primary `batches/part-*.parquet` objects.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/dataset.json` | Format `csv` must stay |
+| `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/metadata.json` | Row count 6374 |
+| `/workspace/.gitattributes` | Twitter csv LFS rule |
+| `/workspace/data_platform/scripts/migrate_bluesky_lfs_to_s3.py` | Upload and hash pattern |
+| `/workspace/data_platform/generate_features/generate_bluesky_features.py` | Campaign Python API to copy |
+| `/workspace/data_platform/generate_features/generate_twitter_features.py` | Missing `campaign_id` today |
+| `/workspace/data_platform/generate_features/platform_cli.py` | Shared campaign CLI already passes `spec.platform` |
+| `/workspace/data_platform/generate_features/smoke_bluesky_campaign.py` | Smoke, interrupt resume, S3 checks |
+| `/workspace/data_platform/generate_features/deterministic_smoke_sample.py` | Hard-coded Bluesky spec today |
+| `/workspace/data_platform/generate_features/campaign_cost_report.py` | `FULL_RUN_POST_COUNT = 200000` |
+| `/workspace/data_platform/generate_features/feature_progress_watcher.py` | Calls missing `FeaturePaths.canonical` |
+| `/workspace/data_platform/generate_features/s3_feature_campaign.py` | `FeaturePaths.for_campaign` |
+| `/workspace/data_platform/generate_features/generate_features.py` | `_smoke_rows_by_id` fold into `part-00000` |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.` and AWS export |
+
+## Files allowed to change
+
+- `/workspace/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py` (new)
+- `/workspace/data_platform/scripts/verify_twitter_preprocessed_s3.py` (new)
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/s3_preprocessed_inventory.json` (new)
+- `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml` (new)
+- `/workspace/data_platform/generate_features/twitter_campaign_config.py` (new loader)
+- `/workspace/data_platform/generate_features/generate_twitter_features.py`
+- `/workspace/data_platform/generate_features/smoke_twitter_campaign.py` (new)
+- `/workspace/data_platform/generate_features/deterministic_smoke_sample.py`
+- `/workspace/data_platform/generate_features/campaign_cost_report.py`
+- `/workspace/data_platform/generate_features/feature_progress_watcher.py`
+- `/workspace/CHANGELOG.md`
+
+Temporary disposable smoke evidence under `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/_step1_disposable/` may be committed during review and must be deleted before merge.
+
+Do not edit files under `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/` during implementation except this step file when correcting the spec.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/utils/storage.py`
+- `/workspace/.gitattributes`
+- `/workspace/.gitignore`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/dataset.json`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/raw/**`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/**`
+- `/workspace/data_platform/data/bluesky/**`
+- `/workspace/data_platform/data/reddit/**`
+- `/workspace/data_platform/generate_features/registry.py`
+- `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml`
+- Any test file under `/workspace/tests/`
+- Any file outside the allowed list
+
+## Locked contracts
+
+| Item | Value |
+|------|-------|
+| S3 bucket | `mirrorview-experimental-artifacts` |
+| AWS region | `us-east-2` |
+| Upload scope | `data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv` only |
+| Expected object count | `1` |
+| Hash | SHA-256 lowercase hex of full object bytes. Never use S3 ETag as a content hash. |
+| LFS retention | Do not remove or rewrite the csv pointer in git |
+| Inventory path | `data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/s3_preprocessed_inventory.json` |
+| Pointer rejection | If the scoped file begins with `version https://git-lfs.github.com/spec/v1`, abort after `git lfs pull` |
+| YAML campaign id | `twitter_2026_09_06_192847_llm_features_v1` only |
+| Loader failure | Any other campaign id raises `ValueError` naming the bad id |
+
+Inventory JSON shape:
+
+`{"bucket":"mirrorview-experimental-artifacts","region":"us-east-2","dataset_id":"twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547","preprocessed_run":"2026_09_06-19:28:47","uploaded_at":"<UTC from lib.timestamp_utils.get_current_timestamp>","object_count":1,"objects":[{"repo_relative_path":"...","s3_key":"...","bytes":N,"sha256":"..."}]}`
+
+Primary S3 object after upload:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv`
+
+## Ordered implementation work
+
+1. Add migrate and verify scripts for the single frozen csv path. Pull LFS, reject pointer text, upload, hash, write inventory.
+2. Add the campaign YAML and loader.
+3. Add `campaign_id` and `preprocessed_run` to `generate_twitter_features()`.
+4. Parameterize `load_deterministic_ten_posts` with a platform spec. Twitter smoke passes `TWITTER_SPEC`.
+5. Add `smoke_twitter_campaign.py` with interrupt-and-resume support, S3 smoke objects, and `--smoke-prefix`.
+6. Add `--full-run-row-count` to `campaign_cost_report.py` aggregate mode. Default remains `200000`.
+7. Add watcher `--platform` and `--dataset-id`. Call `FeaturePaths.for_campaign`. Keep Bluesky defaults when flags are omitted.
+8. Run live smoke commands below. Delete the disposable prefix and `_step1_disposable` Git copies before merge.
+
+## Live smoke and basic check commands
+
+From the repo root. Export AWS credentials first:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+aws sts get-caller-identity
+```
+
+Expected: JSON with `"Arn"` containing the lab IAM user and exit code 0.
+
+```bash
+git lfs pull --include "data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv"
+```
+
+Expected: exit code 0. The file is larger than 2,000 bytes and is not an LFS pointer:
+
+```bash
+python3 -c "
+from pathlib import Path
+p = Path('data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv')
+head = p.read_bytes()[:40]
+assert not head.startswith(b'version https://git-lfs.github.com/spec/v1'), head
+assert p.stat().st_size > 2000, p.stat().st_size
+print('csv smudged ok', p.stat().st_size)
+"
+```
+
+Expected: `csv smudged ok` plus a byte size near 2,584,416.
+
+```bash
+PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py
+```
+
+Expected: migration reports `uploaded 1 object`. Verifier prints `OK: 1/1 objects present with matching sha256`.
+
+```bash
+PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; c=load_twitter_campaign_config('twitter_2026_09_06_192847_llm_features_v1'); print(c['row_count'], c['engine_type'], len(c['features']))"
+```
+
+Expected: `6374 openai 7`.
+
+```bash
+PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; load_twitter_campaign_config('bluesky_2026_09_03_235130_llm_features_v1')"
+```
+
+Expected: non-zero exit and `ValueError` naming the rejected campaign id.
+
+```bash
+DISPOSABLE_PREFIX=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/twitter_step1_campaign_smoke/
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_twitter_campaign.py \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --feature is_news_or_opinion \
+  --smoke-prefix "$DISPOSABLE_PREFIX" \
+  --output-dir docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/_step1_disposable
+```
+
+Expected: `smoke_rows=10`, `full_run_row_count=6374`, `no_batches_prefix_objects=true`, `primary_smoke_prefix_touched=false`. Then delete the disposable prefix and the `_step1_disposable` Git directory.
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/feature_progress_watcher.py \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --feature is_news_or_opinion \
+  --platform twitter \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --once
+```
+
+Expected: exit 0. Printed markdown only. No GitHub API write.
+
+```bash
+git lfs ls-files | grep "twitter_fba4ddb2" | grep "posts.csv"
+```
+
+Expected: the preprocessed `posts.csv` line remains.
+
+## Acceptance criteria
+
+- The scoped csv exists in S3 at the repo-relative key with matching SHA-256 in the inventory.
+- Git still tracks the csv as LFS. `dataset.json` still says `format: csv`.
+- YAML loader returns the seven features and rejects any other campaign id.
+- `generate_twitter_features.py` accepts `--campaign-id` with `--preprocessed-run`.
+- Disposable-prefix smoke writes ten rows and no production batch objects.
+- Watcher resolves Twitter paths through `FeaturePaths.for_campaign`.
+- No automated tests added or run.
+
+## Failure conditions
+
+- Verification accepts ETag instead of SHA-256.
+- The csv uploads as an LFS pointer.
+- S3 key starts with `data_platform/data_platform/`.
+- Raw Twitter csv, Bluesky paths, or Reddit paths appear in the inventory.
+- Git LFS pointer is removed.
+- `FEATURE_REGISTRY` defaults change.
+- Primary campaign `batches/` objects are written in this PR.
+- Any pytest file is added or run.
+
+## PR artifact and commit rules
+
+- One independently mergeable PR for this step only.
+- Bottom of the GitHub stack. Base `main`.
+- Logical commits: migrate scripts, YAML and loader, campaign CLI, smoke and watcher, inventory after successful upload, changelog.
+- Delete disposable smoke Git copies before merge.
+- PR title suggestion: `Add Twitter LLM campaign config, S3 csv copy, and smoke tooling`.
+
+## GitHub issue body
+
+Upload the pinned Twitter preprocessed posts csv (6374 rows, run `2026_09_06-19:28:47`) to `mirrorview-experimental-artifacts`, add campaign YAML for `twitter_2026_09_06_192847_llm_features_v1`, wire Twitter campaign mode, and add smoke, cost, and watcher tooling. Keep Git LFS unchanged. Do not label all 6,374 posts in this pull request.
+
+Plan step: `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step1.md`
+
+Done when:
+
+- `posts.csv` is on S3 at the repo-relative key with matching SHA-256 in the inventory.
+- Git still tracks the csv as LFS. No Bluesky or Reddit paths were uploaded.
+- Campaign YAML loads for this campaign id only.
+- Smoke and watcher commands in the step file pass on a disposable prefix.
+- No production `batches/part-*.parquet` objects were written.
+
+Ship as one PR. Do not bundle with sibling issues.
+
+## Pull request description
+
+# Add Twitter LLM campaign config, S3 csv copy, and smoke tooling
+
+Fixes #<child>
+
+Part of #<parent>
+
+## Problem
+
+Pull request 215 left 6,374 preprocessed Twitter posts in Git LFS csv. Campaign workers need those bytes on `mirrorview-experimental-artifacts`, a Twitter campaign id, and smoke tooling before anyone labels the full set.
+
+## Solution
+
+Upload only `posts.csv`. Add `mirrorview_2026-09-05_llm_features_v1.yaml` and a loader that accepts that campaign id only. Wire `generate_twitter_features.py` campaign flags. Add `smoke_twitter_campaign.py`, `--full-run-row-count` on the cost aggregator, and watcher `--platform` / `--dataset-id`.
+
+## Purpose
+
+Step 2 depends on S3-hosted input and smoke tooling. Changing `StorageManager`, converting the dataset to parquet, or labeling 6,374 rows is out of scope.
+
+## How to run
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+git lfs pull --include "data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv"
+PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py
+```
+
+Expected: `uploaded 1 object`, then `OK: 1/1 objects present with matching sha256`.

--- a/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step2.md
+++ b/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step2.md
@@ -1,0 +1,244 @@
+# Step 2: Smoke and generate seven LLM features for 6,374 Twitter posts
+
+## Goal
+
+One pull request runs the seven ten-post smokes, posts cost on the parent issue, waits for owner sign-off, then labels all 6,374 posts on OpenAI Batch with `gpt-5.4-nano`, one feature at a time. The pull request carries documentation and run artifacts only. It does not change product code.
+
+## Dependencies
+
+- **Step 1 merged** on the GitHub stack: csv on S3, campaign YAML, `generate_twitter_features.py` campaign mode, `smoke_twitter_campaign.py`, cost aggregate with `--full-run-row-count 6374`, watcher flags.
+- **Parent issue owner sign-off** after Phase A, before Phase B. Sign-off is a comment on the parent issue. It is not a GitHub `blocked-by`. Merged Step 1 is not permission to label 6,374 rows.
+
+Pinned identities: see `campaign_contract.md`.
+
+## Main caller and implementation scope
+
+Phase A (each feature, YAML order). Interrupt and resume only on `is_news_or_opinion`:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_twitter_campaign.py \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --feature is_news_or_opinion \
+  --output-dir docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/is_news_or_opinion
+```
+
+Repeat for `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tiered` without a second interrupt.
+
+Aggregate after all seven cost reports exist:
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/campaign_cost_report.py \
+  --aggregate \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --smoke-reports-dir docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke \
+  --output docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/parent_cost_aggregate.json \
+  --full-run-row-count 6374
+```
+
+Phase B (each feature, same order, after parent sign-off):
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/generate_twitter_features.py \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --features is_news_or_opinion \
+  --batch-size 2000
+```
+
+**One implementation scope:** run the callers above. Commit temporary smoke Git copies in Phase A. Post per-feature costs on this issue and the aggregate on the parent. Stop. After the owner comments on the parent, run production serially, write seven run reports, delete temporary smoke Git copies. Do not edit Python under `data_platform/` or `lib/`.
+
+**Out of scope:** product-code changes, pytest, GitHub posting from repository code, wide join, changing filter YAML, Bedrock, Perspective `is_toxic_tiered`, parallel OpenAI Batch jobs.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/campaign_contract.md` | Identities, part layout, schemas |
+| `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step1.md` | Tooling that must already be on the stack |
+| `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml` | Feature order and row count |
+| `/workspace/data_platform/generate_features/smoke_twitter_campaign.py` | Phase A caller |
+| `/workspace/data_platform/generate_features/generate_twitter_features.py` | Phase B caller |
+| `/workspace/data_platform/generate_features/generate_features.py` | `_smoke_rows_by_id` fold |
+
+## Files allowed to change
+
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/**` (temporary Phase A copies, deleted before merge)
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/is_news_or_opinion_run_report.md` (new, keep)
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/is_political_run_report.md` (new, keep)
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/is_likely_spam_run_report.md` (new, keep)
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/is_self_contained_run_report.md` (new, keep)
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/is_structurally_complete_run_report.md` (new, keep)
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/political_stance_run_report.md` (new, keep)
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/llm_toxicity_tiered_run_report.md` (new, keep)
+- `/workspace/CHANGELOG.md`
+
+Do not edit this step file except to correct a spec bug.
+
+## Files forbidden to change
+
+- Any file under `/workspace/data_platform/` except the reports and changelog listed above
+- `/workspace/lib/`
+- `/workspace/tests/`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/plan.md`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/campaign_contract.md`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step1.md`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step3.md`
+- Any committed parquet or csv label file
+
+## Locked contracts
+
+Serial feature order:
+
+1. `is_news_or_opinion` (interrupt-and-resume once during its smoke)
+2. `is_political`
+3. `is_likely_spam`
+4. `is_self_contained`
+5. `is_structurally_complete`
+6. `political_stance`
+7. `llm_toxicity_tiered`
+
+After parent approval, each feature must have:
+
+- `smoke/input.parquet`, `smoke/output.parquet`, `smoke/cost_report.json` (untagged)
+- `smoke/resume_evidence.json` on `is_news_or_opinion` only
+- `batches/part-00000.parquet` (10 smoke rows + 1,990 new)
+- `batches/part-00001.parquet` (2,000)
+- `batches/part-00002.parquet` (2,000)
+- `batches/part-00003.parquet` (374)
+- `final.parquet` with 6,374 unique `source_record_id` values
+- `manifest.json` with `engine_type=openai` and `expected_row_count=6374`
+- `progress.jsonl` with one record per finished part
+
+Preserve original smoke `batch_id` and `request_id` on the ten folded rows. One OpenAI Batch job in flight per feature. Do not start the next feature's production command until the previous feature's `final.parquet` validates.
+
+## Two-phase pull request flow
+
+### Phase A
+
+1. Confirm Step 1 is on the stack below this branch.
+2. Run `smoke_twitter_campaign.py` for all seven features. Interrupt and resume only `is_news_or_opinion`.
+3. Commit temporary Git copies under `reports/smoke/{feature}/`.
+4. Post each per-feature `estimated_full_run_usd_avg` and `estimated_full_run_usd_max` on this issue.
+5. Write and post `parent_cost_aggregate.json` on the parent issue.
+6. Stop. Leave the stack pull request as draft. Do not start production.
+
+### Phase B
+
+1. Confirm the parent issue has an explicit owner comment signing off on Step 1, the seven smokes, and the aggregate cost.
+2. Run the seven production commands in order.
+3. Validate S3 artifacts and row counts for each feature before starting the next.
+4. Write the seven `*_run_report.md` files.
+5. Delete temporary `reports/smoke/` Git copies. S3 smoke evidence remains.
+6. Mark the stack pull request ready.
+
+## Exact commands and expected output
+
+List one feature prefix:
+
+```bash
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/is_news_or_opinion/ --recursive
+```
+
+Expected after Phase A: smoke objects only. No `batches/part-*.parquet`.
+
+Expected after Phase B: four `batches/part-*.parquet` objects, `final.parquet`, `manifest.json`, `progress.jsonl`.
+
+Validate one final file:
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/is_news_or_opinion/final.parquet /tmp/twitter_is_news_or_opinion_final.parquet
+PYTHONPATH=. uv run python - <<'PY'
+import pyarrow.parquet as pq
+t = pq.read_table("/tmp/twitter_is_news_or_opinion_final.parquet")
+assert t.num_rows == 6374, t.num_rows
+ids = t.column("source_record_id").to_pylist()
+assert len(set(ids)) == 6374
+print("final ok", t.num_rows)
+PY
+```
+
+Expected: `final ok 6374`.
+
+Watcher (no GitHub post):
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/feature_progress_watcher.py \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --feature is_news_or_opinion \
+  --platform twitter \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --once
+```
+
+Expected: printed markdown. 10,000-row milestone absent.
+
+Each run report must include S3 URIs, manifest SHA-256, model id `gpt-5.4-nano`, prompt hash, estimated and actual USD, part counts, unique id count 6374, and a note that Git smoke copies were removed.
+
+## Acceptance criteria
+
+- Seven smoke cost estimates are posted on this issue. Aggregate is posted on the parent.
+- Parent issue has explicit owner sign-off before any `batches/part-*.parquet` object exists.
+- Each feature has four batch objects and `final.parquet` with 6,374 unique ids.
+- Only `is_news_or_opinion` has `resume_evidence.json`.
+- Seven run reports remain in Git. Temporary smoke Git copies are gone.
+- No product-code diff.
+
+## Failure conditions
+
+- Phase B starts without a parent-issue owner comment.
+- Two OpenAI Batch jobs for the same feature exist at once.
+- Smoke rows in `part-00000` have new `batch_id` values.
+- `part-00003` does not have 374 rows.
+- Perspective `is_toxic_tiered` runs.
+- Product Python changes.
+- Pytest added or run.
+- Watcher posts to GitHub.
+
+## PR artifact and commit rules
+
+- One independently mergeable PR for this step only, stacked on Step 1.
+- Stay draft through Phase A. Ready after Phase B.
+- PR title suggestion: `Label 6374 Twitter posts with seven OpenAI LLM features`.
+
+## GitHub issue body
+
+Generate all seven LLM features for 6,374 pinned Twitter posts through OpenAI Batch with model `gpt-5.4-nano` in one pull request. Run Phase A smoke once per feature with `smoke_twitter_campaign.py`, interrupt and resume only `is_news_or_opinion`, post costs, and wait for parent issue owner sign-off before Phase B. Phase B writes four immutable batch objects, `final.parquet`, `manifest.json`, progress records, and a permanent run report per feature on S3. The pull request carries documentation and run artifacts only and does not change product code.
+
+Plan step: `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step2.md`
+
+Done when:
+
+- Seven smoke cost estimates and the parent aggregate are posted.
+- Parent issue has explicit owner sign-off before the 6,374-post runs start.
+- S3 holds four batch objects and validated `final.parquet` with 6374 unique `source_record_id` values per feature.
+- Seven `reports/*_run_report.md` files are committed and temporary Git smoke copies are removed before merge.
+
+Ship as one PR. Do not bundle with sibling issues.
+
+## Pull request description
+
+# Label 6374 Twitter posts with seven OpenAI LLM features
+
+Fixes #<child>
+
+Part of #<parent>
+
+## Problem
+
+The dated Twitter collection is labeled only after smoke costs are reviewed. Operators need all seven features in one stack pull request, with a pause for parent-issue sign-off.
+
+## Solution
+
+Phase A runs `smoke_twitter_campaign.py` for seven features and posts `parent_cost_aggregate.json` scaled to 6,374 rows. After owner sign-off, Phase B runs `generate_twitter_features.py` once per feature with `--batch-size 2000`. No product code.
+
+## How to run
+
+See the Phase A and Phase B command blocks in the step file.
+
+Expected after Phase B: seven `final.parquet` files, each with 6,374 rows, and seven run reports in git.

--- a/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step3.md
+++ b/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step3.md
@@ -1,0 +1,184 @@
+# Step 3: Consolidate seven Twitter LLM features and write the MirrorView curated export
+
+## Goal
+
+Operators need one wide table and a MirrorView export, so the implementer joins seven verified `final.parquet` files to pinned preprocessed `posts.csv` on `source_record_id`, uploads `wide/features.parquet`, and writes a curated run through `data_platform/curate/configs/twitter/mirrorview.yaml`.
+
+## Dependencies
+
+- **Step 2 merged** on the GitHub stack: seven features each have `final.parquet` with 6,374 unique ids and a matching `manifest.json`.
+- Step 1 identities and S3 csv must still match the inventory hash.
+
+## Main caller and implementation scope
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/features.parquet
+```
+
+**One implementation scope:** add `consolidate_twitter_llm_campaign.py`. Download pinned `posts.csv` (not parquet). Verify each feature manifest `row_count=6374` and SHA-256 of `final.parquet`. Inner-join on `source_record_id` to the 21-column contract. Upload `wide/features.parquet` and `wide/manifest.json`. Run `apply_rules` with `twitter/mirrorview.yaml`. Write curated output with `TwitterStorageManager("curated", dataset_id)`. Write `reports/wide_run_report.md`.
+
+Reuse join helpers from `data_platform/curate/consolidate.py` only where they already take column lists. Do not change Bluesky `PREPROCESSED_WIDE_COLUMNS` or `EXPECTED_WIDE_ROW_COUNT = 200000`. Do not change `twitter/mirrorview.yaml` filter semantics.
+
+**Out of scope:** relabeling features, pytest, GitHub posting, lifecycle rules, converting the dated dataset to parquet.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py` | Campaign join, manifest checks, curation write |
+| `/workspace/data_platform/curate/consolidate.py` | `LLM_CAMPAIGN_FEATURE_NAMES`, feature aliases |
+| `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml` | Filter set |
+| `/workspace/data_platform/utils/storage.py` | `TwitterStorageManager` |
+| `/workspace/data_platform/models/sync.py` | `PreprocessedTwitterPostModel` |
+| `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/campaign_contract.md` | 21-column contract |
+
+## Files allowed to change
+
+- `/workspace/data_platform/curate/consolidate_twitter_llm_campaign.py` (new)
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md` (new)
+- `/workspace/CHANGELOG.md`
+
+Do not edit other plan files except this step file when correcting the spec.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/curate/consolidate.py` unless a tiny helper must accept a column list without changing Bluesky behavior. Prefer keeping Twitter columns inside the new module.
+- `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py`
+- `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/tests/**`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/dataset.json`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/plan.md`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step1.md`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step2.md`
+
+## Locked contracts
+
+Wide file: exactly 21 columns in this order.
+
+`tweet_id`, `record_id`, `url`, `username`, `author_handle`, `text`, `created_at`, `like_count`, `retweet_count`, `reply_count`, `quote_count`, `keyword`, `sync_timestamp`, `source_record_id`, `news_or_opinion_category`, `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tier`
+
+Row count: `6374`. Distinct `source_record_id`: `6374`. Sort: `source_record_id ASC`. No nulls in the seven label columns.
+
+Wide manifest links all seven feature manifests plus the preprocessed csv SHA-256 from `s3_preprocessed_inventory.json`.
+
+Forbidden wide columns: `toxicity_prob`, `toxicity_tier`, any `is_toxic_tiered` field, `label_timestamp`, `run_id`, `author_id`.
+
+Left table key:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv`
+
+Read that object as csv. Do not require `posts.parquet`.
+
+Curation: `TwitterStorageManager("curated", dataset_id)` writes `curated/<timestamp>/mirrorview.parquet` plus `metadata.json`. Filename stem is `mirrorview` from the YAML.
+
+## Ordered implementation work
+
+1. Add `consolidate_twitter_llm_campaign.py` with Twitter column lists and csv left-table load.
+2. Verify seven manifests before writing wide output.
+3. Join, upload wide parquet and manifest.
+4. Apply MirrorView rules. Write curated run.
+5. Write `reports/wide_run_report.md` with curated row count and `political_stance` by `llm_toxicity_tier` crosstab for rows that survive the filters.
+6. Run the runtime checks below.
+
+## Live smoke and basic check commands
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/features.parquet
+```
+
+Expected stdout includes each accepted manifest digest, `wide_rows=6374`, `wide_columns=21`, `sort_key=source_record_id ASC`, and the wide manifest URI.
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/features.parquet /tmp/twitter_wide.parquet
+PYTHONPATH=. uv run python - <<'PY'
+import pyarrow.parquet as pq
+t = pq.read_table("/tmp/twitter_wide.parquet")
+want = [
+    "tweet_id","record_id","url","username","author_handle","text","created_at",
+    "like_count","retweet_count","reply_count","quote_count","keyword","sync_timestamp",
+    "source_record_id","news_or_opinion_category","is_political","is_likely_spam",
+    "is_self_contained","is_structurally_complete","political_stance","llm_toxicity_tier",
+]
+assert t.column_names == want, t.column_names
+assert t.num_rows == 6374
+print("wide ok", t.num_rows, len(t.column_names))
+PY
+```
+
+Expected: `wide ok 6374 21`.
+
+## Acceptance criteria
+
+- `wide/features.parquet` has exactly 6,374 rows, 21 columns, and no missing feature values.
+- `wide/manifest.json` links all seven feature manifests and the preprocessed csv hash.
+- MirrorView curation writes `curated/<timestamp>/mirrorview.parquet` and `metadata.json` through `TwitterStorageManager`.
+- `reports/wide_run_report.md` is committed with curated row count and the stance by toxicity crosstab.
+- Filter YAML semantics are unchanged.
+- No pytest added or run.
+
+## Failure conditions
+
+- Left table loaded from parquet or from a converted copy of `posts.csv`.
+- Wide column order differs from the contract.
+- Bluesky `EXPECTED_WIDE_ROW_COUNT` is changed.
+- Join uses `tweet_id` instead of `source_record_id`.
+- Curated files land under `wide/curated/` or through `BlueskyStorageManager`.
+- Any feature `final.parquet` with a mismatched hash is accepted.
+
+## PR artifact and commit rules
+
+- One independently mergeable PR for this step only, stacked on Step 2.
+- Logical commits: consolidator module, live run report, changelog.
+- PR title suggestion: `Join seven Twitter LLM features and write the MirrorView export`.
+
+## GitHub issue body
+
+Join seven verified Twitter LLM feature `final.parquet` files to pinned preprocessed `posts.csv` on `source_record_id`. Write untagged `wide/features.parquet` and `wide/manifest.json` for campaign `twitter_2026_09_06_192847_llm_features_v1` with 6374 rows and 21 columns. Apply `data_platform/curate/configs/twitter/mirrorview.yaml` and write `curated/<timestamp>/mirrorview.parquet` plus `metadata.json` through `TwitterStorageManager("curated", dataset_id)`. The work depends on Step 2 merged with verified `final.parquet` at 6374 rows each.
+
+Plan step: `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step3.md`
+
+Done when:
+
+- `wide/features.parquet` has exactly 6374 rows, 21 columns, and no missing feature values.
+- `wide/manifest.json` links all seven feature manifests and the preprocessed input hash.
+- MirrorView curation writes `curated/<timestamp>/mirrorview.parquet` and `metadata.json`.
+- `reports/wide_run_report.md` is committed with curated row count and `political_stance` by `llm_toxicity_tier` crosstab.
+
+Ship as one PR. Do not bundle with sibling issues.
+
+## Pull request description
+
+# Join seven Twitter LLM features and write the MirrorView export
+
+Fixes #<child>
+
+Part of #<parent>
+
+## Summary
+
+Adds `consolidate_twitter_llm_campaign.py` to join seven verified `final.parquet` files to pinned preprocessed Twitter csv, upload `wide/features.parquet` with a SHA-256 manifest, and write a MirrorView curated export for dataset `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547`.
+
+## Purpose
+
+Step 2 leaves seven isolated feature prefixes. MirrorView needs one 21-column table and the existing Twitter filter YAML.
+
+## How to run
+
+See the main caller in the step file.
+
+Expected: `wide_rows=6374`, `wide_columns=21`, plus a timestamped `mirrorview.parquet` under the dataset `curated/` stage.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Pull request 215 left 6,374 preprocessed Twitter posts in Git LFS csv. Feature generation, curation, and S3 were out of scope. Campaign mode cannot yet target this dated Twitter run.

## Solution

Docs-only implementation plan under `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/`: executive `plan.md`, `campaign_contract.md`, and three step specs. No product code.

GitHub epic is filed. This PR remains plan and docs only. Implementing children is `/implement-epic`, not this PR.

## Epic

- Parent (tracking only): https://github.com/METResearchGroup/mirrorView-task/issues/232
- Plan: `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/plan.md`

## Children (one PR each, GitHub stack)

- https://github.com/METResearchGroup/mirrorView-task/issues/233 Add Twitter campaign config, copy posts.csv to S3, and wire smoke tooling
- https://github.com/METResearchGroup/mirrorView-task/issues/234 Smoke and generate seven LLM features for 6,374 Twitter posts
- https://github.com/METResearchGroup/mirrorView-task/issues/235 Consolidate seven Twitter LLM features and write the MirrorView curated export

## Purpose

Give implementers a self-contained package: copy `posts.csv` to S3, add a Twitter campaign YAML, run all seven OpenAI Batch features in one issue after owner sign-off, then wide join and MirrorView curation. Git LFS stays. `dataset.json` stays csv.

## How to run

Read `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/plan.md` then `campaign_contract.md`. Open any `steps/stepN.md` for caller commands, pass/fail checks, the issue body, and the PR description.

Expected: three steps, 6,374 posts, campaign id `twitter_2026_09_06_192847_llm_features_v1`, no Python changes in this diff.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07377-f9f2-70e3-a529-c0f524b4d983?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07377-f9f2-70e3-a529-c0f524b4d983&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

