### PR TITLE
Add Reddit campaign engine map and Bedrock S3 campaign path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 2. Operators now have seven OpenAI Batch labels for all 6,374 pinned Twitter posts, with four batch objects and a run report per feature. [PR #240](https://github.com/METResearchGroup/mirrorView-task/pull/240)
 3. The pinned Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_06_192847_llm_features_v1`, run a ten-post disposable smoke, scale cost math to 6,374 rows, and print watcher status without writing to GitHub. [PR #238](https://github.com/METResearchGroup/mirrorView-task/pull/238)
 4. The pinned Reddit preprocessed comments parquet (400,000 comments, run `2026_09_03-23:39:28`) now exists in the `mirrorview-experimental-artifacts` S3 bucket at the repo-relative key, and a committed inventory records the SHA-256 of the single object. Git LFS still holds the local copy. [PR #230](https://github.com/METResearchGroup/mirrorView-task/pull/230)
-5. Reddit campaign `reddit_2026_09_03_233928_llm_features_v1` can label four LLM features through OpenAI Batch and three through Bedrock Converse, with Bedrock content-filter failures retried through OpenAI Batch, while Bluesky campaigns stay on OpenAI. [PR #236](https://github.com/METResearchGroup/mirrorView-task/pull/236)
+5. Reddit campaign `reddit_2026_09_03_233928_llm_features_v1` can label four LLM features through OpenAI Batch and three through Bedrock Converse, with Bedrock content-filter failures retried through OpenAI Batch, while Bluesky campaigns stay on OpenAI. Bedrock part 0 keeps the ten smoke labels unchanged and labels the rest of that chunk. [PR #236](https://github.com/METResearchGroup/mirrorView-task/pull/236)
 
 ## 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 2. Operators now have seven OpenAI Batch labels for all 6,374 pinned Twitter posts, with four batch objects and a run report per feature. [PR #240](https://github.com/METResearchGroup/mirrorView-task/pull/240)
 3. The pinned Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_06_192847_llm_features_v1`, run a ten-post disposable smoke, scale cost math to 6,374 rows, and print watcher status without writing to GitHub. [PR #238](https://github.com/METResearchGroup/mirrorView-task/pull/238)
 4. The pinned Reddit preprocessed comments parquet (400,000 comments, run `2026_09_03-23:39:28`) now exists in the `mirrorview-experimental-artifacts` S3 bucket at the repo-relative key, and a committed inventory records the SHA-256 of the single object. Git LFS still holds the local copy. [PR #230](https://github.com/METResearchGroup/mirrorView-task/pull/230)
+5. Reddit campaign `reddit_2026_09_03_233928_llm_features_v1` can label four LLM features through OpenAI Batch and three through Bedrock Converse, with Bedrock content-filter failures retried through OpenAI Batch, while Bluesky campaigns stay on OpenAI. [PR #236](https://github.com/METResearchGroup/mirrorView-task/pull/236)
 
 ## 2026-09-06
 

--- a/data_platform/curate/consolidate_bluesky_llm_campaign.py
+++ b/data_platform/curate/consolidate_bluesky_llm_campaign.py
@@ -231,7 +231,12 @@ def verify_feature_manifest(
     dataset_id: str,
 ) -> tuple[str, dict[str, Any]]:
     """Return manifest SHA-256 and parsed JSON after checking row count 200000."""
-    paths = FeaturePaths.canonical(campaign_id, feature_name, dataset_id=dataset_id)
+    paths = FeaturePaths.for_campaign(
+        campaign_id,
+        feature_name,
+        platform=DEFAULT_CAMPAIGN_PLATFORM,
+        dataset_id=dataset_id,
+    )
     stored = store.get(paths.manifest_key)
     if stored is None:
         raise FileNotFoundError(f"missing feature manifest: {paths.uri(paths.manifest_key)}")
@@ -272,7 +277,12 @@ def _download_feature_final(
     work_dir: Path,
     feature_name: str,
 ) -> FeatureInputRecord:
-    paths = FeaturePaths.canonical(args.campaign_id, feature_name, dataset_id=args.dataset_id)
+    paths = FeaturePaths.for_campaign(
+        args.campaign_id,
+        feature_name,
+        platform=DEFAULT_CAMPAIGN_PLATFORM,
+        dataset_id=args.dataset_id,
+    )
     manifest_sha, manifest = verify_feature_manifest(
         store, feature_name, args.campaign_id, args.dataset_id
     )
@@ -482,8 +492,11 @@ def upload_wide_artifacts(
 
 def run_campaign_consolidation(args: CampaignConsolidateArgs) -> WideConsolidateResult:
     """Download inputs, join, validate, upload wide artifacts, and curate."""
-    paths = FeaturePaths.canonical(
-        args.campaign_id, LLM_CAMPAIGN_FEATURE_NAMES[0], dataset_id=args.dataset_id
+    paths = FeaturePaths.for_campaign(
+        args.campaign_id,
+        LLM_CAMPAIGN_FEATURE_NAMES[0],
+        platform=DEFAULT_CAMPAIGN_PLATFORM,
+        dataset_id=args.dataset_id,
     )
     store = CampaignObjectStore(paths.bucket)
     with TemporaryDirectory() as tmp:

--- a/data_platform/generate_features/campaign_engine_map.py
+++ b/data_platform/generate_features/campaign_engine_map.py
@@ -14,7 +14,15 @@ BEDROCK_ENGINE_TYPE = "bedrock"
 REDDIT_LLM_FEATURES_CAMPAIGN_ID = "reddit_2026_09_03_233928_llm_features_v1"
 BLUESKY_LLM_FEATURES_CAMPAIGN_ID = "bluesky_2026_09_03_235130_llm_features_v1"
 
-REDDIT_CAMPAIGN_ENGINE_BY_FEATURE: dict[str, str] = {}
+REDDIT_CAMPAIGN_ENGINE_BY_FEATURE: dict[str, str] = {
+    "is_news_or_opinion": OPENAI_ENGINE_TYPE,
+    "is_political": OPENAI_ENGINE_TYPE,
+    "political_stance": OPENAI_ENGINE_TYPE,
+    "llm_toxicity_tiered": OPENAI_ENGINE_TYPE,
+    "is_likely_spam": BEDROCK_ENGINE_TYPE,
+    "is_self_contained": BEDROCK_ENGINE_TYPE,
+    "is_structurally_complete": BEDROCK_ENGINE_TYPE,
+}
 
 
 def campaign_engine_type(campaign_id: str, feature: str) -> str:
@@ -37,4 +45,11 @@ def campaign_engine_type(campaign_id: str, feature: str) -> str:
     ValueError
         When the Reddit campaign has no map entry for ``feature``.
     """
-    raise NotImplementedError
+    if campaign_id != REDDIT_LLM_FEATURES_CAMPAIGN_ID:
+        return OPENAI_ENGINE_TYPE
+    engine = REDDIT_CAMPAIGN_ENGINE_BY_FEATURE.get(feature)
+    if engine is None:
+        raise ValueError(
+            f"campaign {campaign_id} has no engine map entry for {feature}"
+        )
+    return engine

--- a/data_platform/generate_features/campaign_engine_map.py
+++ b/data_platform/generate_features/campaign_engine_map.py
@@ -1,0 +1,40 @@
+"""Campaign-only engine overrides for mixed OpenAI and Bedrock labeling.
+
+Run from the repo root:
+
+    PYTHONPATH=. uv run python -c \\
+        "from data_platform.generate_features.campaign_engine_map import campaign_engine_type; \\
+        print(campaign_engine_type('reddit_2026_09_03_233928_llm_features_v1', 'is_political'))"
+"""
+
+from __future__ import annotations
+
+OPENAI_ENGINE_TYPE = "openai"
+BEDROCK_ENGINE_TYPE = "bedrock"
+REDDIT_LLM_FEATURES_CAMPAIGN_ID = "reddit_2026_09_03_233928_llm_features_v1"
+BLUESKY_LLM_FEATURES_CAMPAIGN_ID = "bluesky_2026_09_03_235130_llm_features_v1"
+
+REDDIT_CAMPAIGN_ENGINE_BY_FEATURE: dict[str, str] = {}
+
+
+def campaign_engine_type(campaign_id: str, feature: str) -> str:
+    """Return ``openai`` or ``bedrock`` for one campaign feature.
+
+    Parameters
+    ----------
+    campaign_id
+        Campaign id. Only the pinned Reddit campaign uses a mixed map.
+    feature
+        Registry feature name.
+
+    Returns
+    -------
+    str
+        ``openai`` or ``bedrock``.
+
+    Raises
+    ------
+    ValueError
+        When the Reddit campaign has no map entry for ``feature``.
+    """
+    raise NotImplementedError

--- a/data_platform/generate_features/engines/bedrock_campaign.py
+++ b/data_platform/generate_features/engines/bedrock_campaign.py
@@ -85,6 +85,26 @@ def run_bedrock_campaign_feature(
 
     Content-filter ids are recorded, then retried through OpenAI Batch in this
     same call. Other Bedrock failures stay failed.
+
+    Parameters
+    ----------
+    records
+        Preprocessed rows with ``source_record_id`` and ``text``.
+    spec
+        Feature spec whose prompt and schema Bedrock uses.
+    campaign
+        Campaign identity, including batch size.
+    run_config
+        OpenAI retry settings. Bedrock parts always use eight threads.
+    paths
+        S3 prefix for this feature. Must not default a Reddit run to Bluesky.
+    engine_type
+        Must be ``bedrock`` and is stored on the manifest.
+
+    Returns
+    -------
+    FeaturePaths
+        The same prefix, after parts, retries, and optional final file.
     """
     store = CampaignObjectStore(paths.bucket)
     run_id = run_id_for_feature(campaign.campaign_id, spec.name)

--- a/data_platform/generate_features/engines/bedrock_campaign.py
+++ b/data_platform/generate_features/engines/bedrock_campaign.py
@@ -143,13 +143,15 @@ def _label_bedrock_parts(
     written_parts = {int(entry["part_index"]) for entry in manifest["batches"]}
     for part_index, chunk_ids in enumerate(_chunks(ordered_ids, campaign.batch_size)):
         if part_index in written_parts:
+            _delete_active_bedrock_job_if_part_in(store, paths, written_parts)
             continue
         adopted = adopt_unrecorded_batch(
             store, paths, manifest, manifest_etag, part_index=part_index, run_id=run_id
         )
         if adopted is not None:
             manifest_etag = adopted.manifest_etag
-            delete_active_bedrock_state(store, paths)
+            written_parts.add(part_index)
+            _delete_active_bedrock_job_if_part_in(store, paths, {part_index})
             continue
         manifest_etag = _label_bedrock_part(
             store, paths, manifest, manifest_etag, spec, campaign, part_index, chunk_ids, texts, run_id
@@ -185,6 +187,33 @@ def _label_bedrock_part(
     return _finish_bedrock_part(
         store, paths, manifest, manifest_etag, spec, run_id, part_index, chunk_ids, rows_by_id, spill_path
     )
+
+
+def _delete_active_bedrock_job_if_part_in(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    recorded_parts: set[int],
+) -> None:
+    """Delete ``active_bedrock_job.json`` when its part is already durable.
+
+    Loads the active Bedrock cursor and deletes it only if
+    ``logical_batch_index`` is in ``recorded_parts``. A cursor for a later
+    unrecorded part is left in place so resume of that part can keep the job.
+
+    Parameters
+    ----------
+    store
+        Campaign object store for this feature prefix.
+    paths
+        Feature prefix that holds ``active_bedrock_job.json``.
+    recorded_parts
+        Part indexes already in the manifest, or the single part just adopted.
+    """
+    remote, _etag = load_active_bedrock_state(store, paths)
+    if remote is None:
+        return
+    if int(remote["logical_batch_index"]) in recorded_parts:
+        delete_active_bedrock_state(store, paths)
 
 
 def _label_pending_bedrock_tasks(
@@ -298,7 +327,7 @@ def _finish_bedrock_part(
         manifest_etag = _write_labeled_part(
             store, paths, manifest, manifest_etag, spec, run_id, part_index, rows
         )
-    delete_active_bedrock_state(store, paths)
+    _delete_active_bedrock_job_if_part_in(store, paths, {part_index})
     spill_path.unlink(missing_ok=True)
     return manifest_etag
 

--- a/data_platform/generate_features/engines/bedrock_campaign.py
+++ b/data_platform/generate_features/engines/bedrock_campaign.py
@@ -1,0 +1,542 @@
+"""Bedrock S3 campaign writer for mixed-engine Reddit LLM features.
+
+Run from the repo root:
+
+    PYTHONPATH=. uv run python -c \\
+        "from data_platform.generate_features.engines.bedrock_campaign import BEDROCK_CAMPAIGN_MAX_CONCURRENCY; \\
+        print(BEDROCK_CAMPAIGN_MAX_CONCURRENCY)"
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from data_platform.generate_features.campaign_engine_map import BEDROCK_ENGINE_TYPE
+from data_platform.generate_features.engines.base import RecordLabelFailure
+from data_platform.generate_features.engines.bedrock_engine import (
+    create_bedrock_runtime_client,
+    label_tasks_collecting_failures,
+)
+from data_platform.generate_features.engines.openai_engine import (
+    DEFAULT_OPENAI_BATCH_ENGINE_CONFIG,
+    OpenAIBatchEngine,
+    create_openai_client,
+)
+from data_platform.generate_features.generate_features import (
+    _append_spilled_rows,
+    _campaign_local_run_dir,
+    _chunks,
+    _label_campaign_chunk,
+    _load_or_create_manifest,
+    _load_spilled_rows,
+    _ordered_campaign_input,
+    _smoke_rows_by_id,
+    _spill_path,
+)
+from data_platform.generate_features.models import (
+    CampaignRunConfig,
+    FeatureRunConfig,
+    FeatureSpec,
+    LabelTask,
+)
+from data_platform.generate_features.s3_feature_batches import (
+    adopt_unrecorded_batch,
+    attach_row_metadata,
+    consolidate_final,
+    labeled_ids,
+    write_batch,
+)
+from data_platform.generate_features.s3_feature_campaign import (
+    ActiveStateMirror,
+    CampaignObjectStore,
+    FeaturePaths,
+    append_errors,
+    delete_active_bedrock_state,
+    delete_active_state,
+    load_active_bedrock_state,
+    read_failed_ids,
+    run_id_for_feature,
+    save_active_bedrock_state,
+    save_manifest,
+)
+from lib.constants import DEFAULT_BEDROCK_NOVA_MICRO, DEFAULT_LLM_MODEL
+from lib.timestamp_utils import get_current_timestamp
+
+BEDROCK_CAMPAIGN_MAX_CONCURRENCY = 8
+BEDROCK_JOB_STATE_RUNNING = "running"
+BEDROCK_JOB_STATE_WRITING = "writing"
+BEDROCK_JOB_STATE_TERMINAL = "terminal"
+CONTENT_FILTER_REASON = "bedrock_content_filter"
+BEDROCK_REQUEST_ID_PREFIX = "bedrock-"
+BEDROCK_ATTEMPT_COUNT = 1
+
+
+def run_bedrock_campaign_feature(
+    records: Any,
+    spec: FeatureSpec,
+    campaign: CampaignRunConfig,
+    run_config: FeatureRunConfig,
+    paths: FeaturePaths,
+    engine_type: str,
+) -> FeaturePaths:
+    """Label one Bedrock-mapped campaign feature into immutable S3 batch objects.
+
+    Content-filter ids are recorded, then retried through OpenAI Batch in this
+    same call. Other Bedrock failures stay failed.
+    """
+    store = CampaignObjectStore(paths.bucket)
+    run_id = run_id_for_feature(campaign.campaign_id, spec.name)
+    ordered_ids, texts = _ordered_campaign_input(records)
+    manifest, manifest_etag = _load_or_create_manifest(
+        store,
+        paths,
+        campaign,
+        spec,
+        expected_row_count=len(ordered_ids),
+        engine_type=engine_type,
+    )
+    if manifest.get("final_parquet"):
+        return paths
+    manifest_etag = _label_bedrock_parts(
+        store, paths, manifest, manifest_etag, spec, campaign, ordered_ids, texts, run_id
+    )
+    manifest_etag = _retry_content_filters_with_openai(
+        store, paths, manifest, manifest_etag, spec, campaign, texts, run_id, run_config
+    )
+    _consolidate_bedrock_final(store, paths, manifest, manifest_etag, spec, ordered_ids, run_id)
+    return paths
+
+
+def _label_bedrock_parts(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    manifest: dict[str, Any],
+    manifest_etag: str,
+    spec: FeatureSpec,
+    campaign: CampaignRunConfig,
+    ordered_ids: list[str],
+    texts: dict[str, str],
+    run_id: str,
+) -> str:
+    written_parts = {int(entry["part_index"]) for entry in manifest["batches"]}
+    for part_index, chunk_ids in enumerate(_chunks(ordered_ids, campaign.batch_size)):
+        if part_index in written_parts:
+            continue
+        adopted = adopt_unrecorded_batch(
+            store, paths, manifest, manifest_etag, part_index=part_index, run_id=run_id
+        )
+        if adopted is not None:
+            manifest_etag = adopted.manifest_etag
+            delete_active_bedrock_state(store, paths)
+            continue
+        manifest_etag = _label_bedrock_part(
+            store, paths, manifest, manifest_etag, spec, campaign, part_index, chunk_ids, texts, run_id
+        )
+    return manifest_etag
+
+
+def _label_bedrock_part(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    manifest: dict[str, Any],
+    manifest_etag: str,
+    spec: FeatureSpec,
+    campaign: CampaignRunConfig,
+    part_index: int,
+    chunk_ids: list[str],
+    texts: dict[str, str],
+    run_id: str,
+) -> str:
+    run_dir = _campaign_local_run_dir(paths)
+    spill_path = _spill_path(run_dir, spec.name, part_index)
+    rows_by_id = _load_spilled_rows(spill_path)
+    job, job_etag = _load_or_start_bedrock_job(
+        store, paths, part_index, chunk_ids, campaign.campaign_id, spec.name, rows_by_id
+    )
+    pending = [uri for uri in chunk_ids if uri not in rows_by_id]
+    if pending:
+        outcome = _label_pending_bedrock_tasks(spec, pending, texts)
+        _record_bedrock_outcome(
+            store, paths, spill_path, rows_by_id, outcome, chunk_ids, run_id, job["job_id"], part_index
+        )
+        _persist_bedrock_job(store, paths, job, job_etag, chunk_ids, rows_by_id)
+    return _finish_bedrock_part(
+        store, paths, manifest, manifest_etag, spec, run_id, part_index, chunk_ids, rows_by_id, spill_path
+    )
+
+
+def _label_pending_bedrock_tasks(
+    spec: FeatureSpec,
+    pending: list[str],
+    texts: dict[str, str],
+) -> Any:
+    tasks = [LabelTask(uri=uri, text=texts[uri]) for uri in pending]
+    return label_tasks_collecting_failures(
+        create_bedrock_runtime_client(),
+        DEFAULT_BEDROCK_NOVA_MICRO,
+        spec,
+        tasks,
+        BEDROCK_CAMPAIGN_MAX_CONCURRENCY,
+        get_current_timestamp(),
+    )
+
+
+def _record_bedrock_outcome(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    spill_path: Path,
+    rows_by_id: dict[str, dict],
+    outcome: Any,
+    chunk_ids: list[str],
+    run_id: str,
+    job_id: str,
+    part_index: int,
+) -> None:
+    if outcome.rows:
+        with_metadata = attach_row_metadata(
+            outcome.rows,
+            run_id=run_id,
+            batch_id=job_id,
+            request_ids=_bedrock_request_ids(chunk_ids),
+            attempt_count=BEDROCK_ATTEMPT_COUNT,
+        )
+        _append_spilled_rows(spill_path, with_metadata)
+        rows_by_id.update({row["source_record_id"]: row for row in with_metadata})
+    _append_bedrock_failures(store, paths, outcome, run_id, part_index)
+
+
+def _bedrock_request_ids(chunk_ids: list[str]) -> dict[str, str]:
+    return {
+        uri: f"{BEDROCK_REQUEST_ID_PREFIX}{index:05d}"
+        for index, uri in enumerate(chunk_ids)
+    }
+
+
+def _append_bedrock_failures(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    outcome: Any,
+    run_id: str,
+    part_index: int,
+) -> None:
+    filter_records = [
+        _content_filter_error_record(failure, run_id, part_index)
+        for failure in outcome.content_filter_failures
+    ]
+    other_records = [
+        _other_bedrock_error_record(failure, run_id, part_index)
+        for failure in outcome.other_failures
+    ]
+    append_errors(store, paths, filter_records + other_records)
+
+
+def _content_filter_error_record(
+    failure: RecordLabelFailure, run_id: str, part_index: int
+) -> dict[str, Any]:
+    return {
+        "source_record_id": failure.source_record_id,
+        "reason": CONTENT_FILTER_REASON,
+        "engine_type": BEDROCK_ENGINE_TYPE,
+        "detail": failure.error,
+        "recorded_at": get_current_timestamp(),
+        "run_id": run_id,
+        "part_index": part_index,
+        "error": failure.error,
+        "attempts": failure.attempts,
+    }
+
+
+def _other_bedrock_error_record(
+    failure: RecordLabelFailure, run_id: str, part_index: int
+) -> dict[str, Any]:
+    return {
+        "ts": get_current_timestamp(),
+        "run_id": run_id,
+        "part_index": part_index,
+        "source_record_id": failure.source_record_id,
+        "error": failure.error,
+        "attempts": failure.attempts,
+    }
+
+
+def _finish_bedrock_part(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    manifest: dict[str, Any],
+    manifest_etag: str,
+    spec: FeatureSpec,
+    run_id: str,
+    part_index: int,
+    chunk_ids: list[str],
+    rows_by_id: dict[str, dict],
+    spill_path: Path,
+) -> str:
+    rows = [rows_by_id[uri] for uri in chunk_ids if uri in rows_by_id]
+    if rows:
+        manifest_etag = _write_labeled_part(
+            store, paths, manifest, manifest_etag, spec, run_id, part_index, rows
+        )
+    delete_active_bedrock_state(store, paths)
+    spill_path.unlink(missing_ok=True)
+    return manifest_etag
+
+
+def _write_labeled_part(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    manifest: dict[str, Any],
+    manifest_etag: str,
+    spec: FeatureSpec,
+    run_id: str,
+    part_index: int,
+    rows: list[dict],
+) -> str:
+    result = write_batch(
+        store,
+        paths,
+        manifest,
+        manifest_etag,
+        part_index=part_index,
+        rows=rows,
+        spec=spec,
+        run_id=run_id,
+    )
+    print(
+        f"generate_features: {spec.name} part {part_index:05d} -> "
+        f"{paths.uri(result.key)} ({result.row_count} rows, sha256 {result.sha256})"
+    )
+    return result.manifest_etag
+
+
+def _load_or_start_bedrock_job(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    part_index: int,
+    chunk_ids: list[str],
+    campaign_id: str,
+    feature: str,
+    rows_by_id: dict[str, dict],
+) -> tuple[dict[str, Any], str]:
+    remote, etag = load_active_bedrock_state(store, paths)
+    if remote is not None:
+        _require_matching_bedrock_part(remote, part_index, paths)
+        return remote, etag or ""
+    job = _new_bedrock_job(part_index, chunk_ids, campaign_id, feature, rows_by_id)
+    return job, save_active_bedrock_state(store, paths, job, None)
+
+
+def _require_matching_bedrock_part(
+    remote: dict[str, Any], part_index: int, paths: FeaturePaths
+) -> None:
+    if int(remote["logical_batch_index"]) != part_index:
+        raise ValueError(
+            f"active Bedrock job at {paths.uri(paths.active_bedrock_state_key)} "
+            f"is for part {remote['logical_batch_index']}, expected {part_index}"
+        )
+
+
+def _new_bedrock_job(
+    part_index: int,
+    chunk_ids: list[str],
+    campaign_id: str,
+    feature: str,
+    rows_by_id: dict[str, dict],
+) -> dict[str, Any]:
+    completed = [uri for uri in chunk_ids if uri in rows_by_id]
+    pending = [uri for uri in chunk_ids if uri not in rows_by_id]
+    return {
+        "logical_batch_index": part_index,
+        "pending_source_record_ids": pending,
+        "completed_source_record_ids": completed,
+        "state": BEDROCK_JOB_STATE_RUNNING,
+        "job_id": _bedrock_job_id(campaign_id, feature, part_index),
+        "campaign_id": campaign_id,
+    }
+
+
+def _bedrock_job_id(campaign_id: str, feature: str, part_index: int) -> str:
+    return f"bedrock-{campaign_id}-{feature}-part-{part_index:05d}"
+
+
+def _persist_bedrock_job(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    job: dict[str, Any],
+    job_etag: str,
+    chunk_ids: list[str],
+    rows_by_id: dict[str, dict],
+) -> tuple[dict[str, Any], str]:
+    updated = {
+        **job,
+        "pending_source_record_ids": [uri for uri in chunk_ids if uri not in rows_by_id],
+        "completed_source_record_ids": [uri for uri in chunk_ids if uri in rows_by_id],
+        "state": BEDROCK_JOB_STATE_WRITING,
+    }
+    return updated, save_active_bedrock_state(store, paths, updated, job_etag)
+
+
+def _retry_content_filters_with_openai(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    manifest: dict[str, Any],
+    manifest_etag: str,
+    spec: FeatureSpec,
+    campaign: CampaignRunConfig,
+    texts: dict[str, str],
+    run_id: str,
+    run_config: FeatureRunConfig,
+) -> str:
+    retry_ids = _pending_content_filter_ids(store, paths, labeled_ids(store, manifest))
+    if not retry_ids:
+        return manifest_etag
+    engine, mirror, run_dir = _openai_retry_engine(store, paths, spec, campaign, run_config)
+    prelabeled = _smoke_rows_by_id(store, paths, spec, run_id)
+    before_parts = {int(entry["part_index"]) for entry in manifest["batches"]}
+    manifest_etag = _write_openai_retry_parts(
+        engine,
+        mirror,
+        store,
+        paths,
+        manifest,
+        manifest_etag,
+        spec,
+        campaign,
+        texts,
+        run_id,
+        run_dir,
+        retry_ids,
+        prelabeled,
+    )
+    return _save_openai_retry_metadata(store, paths, manifest, manifest_etag, retry_ids, before_parts)
+
+
+def _openai_retry_engine(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    spec: FeatureSpec,
+    campaign: CampaignRunConfig,
+    run_config: FeatureRunConfig,
+) -> tuple[OpenAIBatchEngine, ActiveStateMirror, Path]:
+    run_dir = _campaign_local_run_dir(paths)
+    mirror = ActiveStateMirror(
+        store, paths, run_dir=run_dir, feature_name=spec.name, campaign_id=campaign.campaign_id
+    )
+    engine = OpenAIBatchEngine(
+        spec, run_config, create_openai_client(), DEFAULT_OPENAI_BATCH_ENGINE_CONFIG, mirror.sleep
+    )
+    return engine, mirror, run_dir
+
+
+def _write_openai_retry_parts(
+    engine: OpenAIBatchEngine,
+    mirror: ActiveStateMirror,
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    manifest: dict[str, Any],
+    manifest_etag: str,
+    spec: FeatureSpec,
+    campaign: CampaignRunConfig,
+    texts: dict[str, str],
+    run_id: str,
+    run_dir: Path,
+    retry_ids: list[str],
+    prelabeled: dict[str, dict],
+) -> str:
+    part_index = _next_part_index(manifest)
+    for chunk_ids in _chunks(retry_ids, campaign.batch_size):
+        manifest_etag = _label_campaign_chunk(
+            engine,
+            mirror,
+            store,
+            paths,
+            manifest,
+            manifest_etag,
+            spec=spec,
+            run_id=run_id,
+            run_dir=run_dir,
+            part_index=part_index,
+            chunk_ids=chunk_ids,
+            texts=texts,
+            prelabeled=prelabeled,
+        )
+        delete_active_state(store, paths)
+        part_index = _next_part_index(manifest)
+    return manifest_etag
+
+
+def _pending_content_filter_ids(
+    store: CampaignObjectStore, paths: FeaturePaths, already_labeled: set[str]
+) -> list[str]:
+    pending: list[str] = []
+    seen: set[str] = set()
+    for record in _error_records(store, paths):
+        uri = str(record.get("source_record_id", ""))
+        if record.get("reason") != CONTENT_FILTER_REASON or uri in already_labeled or uri in seen:
+            continue
+        seen.add(uri)
+        pending.append(uri)
+    return pending
+
+
+def _error_records(store: CampaignObjectStore, paths: FeaturePaths) -> list[dict[str, Any]]:
+    stored = store.get(paths.errors_key)
+    if stored is None:
+        return []
+    return [json.loads(line) for line in stored.body.decode("utf-8").splitlines() if line]
+
+
+def _next_part_index(manifest: dict[str, Any]) -> int:
+    if not manifest["batches"]:
+        return 0
+    return max(int(entry["part_index"]) for entry in manifest["batches"]) + 1
+
+
+def _save_openai_retry_metadata(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    manifest: dict[str, Any],
+    manifest_etag: str,
+    retry_ids: list[str],
+    before_parts: set[int],
+) -> str:
+    provider_batch_ids: list[str] = []
+    for entry in manifest["batches"]:
+        if int(entry["part_index"]) in before_parts:
+            continue
+        provider_batch_ids.extend(str(batch_id) for batch_id in entry["provider_batch_ids"])
+    manifest["openai_content_filter_retry"] = {
+        "count": len(retry_ids),
+        "model_id": DEFAULT_LLM_MODEL,
+        "provider_batch_ids": provider_batch_ids,
+    }
+    return save_manifest(store, paths, manifest, manifest_etag)
+
+
+def _consolidate_bedrock_final(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    manifest: dict[str, Any],
+    manifest_etag: str,
+    spec: FeatureSpec,
+    ordered_ids: list[str],
+    run_id: str,
+) -> None:
+    final_etag = consolidate_final(
+        store,
+        paths,
+        manifest,
+        manifest_etag,
+        expected_ids=ordered_ids,
+        failed_ids=read_failed_ids(store, paths),
+        spec=spec,
+        run_id=run_id,
+    )
+    if final_etag is None:
+        return
+    final = manifest["final_parquet"]
+    print(
+        f"generate_features: {spec.name} -> {paths.uri(paths.final_key)} "
+        f"({final['row_count']} rows, {final['failed_row_count']} permanently failed ids excluded)"
+    )

--- a/data_platform/generate_features/engines/bedrock_campaign.py
+++ b/data_platform/generate_features/engines/bedrock_campaign.py
@@ -141,6 +141,7 @@ def _label_bedrock_parts(
     run_id: str,
 ) -> str:
     written_parts = {int(entry["part_index"]) for entry in manifest["batches"]}
+    prelabeled = _smoke_rows_by_id(store, paths, spec, run_id)
     for part_index, chunk_ids in enumerate(_chunks(ordered_ids, campaign.batch_size)):
         if part_index in written_parts:
             _delete_active_bedrock_job_if_part_in(store, paths, written_parts)
@@ -154,7 +155,17 @@ def _label_bedrock_parts(
             _delete_active_bedrock_job_if_part_in(store, paths, {part_index})
             continue
         manifest_etag = _label_bedrock_part(
-            store, paths, manifest, manifest_etag, spec, campaign, part_index, chunk_ids, texts, run_id
+            store,
+            paths,
+            manifest,
+            manifest_etag,
+            spec,
+            campaign,
+            part_index,
+            chunk_ids,
+            texts,
+            run_id,
+            prelabeled,
         )
         written_parts.add(part_index)
     return manifest_etag
@@ -171,10 +182,12 @@ def _label_bedrock_part(
     chunk_ids: list[str],
     texts: dict[str, str],
     run_id: str,
+    prelabeled: dict[str, dict],
 ) -> str:
     run_dir = _campaign_local_run_dir(paths)
     spill_path = _spill_path(run_dir, spec.name, part_index)
     rows_by_id = _load_spilled_rows(spill_path)
+    rows_by_id.update({uri: prelabeled[uri] for uri in chunk_ids if uri in prelabeled})
     job, job_etag = _load_or_start_bedrock_job(
         store, paths, part_index, chunk_ids, campaign.campaign_id, spec.name, rows_by_id
     )

--- a/data_platform/generate_features/engines/bedrock_campaign.py
+++ b/data_platform/generate_features/engines/bedrock_campaign.py
@@ -156,6 +156,7 @@ def _label_bedrock_parts(
         manifest_etag = _label_bedrock_part(
             store, paths, manifest, manifest_etag, spec, campaign, part_index, chunk_ids, texts, run_id
         )
+        written_parts.add(part_index)
     return manifest_etag
 
 
@@ -327,9 +328,67 @@ def _finish_bedrock_part(
         manifest_etag = _write_labeled_part(
             store, paths, manifest, manifest_etag, spec, run_id, part_index, rows
         )
-    _delete_active_bedrock_job_if_part_in(store, paths, {part_index})
+    else:
+        manifest_etag = _record_empty_bedrock_part(
+            store, paths, manifest, manifest_etag, spec, part_index
+        )
+    recorded_parts = {int(entry["part_index"]) for entry in manifest["batches"]}
+    _delete_active_bedrock_job_if_part_in(store, paths, recorded_parts)
     spill_path.unlink(missing_ok=True)
     return manifest_etag
+
+
+def _record_empty_bedrock_part(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    manifest: dict[str, Any],
+    manifest_etag: str,
+    spec: FeatureSpec,
+    part_index: int,
+) -> str:
+    """Record a zero-row part in the manifest without writing parquet.
+
+    ``write_batch`` refuses empty rows, so an all-failure part has no object.
+    The manifest entry is the durable skip marker: ``_label_bedrock_parts``
+    treats ``part_index`` as already recorded. Call this before deleting
+    ``active_bedrock_job.json``.
+
+    Parameters
+    ----------
+    store
+        Campaign object store for this feature prefix.
+    paths
+        Feature prefix that holds ``manifest.json``.
+    manifest
+        In-memory manifest mutated in place.
+    manifest_etag
+        ETag of the current ``manifest.json`` object.
+    spec
+        Feature being labeled, used only in the stdout line.
+    part_index
+        Chunk index that produced no labeled rows.
+
+    Returns
+    -------
+    str
+        The new manifest ETag.
+    """
+    if part_index in {int(entry["part_index"]) for entry in manifest["batches"]}:
+        return manifest_etag
+    manifest["batches"].append(
+        {
+            "part_index": part_index,
+            "row_count": 0,
+            "provider_batch_ids": [],
+        }
+    )
+    manifest["batches"].sort(key=lambda entry: entry["part_index"])
+    new_etag = save_manifest(store, paths, manifest, manifest_etag)
+    print(
+        f"generate_features: {spec.name} part {part_index:05d} -> "
+        "0 rows (all records failed; no parquet)"
+    )
+    return new_etag
 
 
 def _write_labeled_part(

--- a/data_platform/generate_features/engines/bedrock_campaign.py
+++ b/data_platform/generate_features/engines/bedrock_campaign.py
@@ -464,25 +464,68 @@ def _write_openai_retry_parts(
     retry_ids: list[str],
     prelabeled: dict[str, dict],
 ) -> str:
-    part_index = _next_part_index(manifest)
-    for chunk_ids in _chunks(retry_ids, campaign.batch_size):
-        manifest_etag = _label_campaign_chunk(
+    remaining = list(retry_ids)
+    while remaining:
+        part_index = _next_part_index(manifest)
+        adopted = adopt_unrecorded_batch(
+            store, paths, manifest, manifest_etag, part_index=part_index, run_id=run_id
+        )
+        if adopted is not None:
+            manifest_etag = adopted.manifest_etag
+            labeled = labeled_ids(store, manifest)
+            remaining = [uri for uri in remaining if uri not in labeled]
+            continue
+        chunk_ids = remaining[: campaign.batch_size]
+        remaining = remaining[campaign.batch_size :]
+        manifest_etag = _label_one_openai_retry_chunk(
             engine,
             mirror,
             store,
             paths,
             manifest,
             manifest_etag,
-            spec=spec,
-            run_id=run_id,
-            run_dir=run_dir,
-            part_index=part_index,
-            chunk_ids=chunk_ids,
-            texts=texts,
-            prelabeled=prelabeled,
+            spec,
+            texts,
+            run_id,
+            run_dir,
+            part_index,
+            chunk_ids,
+            prelabeled,
         )
-        delete_active_state(store, paths)
-        part_index = _next_part_index(manifest)
+    return manifest_etag
+
+
+def _label_one_openai_retry_chunk(
+    engine: OpenAIBatchEngine,
+    mirror: ActiveStateMirror,
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    manifest: dict[str, Any],
+    manifest_etag: str,
+    spec: FeatureSpec,
+    texts: dict[str, str],
+    run_id: str,
+    run_dir: Path,
+    part_index: int,
+    chunk_ids: list[str],
+    prelabeled: dict[str, dict],
+) -> str:
+    manifest_etag = _label_campaign_chunk(
+        engine,
+        mirror,
+        store,
+        paths,
+        manifest,
+        manifest_etag,
+        spec=spec,
+        run_id=run_id,
+        run_dir=run_dir,
+        part_index=part_index,
+        chunk_ids=chunk_ids,
+        texts=texts,
+        prelabeled=prelabeled,
+    )
+    delete_active_state(store, paths)
     return manifest_etag
 
 

--- a/data_platform/generate_features/engines/bedrock_engine.py
+++ b/data_platform/generate_features/engines/bedrock_engine.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, ValidationError
 
 from data_platform.generate_features.engines.base import (
     BaseBatchExecutionEngine,
+    RecordLabelFailure,
     row_with_label_timestamp,
 )
 from data_platform.generate_features.models import FeatureRunConfig, FeatureSpec, LabelTask
@@ -30,11 +31,7 @@ from lib.timestamp_utils import get_current_timestamp
 
 BEDROCK_MAX_TOKENS = 32
 BEDROCK_TEMPERATURE = 0.0
-BEDROCK_JSON_INSTRUCTION = (
-    "Reply with a single JSON object only. "
-    "The object must have one string field named category "
-    "whose value is news, opinion, or neither."
-)
+JSON_INSTRUCTION_PREFIX = "Reply with a single JSON object only. The object must have these fields: "
 JSON_FENCE = "```"
 JSON_FENCE_LANGUAGE = "json"
 MIN_THREAD_WORKERS = 1
@@ -42,7 +39,7 @@ CONVERSE_RETRY_ATTEMPTS = 8
 CONVERSE_RETRY_SLEEP_SECONDS = 1.0
 NEWS_OPINION_CATEGORIES = frozenset({"news", "opinion", "neither"})
 CONTENT_FILTER_MARKER = "blocked by our content filters"
-FILTERED_CATEGORY = "neither"
+CONTENT_FILTER_STOP_REASONS = frozenset({"content_filtered", "guardrail_intervened"})
 RETRYABLE_CONVERSE_ERRORS = (
     json.JSONDecodeError,
     ValueError,
@@ -55,6 +52,14 @@ class BedrockRuntimeClient(Protocol):
     """Subset of the Bedrock Runtime client used by the Converse engine."""
 
     def converse(self, **kwargs: Any) -> dict[str, Any]: ...
+
+
+class BedrockContentFilterError(Exception):
+    """Bedrock refused the prompt under its content filters."""
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
 
 
 @dataclass(frozen=True)
@@ -115,13 +120,33 @@ def _llm_prompt_and_schema(spec: FeatureSpec) -> tuple[str, type[BaseModel]]:
     return system_prompt, output_schema
 
 
+def json_instruction_for_schema(output_schema: type[BaseModel]) -> str:
+    """Return a JSON-only instruction derived from ``output_schema`` field names and types."""
+    schema = output_schema.model_json_schema()
+    properties = schema.get("properties") or {}
+    required = schema.get("required") or list(properties)
+    phrases = [_schema_field_phrase(name, properties.get(name) or {}) for name in required]
+    return f"{JSON_INSTRUCTION_PREFIX}{'; '.join(phrases)}."
+
+
+def _schema_field_phrase(name: str, field: dict[str, Any]) -> str:
+    type_name = str(field.get("type", "value"))
+    enum_values = field.get("enum")
+    if not enum_values:
+        return f"{name} ({type_name})"
+    allowed = ", ".join(str(value) for value in enum_values)
+    return f"{name} ({type_name}: {allowed})"
+
+
 def parse_json_object(text: str) -> dict[str, Any]:
     """Parse a JSON object from model text, ignoring optional markdown fences.
 
     A bare news, opinion, or neither word is accepted when JSON is missing.
-    A Bedrock content-filter message is stored as neither.
+    A Bedrock content-filter message raises ``BedrockContentFilterError``.
     """
     stripped = text.strip()
+    if _is_content_filter_text(stripped):
+        raise BedrockContentFilterError(stripped)
     if stripped.startswith(JSON_FENCE):
         stripped = _strip_markdown_fence(stripped)
     try:
@@ -135,12 +160,14 @@ def parse_json_object(text: str) -> dict[str, Any]:
     return payload
 
 
+def _is_content_filter_text(text: str) -> bool:
+    return CONTENT_FILTER_MARKER in text.lower()
+
+
 def _payload_from_loose_text(text: str) -> dict[str, Any] | None:
     lowered = text.strip().strip('"').lower()
     if lowered in NEWS_OPINION_CATEGORIES:
         return {"category": lowered}
-    if CONTENT_FILTER_MARKER in lowered:
-        return {"category": FILTERED_CATEGORY}
     start = text.find("{")
     end = text.rfind("}")
     if start >= 0 and end > start:
@@ -203,7 +230,7 @@ def _converse_once(
 ) -> tuple[BaseModel, BedrockUsage]:
     response = client.converse(
         modelId=model_id,
-        system=[{"text": f"{system_prompt}\n{BEDROCK_JSON_INSTRUCTION}"}],
+        system=[{"text": f"{system_prompt}\n{json_instruction_for_schema(output_schema)}"}],
         messages=[{"role": "user", "content": [{"text": user_text}]}],
         inferenceConfig={
             "maxTokens": BEDROCK_MAX_TOKENS,
@@ -217,15 +244,23 @@ def _converse_once(
 
 def _first_text_block(response: dict[str, Any]) -> str:
     content = response["output"]["message"]["content"]
+    stop_reason = str(response.get("stopReason", ""))
     for block in content:
         text = block.get("text")
         if text:
-            return str(text)
-    stop_reason = response.get("stopReason", "")
+            return _text_or_content_filter(str(text), stop_reason)
+    if stop_reason in CONTENT_FILTER_STOP_REASONS:
+        raise BedrockContentFilterError(f"stopReason={stop_reason!r}")
     raise ValueError(
         "Bedrock Converse response had no text "
         f"(stopReason={stop_reason!r}, content={content!r})"
     )
+
+
+def _text_or_content_filter(text: str, stop_reason: str) -> str:
+    if stop_reason in CONTENT_FILTER_STOP_REASONS or _is_content_filter_text(text):
+        raise BedrockContentFilterError(text)
+    return text
 
 
 def _usage_from_response(response: dict[str, Any]) -> BedrockUsage:
@@ -296,6 +331,114 @@ def _label_row_for_task(
         label_timestamp=label_timestamp,
     )
     return spec.model.model_validate(row).model_dump()
+
+
+@dataclass(frozen=True)
+class BedrockTaskOutcome:
+    """Successful label rows plus per-record failures from one Bedrock part."""
+
+    rows: list[dict]
+    content_filter_failures: list[RecordLabelFailure]
+    other_failures: list[RecordLabelFailure]
+
+
+def label_tasks_collecting_failures(
+    client: BedrockRuntimeClient,
+    model_id: str,
+    spec: FeatureSpec,
+    tasks: list[LabelTask],
+    max_concurrency: int,
+    label_timestamp: str,
+) -> BedrockTaskOutcome:
+    """Label tasks and split content-filter failures from other failures."""
+    if not tasks:
+        return BedrockTaskOutcome([], [], [])
+    system_prompt, output_schema = _llm_prompt_and_schema(spec)
+    worker_count = max(MIN_THREAD_WORKERS, min(max_concurrency, len(tasks)))
+    outcomes = _run_label_pool(
+        client,
+        model_id,
+        spec,
+        system_prompt,
+        output_schema,
+        tasks,
+        worker_count,
+        label_timestamp,
+    )
+    return _split_task_outcomes(outcomes)
+
+
+def _run_label_pool(
+    client: BedrockRuntimeClient,
+    model_id: str,
+    spec: FeatureSpec,
+    system_prompt: str,
+    output_schema: type[BaseModel],
+    tasks: list[LabelTask],
+    worker_count: int,
+    label_timestamp: str,
+) -> list[tuple[str, dict | RecordLabelFailure] | None]:
+    outcomes: list[tuple[str, dict | RecordLabelFailure] | None] = [None] * len(tasks)
+    with ThreadPoolExecutor(max_workers=worker_count) as pool:
+        futures = {
+            pool.submit(
+                _label_task_or_failure,
+                client,
+                model_id,
+                spec,
+                system_prompt,
+                output_schema,
+                task,
+                label_timestamp,
+            ): index
+            for index, task in enumerate(tasks)
+        }
+        for future in as_completed(futures):
+            outcomes[futures[future]] = future.result()
+    return outcomes
+
+
+def _label_task_or_failure(
+    client: BedrockRuntimeClient,
+    model_id: str,
+    spec: FeatureSpec,
+    system_prompt: str,
+    output_schema: type[BaseModel],
+    task: LabelTask,
+    label_timestamp: str,
+) -> tuple[str, dict | RecordLabelFailure]:
+    try:
+        parsed, _usage = converse_label(
+            client, model_id, system_prompt, output_schema, task.text
+        )
+        return ("row", _label_row_for_task(task, parsed, spec, label_timestamp))
+    except BedrockContentFilterError as error:
+        return ("content_filter", _failure_for_task(task, str(error)))
+    except Exception as error:
+        return ("other", _failure_for_task(task, str(error)))
+
+
+def _failure_for_task(task: LabelTask, error: str) -> RecordLabelFailure:
+    return RecordLabelFailure(source_record_id=task.uri, error=error, attempts=1)
+
+
+def _split_task_outcomes(
+    outcomes: list[tuple[str, dict | RecordLabelFailure] | None],
+) -> BedrockTaskOutcome:
+    rows: list[dict] = []
+    content_filter_failures: list[RecordLabelFailure] = []
+    other_failures: list[RecordLabelFailure] = []
+    for outcome in outcomes:
+        if outcome is None:
+            raise RuntimeError("Bedrock Converse did not return a result for every task")
+        kind, payload = outcome
+        if kind == "row":
+            rows.append(payload)  # type: ignore[arg-type]
+        elif kind == "content_filter":
+            content_filter_failures.append(payload)  # type: ignore[arg-type]
+        else:
+            other_failures.append(payload)  # type: ignore[arg-type]
+    return BedrockTaskOutcome(rows, content_filter_failures, other_failures)
 
 
 def create_bedrock_runtime_client() -> BedrockRuntimeClient:

--- a/data_platform/generate_features/generate_features.py
+++ b/data_platform/generate_features/generate_features.py
@@ -8,6 +8,11 @@ from pathlib import Path
 
 import pandas as pd
 
+from data_platform.generate_features.campaign_engine_map import (
+    BEDROCK_ENGINE_TYPE,
+    OPENAI_ENGINE_TYPE,
+    campaign_engine_type,
+)
 from data_platform.generate_features.engines import build_engine
 from data_platform.generate_features.engines.base import RecordLabelFailure
 from data_platform.generate_features.engines.openai_engine import (
@@ -23,8 +28,11 @@ from data_platform.generate_features.metadata import (
     load_feature_run_metadata,
     mark_feature_completed,
     mark_feature_in_progress,
+    model_id_for_campaign_engine,
+    prompt_hash,
     set_sync_status_completed,
     update_batch_counts,
+    write_campaign_local_metadata,
 )
 from data_platform.generate_features.models import (
     BatchRunStats,
@@ -79,7 +87,9 @@ MANIFEST_IDENTITY_FIELDS = (
     "batch_size",
     "expected_row_count",
     "run_id",
+    "engine_type",
 )
+ENGINE_TYPE_FIELD = "engine_type"
 
 
 def tasks_from_dataframe(
@@ -291,7 +301,41 @@ def generate_features(
 
 def _resolve_campaign_engine(campaign_id: str, feature_name: str) -> str:
     """Return the campaign engine for ``feature_name``, or raise ``ValueError``."""
-    raise NotImplementedError
+    engine_type = campaign_engine_type(campaign_id, feature_name)
+    if engine_type not in CAMPAIGN_ENGINE_TYPES:
+        raise ValueError(f"campaign mode requires engine_type in {sorted(CAMPAIGN_ENGINE_TYPES)}")
+    return engine_type
+
+
+def _campaign_feature_paths(
+    campaign: CampaignRunConfig,
+    spec: FeatureSpec,
+    paths: FeaturePaths | None,
+) -> FeaturePaths:
+    if paths is not None:
+        return paths
+    return FeaturePaths.for_campaign(
+        campaign.campaign_id,
+        spec.name,
+        platform=campaign.platform,
+        dataset_id=campaign.dataset_id,
+    )
+
+
+def _stamp_campaign_local_metadata(
+    paths: FeaturePaths,
+    campaign: CampaignRunConfig,
+    spec: FeatureSpec,
+    engine_type: str,
+) -> None:
+    write_campaign_local_metadata(
+        _campaign_local_run_dir(paths),
+        campaign.dataset_id,
+        spec.name,
+        engine_type,
+        model_id_for_campaign_engine(spec, engine_type),
+        prompt_hash(spec.system_prompt),
+    )
 
 
 def generate_campaign_feature(
@@ -319,23 +363,53 @@ def generate_campaign_feature(
     Raises
     ------
     ValueError
-        When ``spec`` is not an OpenAI feature, when ``records`` repeats an id,
-        or when an existing manifest describes a different campaign, dataset,
-        preprocessed run, model, prompt, batch size, or row count.
+        When the campaign engine is not OpenAI or Bedrock, when ``records``
+        repeats an id, or when an existing manifest describes a different
+        campaign identity.
     """
-    if spec.engine_type != CAMPAIGN_ENGINE_TYPE:
-        raise ValueError(f"campaign mode requires engine_type {CAMPAIGN_ENGINE_TYPE!r}")
-    paths = paths or FeaturePaths.for_campaign(
-        campaign.campaign_id,
-        spec.name,
-        platform=campaign.platform,
-        dataset_id=campaign.dataset_id,
+    engine_type = _resolve_campaign_engine(campaign.campaign_id, spec.name)
+    paths = _campaign_feature_paths(campaign, spec, paths)
+    _stamp_campaign_local_metadata(paths, campaign, spec, engine_type)
+    if engine_type == BEDROCK_ENGINE_TYPE:
+        return _generate_bedrock_campaign_feature(
+            records, spec, campaign, run_config, paths, engine_type
+        )
+    return _generate_openai_campaign_feature(
+        records, spec, campaign, run_config, paths, engine_type
     )
+
+
+def _generate_bedrock_campaign_feature(
+    records: pd.DataFrame,
+    spec: FeatureSpec,
+    campaign: CampaignRunConfig,
+    run_config: FeatureRunConfig,
+    paths: FeaturePaths,
+    engine_type: str,
+) -> FeaturePaths:
+    """Label a Bedrock-mapped campaign feature. Implemented in the Bedrock campaign writer."""
+    raise NotImplementedError
+
+
+def _generate_openai_campaign_feature(
+    records: pd.DataFrame,
+    spec: FeatureSpec,
+    campaign: CampaignRunConfig,
+    run_config: FeatureRunConfig,
+    paths: FeaturePaths,
+    engine_type: str,
+) -> FeaturePaths:
+    """Label an OpenAI-mapped campaign feature into immutable S3 batch objects."""
     store = CampaignObjectStore(paths.bucket)
     run_id = run_id_for_feature(campaign.campaign_id, spec.name)
     ordered_ids, texts = _ordered_campaign_input(records)
     manifest, manifest_etag = _load_or_create_manifest(
-        store, paths, campaign, spec, expected_row_count=len(ordered_ids)
+        store,
+        paths,
+        campaign,
+        spec,
+        expected_row_count=len(ordered_ids),
+        engine_type=engine_type,
     )
     if manifest.get("final_parquet"):
         print(
@@ -432,20 +506,36 @@ def _load_or_create_manifest(
     spec: FeatureSpec,
     *,
     expected_row_count: int,
+    engine_type: str,
 ) -> tuple[dict, str]:
     """Return the manifest and its ETag, creating it on the first run and checking identity on resume."""
-    fresh = new_manifest(campaign=campaign, spec=spec, expected_row_count=expected_row_count)
+    fresh = new_manifest(
+        campaign=campaign,
+        spec=spec,
+        expected_row_count=expected_row_count,
+        engine_type=engine_type,
+    )
     manifest, etag = load_manifest(store, paths)
     if manifest is None or etag is None:
         return fresh, save_manifest(store, paths, fresh, None)
-    mismatched = [
-        field for field in MANIFEST_IDENTITY_FIELDS if manifest.get(field) != fresh[field]
-    ]
+    mismatched = _manifest_identity_mismatches(manifest, fresh)
     if mismatched:
         raise ValueError(
             f"manifest at {paths.uri(paths.manifest_key)} does not match this run on {mismatched}"
         )
     return manifest, etag
+
+
+def _manifest_identity_mismatches(manifest: dict, fresh: dict) -> list[str]:
+    """Return identity fields that differ, treating a missing engine_type as openai."""
+    mismatched: list[str] = []
+    for field in MANIFEST_IDENTITY_FIELDS:
+        existing = manifest.get(field)
+        if field == ENGINE_TYPE_FIELD and existing is None:
+            existing = OPENAI_ENGINE_TYPE
+        if existing != fresh[field]:
+            mismatched.append(field)
+    return mismatched
 
 
 def _smoke_rows_by_id(

--- a/data_platform/generate_features/generate_features.py
+++ b/data_platform/generate_features/generate_features.py
@@ -67,6 +67,7 @@ from data_platform.utils.storage import DATA_ROOT, StorageManager, StorageStage
 from lib.timestamp_utils import get_current_timestamp
 
 CAMPAIGN_ENGINE_TYPE = "openai"
+CAMPAIGN_ENGINE_TYPES = frozenset({"openai", "bedrock"})
 # Manifest fields that must match between a resumed run and the command line.
 MANIFEST_IDENTITY_FIELDS = (
     "campaign_id",
@@ -286,6 +287,11 @@ def generate_features(
 
     print(f"generate_features: finished {len(written)} features under {config.features_dir}")
     return written
+
+
+def _resolve_campaign_engine(campaign_id: str, feature_name: str) -> str:
+    """Return the campaign engine for ``feature_name``, or raise ``ValueError``."""
+    raise NotImplementedError
 
 
 def generate_campaign_feature(

--- a/data_platform/generate_features/generate_features.py
+++ b/data_platform/generate_features/generate_features.py
@@ -387,8 +387,14 @@ def _generate_bedrock_campaign_feature(
     paths: FeaturePaths,
     engine_type: str,
 ) -> FeaturePaths:
-    """Label a Bedrock-mapped campaign feature. Implemented in the Bedrock campaign writer."""
-    raise NotImplementedError
+    """Label a Bedrock-mapped campaign feature into immutable S3 batch objects."""
+    from data_platform.generate_features.engines.bedrock_campaign import (
+        run_bedrock_campaign_feature,
+    )
+
+    return run_bedrock_campaign_feature(
+        records, spec, campaign, run_config, paths, engine_type
+    )
 
 
 def _generate_openai_campaign_feature(

--- a/data_platform/generate_features/generate_reddit_features.py
+++ b/data_platform/generate_features/generate_reddit_features.py
@@ -7,6 +7,15 @@ Run from the repo root:
 
     PYTHONPATH=. uv run python data_platform/generate_features/generate_reddit_features.py \\
         --dataset-id reddit_<uuid> --checkpoint 2026_05_30-12:00:00
+
+Campaign mode writes immutable 2,000-row batch objects to S3 and resumes from
+that prefix on restart:
+
+    PYTHONPATH=. uv run python data_platform/generate_features/generate_reddit_features.py \\
+        --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079 \\
+        --preprocessed-run 2026_09_03-23:39:28 \\
+        --campaign-id reddit_2026_09_03_233928_llm_features_v1 \\
+        --features is_political --batch-size 2000
 """
 
 from __future__ import annotations
@@ -88,7 +97,26 @@ def generate_reddit_features(
         Feature name to the label file written in the feature run folder, or
         to the S3 feature prefix URI in campaign mode.
     """
-    raise NotImplementedError
+    if campaign_id is not None or preprocessed_run is not None:
+        feature_names = feature_subset or []
+        prefix_uri = generate_platform_campaign_feature(
+            REDDIT_SPEC,
+            dataset_id,
+            campaign_id=campaign_id,
+            preprocessed_run=preprocessed_run,
+            feature_subset=feature_subset,
+            batch_size=batch_size,
+            checkpoint=checkpoint,
+        )
+        return {feature_names[0]: prefix_uri}
+    return generate_platform_features(
+        REDDIT_SPEC,
+        dataset_id,
+        batch_size=batch_size,
+        max_concurrency=max_concurrency,
+        feature_subset=feature_subset,
+        checkpoint=checkpoint,
+    )
 
 
 if __name__ == "__main__":

--- a/data_platform/generate_features/generate_reddit_features.py
+++ b/data_platform/generate_features/generate_reddit_features.py
@@ -20,6 +20,7 @@ from data_platform.generate_features.platform_cli import (
     build_feature_cli_app,
     build_feature_cli_main,
     build_feature_config,
+    generate_platform_campaign_feature,
     generate_platform_features,
     load_preprocessed_records,
 )
@@ -55,36 +56,39 @@ def generate_reddit_features(
     max_concurrency: int = 80,
     feature_subset: list[str] | None = None,
     checkpoint: str | None = None,
-) -> dict[str, Path]:
-    """Generate Reddit feature labels in a new or unfinished feature run.
+    campaign_id: str | None = None,
+    preprocessed_run: str | None = None,
+) -> dict[str, Path | str]:
+    """Generate Reddit feature labels in a new or unfinished feature run, or in S3 campaign mode.
 
     Parameters
     ----------
     dataset_id
         Dataset identifier from ingestion YAML.
     batch_size
-        Label batch size.
+        Label batch size. Campaign mode requires 2000.
     max_concurrency
         Engine concurrency cap.
     feature_subset
-        Optional registry subset. None runs every feature.
+        Optional registry subset. None runs every feature. Campaign mode
+        requires exactly one feature.
     checkpoint
         Named unfinished feature run timestamp. Pass None to start a new
-        feature run.
+        feature run. Not allowed in campaign mode.
+    campaign_id
+        S3 campaign id. Pass together with ``preprocessed_run`` to write
+        immutable batch objects under the campaign feature prefix and resume
+        from that prefix.
+    preprocessed_run
+        Preprocessed run timestamp that campaign mode labels.
 
     Returns
     -------
-    dict[str, Path]
-        Feature name to the label file written in the feature run folder.
+    dict[str, Path | str]
+        Feature name to the label file written in the feature run folder, or
+        to the S3 feature prefix URI in campaign mode.
     """
-    return generate_platform_features(
-        REDDIT_SPEC,
-        dataset_id,
-        batch_size=batch_size,
-        max_concurrency=max_concurrency,
-        feature_subset=feature_subset,
-        checkpoint=checkpoint,
-    )
+    raise NotImplementedError
 
 
 if __name__ == "__main__":

--- a/data_platform/generate_features/metadata.py
+++ b/data_platform/generate_features/metadata.py
@@ -69,6 +69,52 @@ def model_id_for_spec(spec: FeatureSpec) -> str:
     return DEFAULT_LLM_MODEL
 
 
+def model_id_for_campaign_engine(spec: FeatureSpec, engine_type: str) -> str:
+    """Return the provider model id for a campaign engine override.
+
+    Parameters
+    ----------
+    spec
+        Registry feature spec. Prompt identity still comes from this spec.
+    engine_type
+        Campaign engine, ``openai`` or ``bedrock``.
+
+    Returns
+    -------
+    str
+        Nova Micro when the campaign engine is Bedrock, otherwise the spec model.
+    """
+    raise NotImplementedError
+
+
+def write_campaign_local_metadata(
+    run_dir: Path,
+    dataset_id: str,
+    feature_name: str,
+    engine_type: str,
+    model_id: str,
+    hashed_prompt: str | None,
+) -> None:
+    """Write ``metadata.json`` for one campaign feature, including ``engine_type``.
+
+    Parameters
+    ----------
+    run_dir
+        Local directory that mirrors the S3 feature prefix.
+    dataset_id
+        Dataset id recorded on the document.
+    feature_name
+        Registry feature name.
+    engine_type
+        Campaign engine recorded on the feature entry.
+    model_id
+        Provider model id recorded on the feature entry.
+    hashed_prompt
+        SHA-256 of the system prompt, or None when the spec has no prompt.
+    """
+    raise NotImplementedError
+
+
 def _stamp_or_check_identity(
     metadata: FeatureRunMetadata,
     config: FeatureGenerationConfig,

--- a/data_platform/generate_features/metadata.py
+++ b/data_platform/generate_features/metadata.py
@@ -84,7 +84,29 @@ def model_id_for_campaign_engine(spec: FeatureSpec, engine_type: str) -> str:
     str
         Nova Micro when the campaign engine is Bedrock, otherwise the spec model.
     """
-    raise NotImplementedError
+    if engine_type == "bedrock":
+        return DEFAULT_BEDROCK_NOVA_MICRO
+    return model_id_for_spec(spec)
+
+
+def _campaign_metadata_document(
+    dataset_id: str,
+    feature_name: str,
+    engine_type: str,
+    model_id: str,
+    hashed_prompt: str | None,
+) -> dict:
+    return {
+        "dataset_id": dataset_id,
+        "features": {
+            feature_name: {
+                "engine_type": engine_type,
+                "model_id": model_id,
+                "prompt_hash": hashed_prompt,
+            }
+        },
+        "updated_at": get_current_timestamp(),
+    }
 
 
 def write_campaign_local_metadata(
@@ -112,7 +134,15 @@ def write_campaign_local_metadata(
     hashed_prompt
         SHA-256 of the system prompt, or None when the spec has no prompt.
     """
-    raise NotImplementedError
+    run_dir.mkdir(parents=True, exist_ok=True)
+    path = metadata_path(run_dir)
+    tmp_path = run_dir / f"{METADATA_FILENAME}.tmp"
+    document = _campaign_metadata_document(
+        dataset_id, feature_name, engine_type, model_id, hashed_prompt
+    )
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(document, handle, indent=2)
+    tmp_path.replace(path)
 
 
 def _stamp_or_check_identity(

--- a/data_platform/generate_features/platform_cli.py
+++ b/data_platform/generate_features/platform_cli.py
@@ -56,7 +56,10 @@ CAMPAIGN_FLAGS_TOGETHER_ERROR = "--campaign-id and --preprocessed-run must be pa
 CAMPAIGN_CHECKPOINT_ERROR = "--checkpoint cannot be combined with --campaign-id"
 CAMPAIGN_BATCH_SIZE_ERROR = f"campaign mode requires --batch-size {CAMPAIGN_BATCH_SIZE}"
 CAMPAIGN_SINGLE_FEATURE_ERROR = "campaign mode requires exactly one --features value"
-CAMPAIGN_ENGINE_ERROR = "campaign mode requires a feature with engine_type 'openai'"
+CAMPAIGN_ENGINE_ERROR = (
+    "campaign mode requires a feature with engine_type 'openai' or 'bedrock'"
+)
+CAMPAIGN_ENGINE_TYPES = frozenset({"openai", "bedrock"})
 PREPROCESSED_RUN_NAME_ERROR = "preprocessed-run must be a single run directory name"
 
 

--- a/data_platform/generate_features/platform_cli.py
+++ b/data_platform/generate_features/platform_cli.py
@@ -16,6 +16,7 @@ import pandas as pd
 import typer
 from pydantic import BaseModel
 
+from data_platform.generate_features.campaign_engine_map import campaign_engine_type
 from data_platform.generate_features.generate_features import (
     FeatureGenerationConfig,
     generate_campaign_feature,
@@ -460,9 +461,17 @@ def _require_campaign_flags(
     if not feature_subset or len(feature_subset) != 1:
         raise ValueError(CAMPAIGN_SINGLE_FEATURE_ERROR)
     (feature_name,) = generate_feature_subset(feature_subset) or ()
-    if FEATURE_REGISTRY[feature_name].engine_type != "openai":
-        raise ValueError(CAMPAIGN_ENGINE_ERROR)
+    _require_campaign_engine(campaign_id, feature_name)
     return campaign_id, preprocessed_run, feature_name
+
+
+def _require_campaign_engine(campaign_id: str, feature_name: str) -> None:
+    """Raise ``ValueError`` when the campaign feature is not OpenAI or Bedrock."""
+    if FEATURE_REGISTRY[feature_name].engine_type == "thread_pool":
+        raise ValueError(CAMPAIGN_ENGINE_ERROR)
+    engine_type = campaign_engine_type(campaign_id, feature_name)
+    if engine_type not in CAMPAIGN_ENGINE_TYPES:
+        raise ValueError(CAMPAIGN_ENGINE_ERROR)
 
 
 def generate_platform_campaign_feature(
@@ -484,7 +493,8 @@ def generate_platform_campaign_feature(
     ValueError
         When only one of ``campaign_id`` and ``preprocessed_run`` is given, when
         ``checkpoint`` is given, when ``batch_size`` is not 2000, or when
-        ``feature_subset`` does not name exactly one OpenAI feature.
+        ``feature_subset`` does not name exactly one OpenAI or Bedrock campaign
+        feature.
     FileNotFoundError
         When the named preprocessed run has no records file.
     """

--- a/data_platform/generate_features/s3_feature_batches.py
+++ b/data_platform/generate_features/s3_feature_batches.py
@@ -306,7 +306,10 @@ def adopt_unrecorded_batch(
 
 
 def read_batches(store: CampaignObjectStore, manifest: dict[str, Any]) -> list[pd.DataFrame]:
-    """Download every manifest batch in part order, verifying each SHA-256.
+    """Download every labeled manifest batch in part order, verifying each SHA-256.
+
+    Entries with ``row_count`` 0 are completion markers for parts that produced
+    no labeled rows. They have no parquet object and are skipped.
 
     Raises
     ------
@@ -317,6 +320,8 @@ def read_batches(store: CampaignObjectStore, manifest: dict[str, Any]) -> list[p
     """
     frames: list[pd.DataFrame] = []
     for entry in sorted(manifest["batches"], key=lambda item: item["part_index"]):
+        if int(entry["row_count"]) == 0:
+            continue
         stored = store.get(entry["key"])
         if stored is None:
             raise FileNotFoundError(f"manifest batch object is missing: {entry['key']}")

--- a/data_platform/generate_features/s3_feature_campaign.py
+++ b/data_platform/generate_features/s3_feature_campaign.py
@@ -148,7 +148,13 @@ class FeaturePaths:
         dataset_id: str = DEFAULT_CAMPAIGN_DATASET_ID,
     ) -> FeaturePaths:
         """Alias of ``for_campaign``. Restores the older caller name."""
-        raise NotImplementedError
+        return cls.for_campaign(
+            campaign_id,
+            feature,
+            bucket=bucket,
+            platform=platform,
+            dataset_id=dataset_id,
+        )
 
     @classmethod
     def from_root_uri(cls, root_uri: str, feature: str) -> FeaturePaths:
@@ -165,7 +171,7 @@ class FeaturePaths:
     @property
     def active_bedrock_state_key(self) -> str:
         """Object key of ``active_bedrock_job.json`` under this feature prefix."""
-        raise NotImplementedError
+        return f"{self.prefix}{ACTIVE_BEDROCK_STATE_FILENAME}"
 
     @property
     def manifest_key(self) -> str:
@@ -459,7 +465,7 @@ def load_active_bedrock_state(
     store: CampaignObjectStore, paths: FeaturePaths
 ) -> tuple[dict[str, Any] | None, str | None]:
     """Return ``(state, etag)`` of ``active_bedrock_job.json``, or ``(None, None)`` when no job is open."""
-    raise NotImplementedError
+    return _load_json(store, paths.active_bedrock_state_key)
 
 
 def save_active_bedrock_state(
@@ -469,12 +475,12 @@ def save_active_bedrock_state(
     etag: str | None,
 ) -> str:
     """Conditionally replace ``active_bedrock_job.json`` and return its new ETag."""
-    raise NotImplementedError
+    return store.replace(paths.active_bedrock_state_key, _json_bytes(state), etag=etag).etag
 
 
 def delete_active_bedrock_state(store: CampaignObjectStore, paths: FeaturePaths) -> None:
     """Remove ``active_bedrock_job.json`` once its part has a durable batch object."""
-    raise NotImplementedError
+    store.delete(paths.active_bedrock_state_key)
 
 
 def manifest_sha256(manifest: dict[str, Any]) -> str:

--- a/data_platform/generate_features/s3_feature_campaign.py
+++ b/data_platform/generate_features/s3_feature_campaign.py
@@ -18,7 +18,11 @@ from urllib.parse import urlencode
 import boto3
 from botocore.exceptions import ClientError
 
-from data_platform.generate_features.metadata import model_id_for_spec, prompt_hash
+from data_platform.generate_features.campaign_engine_map import OPENAI_ENGINE_TYPE
+from data_platform.generate_features.metadata import (
+    model_id_for_campaign_engine,
+    prompt_hash,
+)
 from data_platform.generate_features.models import CampaignRunConfig, FeatureSpec
 from data_platform.generate_features.openai_batch_state import (
     load_active_batch_state,
@@ -397,7 +401,7 @@ def new_manifest(
     campaign: CampaignRunConfig,
     spec: FeatureSpec,
     expected_row_count: int,
-    engine_type: str = "openai",
+    engine_type: str = OPENAI_ENGINE_TYPE,
 ) -> dict[str, Any]:
     """Return a manifest with the campaign identity, an empty batch list, and no final file."""
     return {
@@ -405,11 +409,12 @@ def new_manifest(
         "dataset_id": campaign.dataset_id,
         "preprocessed_run": campaign.preprocessed_run,
         "feature": spec.name,
-        "model_id": model_id_for_spec(spec),
+        "model_id": model_id_for_campaign_engine(spec, engine_type),
         "prompt_hash": prompt_hash(spec.system_prompt),
         "batch_size": campaign.batch_size,
         "expected_row_count": expected_row_count,
         "run_id": run_id_for_feature(campaign.campaign_id, spec.name),
+        "engine_type": engine_type,
         "created_at": get_current_timestamp(),
         "batches": [],
         "final_parquet": None,

--- a/data_platform/generate_features/s3_feature_campaign.py
+++ b/data_platform/generate_features/s3_feature_campaign.py
@@ -151,7 +151,11 @@ class FeaturePaths:
         platform: str = DEFAULT_CAMPAIGN_PLATFORM,
         dataset_id: str = DEFAULT_CAMPAIGN_DATASET_ID,
     ) -> FeaturePaths:
-        """Alias of ``for_campaign``. Restores the older caller name."""
+        """Alias of ``for_campaign``. Restores the older caller name.
+
+        Callers that serve Reddit must pass ``platform`` and ``dataset_id``.
+        Omitting them keeps the historical Bluesky defaults.
+        """
         return cls.for_campaign(
             campaign_id,
             feature,

--- a/data_platform/generate_features/s3_feature_campaign.py
+++ b/data_platform/generate_features/s3_feature_campaign.py
@@ -391,6 +391,7 @@ def new_manifest(
     campaign: CampaignRunConfig,
     spec: FeatureSpec,
     expected_row_count: int,
+    engine_type: str = "openai",
 ) -> dict[str, Any]:
     """Return a manifest with the campaign identity, an empty batch list, and no final file."""
     return {
@@ -452,6 +453,28 @@ def save_active_state(
 def delete_active_state(store: CampaignObjectStore, paths: FeaturePaths) -> None:
     """Remove the S3 active state once its chunk has a durable batch object."""
     store.delete(paths.active_state_key)
+
+
+def load_active_bedrock_state(
+    store: CampaignObjectStore, paths: FeaturePaths
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Return ``(state, etag)`` of ``active_bedrock_job.json``, or ``(None, None)`` when no job is open."""
+    raise NotImplementedError
+
+
+def save_active_bedrock_state(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    state: dict[str, Any],
+    etag: str | None,
+) -> str:
+    """Conditionally replace ``active_bedrock_job.json`` and return its new ETag."""
+    raise NotImplementedError
+
+
+def delete_active_bedrock_state(store: CampaignObjectStore, paths: FeaturePaths) -> None:
+    """Remove ``active_bedrock_job.json`` once its part has a durable batch object."""
+    raise NotImplementedError
 
 
 def manifest_sha256(manifest: dict[str, Any]) -> str:

--- a/data_platform/generate_features/s3_feature_campaign.py
+++ b/data_platform/generate_features/s3_feature_campaign.py
@@ -39,6 +39,7 @@ DEFAULT_CAMPAIGN_PLATFORM = "bluesky"
 DEFAULT_CAMPAIGN_DATASET_ID = "bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73"
 INTERMEDIATE_ARTIFACT_TAG = {"intermediate-artifact": "true"}
 ACTIVE_STATE_FILENAME = "active_openai_batch.json"
+ACTIVE_BEDROCK_STATE_FILENAME = "active_bedrock_job.json"
 MANIFEST_FILENAME = "manifest.json"
 PROGRESS_FILENAME = "progress.jsonl"
 ERRORS_FILENAME = "errors.jsonl"
@@ -137,6 +138,19 @@ class FeaturePaths:
         )
 
     @classmethod
+    def canonical(
+        cls,
+        campaign_id: str,
+        feature: str,
+        *,
+        bucket: str | None = None,
+        platform: str = DEFAULT_CAMPAIGN_PLATFORM,
+        dataset_id: str = DEFAULT_CAMPAIGN_DATASET_ID,
+    ) -> FeaturePaths:
+        """Alias of ``for_campaign``. Restores the older caller name."""
+        raise NotImplementedError
+
+    @classmethod
     def from_root_uri(cls, root_uri: str, feature: str) -> FeaturePaths:
         """Paths under an arbitrary ``s3://bucket/prefix/`` root, used by the smoke helper."""
         bucket, root_key = parse_s3_uri(root_uri)
@@ -147,6 +161,11 @@ class FeaturePaths:
     @property
     def active_state_key(self) -> str:
         return f"{self.prefix}{ACTIVE_STATE_FILENAME}"
+
+    @property
+    def active_bedrock_state_key(self) -> str:
+        """Object key of ``active_bedrock_job.json`` under this feature prefix."""
+        raise NotImplementedError
 
     @property
     def manifest_key(self) -> str:

--- a/data_platform/generate_features/smoke_bluesky_campaign.py
+++ b/data_platform/generate_features/smoke_bluesky_campaign.py
@@ -64,6 +64,7 @@ from data_platform.generate_features.s3_feature_batches import (
     validate_q44_rows,
 )
 from data_platform.generate_features.s3_feature_campaign import (
+    DEFAULT_CAMPAIGN_PLATFORM,
     CampaignObjectStore,
     FeaturePaths,
     run_id_for_feature,
@@ -174,7 +175,12 @@ def build_smoke_paths(
         When ``smoke_prefix`` is not an ``s3://`` URI, or when it lands on or
         inside the canonical feature prefix, or contains it.
     """
-    canonical = FeaturePaths.canonical(campaign_id, feature, dataset_id=dataset_id)
+    canonical = FeaturePaths.for_campaign(
+        campaign_id,
+        feature,
+        platform=DEFAULT_CAMPAIGN_PLATFORM,
+        dataset_id=dataset_id,
+    )
     if smoke_prefix is None:
         return SmokePaths(
             paths=canonical,

--- a/docs/plans/2026-09-07_reddit_campaign_engine_map_bedrock_156246/plan.md
+++ b/docs/plans/2026-09-07_reddit_campaign_engine_map_bedrock_156246/plan.md
@@ -1,0 +1,74 @@
+# Add a Reddit campaign engine map and a Bedrock S3 campaign path
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, frequent commits
+- Use only the approved smoke checks. Do not add or run automated tests.
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Reddit campaign `reddit_2026_09_03_233928_llm_features_v1` labels 400,000 comments with seven LLM features. Four features stay on OpenAI Batch. Three boolean structure features use Bedrock Converse. Bluesky campaign `bluesky_2026_09_03_235130_llm_features_v1` stays on OpenAI for every LLM feature. Global registry engine values stay unchanged.
+
+The package is one independently mergeable pull request for child issue [219](https://github.com/METResearchGroup/mirrorView-task/issues/219). The pull request is part of parent issue [218](https://github.com/METResearchGroup/mirrorView-task/issues/218). The parent issue stays open. Sibling issues stay out of the pull request. The pull request does not run the full 400,000 comment job.
+
+## Happy flow
+
+An operator runs the Reddit feature command with a campaign id and a pinned preprocessed run. The campaign engine map picks OpenAI or Bedrock for that feature. Both engines write the same S3 batch layout. Bedrock content filter blocks are recorded as errors and retried through OpenAI Batch in the same command.
+
+```mermaid
+flowchart LR
+  A[Reddit feature command] --> B[Campaign engine map]
+  B -->|OpenAI features| C[OpenAI Batch writer]
+  B -->|Bedrock features| D[Bedrock part writer]
+  D -->|content filter ids| E[errors log]
+  E --> C
+  C --> F[S3 batches and manifest]
+  D --> F
+```
+
+## Approach
+
+Add a campaign only engine map. Reuse the existing OpenAI campaign writer. Add a Bedrock campaign writer that labels one 2,000 row part at a time with eight threads, and that stores resume state in a Bedrock job file separate from the OpenAI batch file. Restore the missing feature path alias so Bluesky callers keep working, and require Reddit callers to pass platform and dataset id. Record engine type on the manifest and on local metadata. Do not add an engine type column to parquet.
+
+Do not add a plugin framework. Do not add Reddit smoke tooling. Do not add watcher platform flags. Do not write under the pinned campaign batches prefix.
+
+## Decisions
+
+- Campaign id `reddit_2026_09_03_233928_llm_features_v1` is the only campaign with mixed engines.
+- OpenAI features: `is_news_or_opinion`, `is_political`, `political_stance`, `llm_toxicity_tiered`.
+- Bedrock features: `is_likely_spam`, `is_self_contained`, `is_structurally_complete`.
+- Bedrock model id is the default Nova Micro constant. OpenAI model id stays the default Batch model.
+- Bedrock uses one process and eight threads per part.
+- Content filter writes reason `bedrock_content_filter`, then retries through OpenAI Batch. The manifest keeps engine type `bedrock` and adds an OpenAI retry block.
+- Other Bedrock failures stay failed. Boolean features never get a content filter label.
+- Feature path callers that still use the old alias get a forwarder to the current helper. Reddit generation always passes platform `reddit` and the pinned dataset id.
+- Local campaign metadata records engine type without changing the shared metadata model module.
+- Existing Bluesky manifests that omit engine type compare as OpenAI on resume.
+- Phase 4 and Phase 6 for this package are the offline and optional live smoke commands in the step files. Do not add or run files under `tests/`.
+- Changelog is updated after the pull request exists.
+
+## Steps
+
+### Step 1: Add the campaign engine map, feature paths, and Reddit campaign flags
+
+Add the Reddit campaign engine map. Restore the missing feature path alias and pass platform plus dataset id from Reddit campaign generation. Record engine type on new manifests and on local campaign metadata. Accept OpenAI or Bedrock in campaign validation. Wire the Reddit Python API to campaign flags. See [steps/step1.md](steps/step1.md).
+
+### Step 2: Generalize Bedrock Converse and add the Bedrock S3 campaign writer
+
+Build Bedrock JSON instructions from each feature schema. Treat content filter as a failure, not a label. Label Bedrock campaign parts serially with eight threads and a Bedrock resume file. Retry content filter ids through OpenAI Batch in the same command. See [steps/step2.md](steps/step2.md).
+
+### Step 3: Run offline smoke and confirm unused production prefixes
+
+Run the engine map check, the Reddit feature path check, the disposable prefix helper print, the pinned batches listing, Reddit help, registry inspection, and parquet column inspection. Optional live Bedrock proof uses only the disposable smoke prefix and must be deleted before merge. See [steps/step3.md](steps/step3.md).
+
+## What "done" looks like
+
+1. The campaign engine map returns OpenAI or Bedrock for the pinned Reddit campaign and returns OpenAI for the Bluesky campaign.
+2. `generate_reddit_features.py` accepts campaign id and preprocessed run flags and returns the S3 feature prefix in campaign mode.
+3. Bedrock features write immutable batch objects, a manifest with engine type, progress, errors, and a final file with the same layout as OpenAI features.
+4. Local metadata records engine type. Parquet rows keep the six label metadata fields and have no engine type column.
+5. Bedrock resume state lives in `active_bedrock_job.json`. OpenAI resume and content filter retries use `active_openai_batch.json`.
+6. Offline smoke commands pass. The pinned campaign batches prefix has no objects from this pull request. The disposable smoke prefix is empty before merge.
+7. Registry default engine values are unchanged. No automated tests were added or run. The full 400,000 row job did not run.

--- a/docs/plans/2026-09-07_reddit_campaign_engine_map_bedrock_156246/steps/step1.md
+++ b/docs/plans/2026-09-07_reddit_campaign_engine_map_bedrock_156246/steps/step1.md
@@ -1,0 +1,151 @@
+# Step 1: Add the campaign engine map, feature paths, and Reddit campaign flags
+
+## Scope
+
+- **Caller:** `data_platform/generate_features/generate_reddit_features.py` `generate_reddit_features` in campaign mode, which calls `generate_platform_campaign_feature`, which calls `generate_campaign_feature`.
+- **Task:** Add a campaign only engine map for `reddit_2026_09_03_233928_llm_features_v1`, restore `FeaturePaths.canonical` as a forwarder to `FeaturePaths.for_campaign`, record `engine_type` on manifests and local campaign metadata, accept OpenAI or Bedrock in campaign validation, and add campaign flags to the Reddit Python API.
+- **Out of scope:** Bedrock Converse prompt and content filter changes, Bedrock part writer, content filter OpenAI retry, live S3 writes, pytest, watcher platform flags, Reddit smoke modules, registry engine defaults.
+
+Phase 4 for this package is the offline `python -c` smoke in Step 3, not pytest. Do not add files under `tests/`. Run unattended. Skip Phase 3 approval.
+
+## Files to inspect
+
+- `data_platform/generate_features/generate_features.py`
+- `data_platform/generate_features/platform_cli.py`
+- `data_platform/generate_features/s3_feature_campaign.py`
+- `data_platform/generate_features/generate_reddit_features.py`
+- `data_platform/generate_features/generate_bluesky_features.py`
+- `data_platform/generate_features/metadata.py`
+- `data_platform/generate_features/models.py` (read only)
+- `data_platform/generate_features/registry.py` (read only)
+- `data_platform/generate_features/feature_progress_watcher.py`
+- `data_platform/generate_features/smoke_bluesky_campaign.py`
+- `data_platform/curate/consolidate_bluesky_llm_campaign.py`
+- `lib/constants.py`
+
+## Files allowed to change
+
+- `data_platform/generate_features/campaign_engine_map.py` (new)
+- `data_platform/generate_features/generate_features.py`
+- `data_platform/generate_features/platform_cli.py`
+- `data_platform/generate_features/s3_feature_campaign.py`
+- `data_platform/generate_features/generate_reddit_features.py`
+- `data_platform/generate_features/metadata.py`
+- `data_platform/generate_features/feature_progress_watcher.py` (FeaturePaths fix only)
+- `data_platform/generate_features/smoke_bluesky_campaign.py` (FeaturePaths fix only)
+- `data_platform/curate/consolidate_bluesky_llm_campaign.py` (FeaturePaths fix only)
+
+## Files forbidden to change
+
+- `data_platform/utils/storage.py`
+- `data_platform/generate_features/registry.py`
+- `data_platform/generate_features/models.py`
+- `data_platform/generate_features/engines/bedrock_engine.py` (Step 2)
+- `data_platform/scripts/migrate_reddit_preprocessed_to_s3.py`
+- Any file under `tests/`
+- `data_platform/data/bluesky/**`
+- Feature prompt modules under `data_platform/generate_features/*/generate_feature.py`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/**`
+- `CHANGELOG.md`
+
+## Locked identities
+
+| Field | Value |
+| ----- | ----- |
+| Reddit campaign id | `reddit_2026_09_03_233928_llm_features_v1` |
+| Bluesky campaign id | `bluesky_2026_09_03_235130_llm_features_v1` |
+| Platform | `reddit` |
+| Dataset id | `reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079` |
+| Preprocessed run | `2026_09_03-23:39:28` |
+| OpenAI engine string | `openai` |
+| Bedrock engine string | `bedrock` |
+
+Engine map for the Reddit campaign only:
+
+| Feature | Engine |
+| ------- | ------ |
+| `is_news_or_opinion` | `openai` |
+| `is_political` | `openai` |
+| `political_stance` | `openai` |
+| `llm_toxicity_tiered` | `openai` |
+| `is_likely_spam` | `bedrock` |
+| `is_self_contained` | `bedrock` |
+| `is_structurally_complete` | `bedrock` |
+
+Any other campaign id, including the Bluesky campaign, resolves to `openai`. A Reddit campaign feature that is missing from the map raises `ValueError`. Thread pool features stay rejected.
+
+## Contracts
+
+`campaign_engine_type(campaign_id: str, feature: str) -> str` in `campaign_engine_map.py` is the resolver. `generate_campaign_feature` uses it instead of comparing `spec.engine_type` to the hardcoded `CAMPAIGN_ENGINE_TYPE` string. Keep `CAMPAIGN_ENGINE_TYPE = "openai"` because Bluesky smoke still imports it.
+
+`FeaturePaths.canonical` is a classmethod alias that forwards to `FeaturePaths.for_campaign` with the same arguments, including optional `platform` and `dataset_id`. Default platform and dataset id stay the existing Bluesky values. Reddit campaign generation already calls `for_campaign` with `campaign.platform` and `campaign.dataset_id`. Watcher, Bluesky smoke, and Bluesky consolidate must compile. Prefer `for_campaign` at call sites that already have a dataset id, and pass `platform="bluesky"` there so a Reddit campaign id cannot silently inherit Bluesky defaults from copied call sites.
+
+`new_manifest` includes `engine_type`. `MANIFEST_IDENTITY_FIELDS` includes `engine_type`. On resume, a missing `engine_type` on an existing manifest compares as `openai` so current Bluesky campaigns still resume. `model_id` on a Bedrock campaign manifest is `lib.constants.DEFAULT_BEDROCK_NOVA_MICRO`. `model_id` on an OpenAI campaign manifest stays `model_id_for_spec`.
+
+Local campaign metadata is a `metadata.json` under the local campaign run directory. Record `engine_type` on the feature entry. Do not edit `models.py`. Do not add `engine_type` to parquet.
+
+`platform_cli` campaign validation accepts map values `openai` or `bedrock`. It still rejects `is_toxic_tiered`.
+
+`generate_reddit_features` matches `generate_bluesky_features`: optional `campaign_id` and `preprocessed_run`, campaign mode returns `{feature_name: prefix_uri}`.
+
+Keep functions under 20 lines. Named constants. Numpy docstrings. Module docstrings include a `uv run python ...` command when the file is a script.
+
+## Ordered units of work
+
+1. `campaign_engine_map.py` constants and `campaign_engine_type`.
+2. `FeaturePaths.canonical` alias plus `active_bedrock_state_key`.
+3. Feature path call sites in watcher, Bluesky smoke, and Bluesky consolidate.
+4. `model_id_for_campaign_engine` and `write_campaign_local_metadata` in `metadata.py`.
+5. `new_manifest` and identity check for `engine_type`.
+6. `generate_campaign_feature` resolves the campaign engine and writes local metadata. OpenAI path stays as today. Bedrock path may raise `NotImplementedError` until Step 2.
+7. `platform_cli` campaign validation uses the map.
+8. Reddit Python API and module docstring campaign example.
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.campaign_engine_map import campaign_engine_type
+assert campaign_engine_type('reddit_2026_09_03_233928_llm_features_v1', 'is_news_or_opinion') == 'openai'
+assert campaign_engine_type('reddit_2026_09_03_233928_llm_features_v1', 'is_political') == 'openai'
+assert campaign_engine_type('reddit_2026_09_03_233928_llm_features_v1', 'is_likely_spam') == 'bedrock'
+assert campaign_engine_type('reddit_2026_09_03_233928_llm_features_v1', 'political_stance') == 'openai'
+assert campaign_engine_type('bluesky_2026_09_03_235130_llm_features_v1', 'is_political') == 'openai'
+print('campaign_engine_map OK')
+"
+```
+
+Expected stdout: `campaign_engine_map OK`
+
+```bash
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.s3_feature_campaign import FeaturePaths
+p = FeaturePaths.for_campaign(
+    'reddit_2026_09_03_233928_llm_features_v1',
+    'is_political',
+    platform='reddit',
+    dataset_id='reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079',
+)
+assert '/reddit/reddit_3d8a2c41' in p.prefix
+assert p.prefix.endswith('features/reddit_2026_09_03_233928_llm_features_v1/is_political/')
+alias = FeaturePaths.canonical(
+    'reddit_2026_09_03_233928_llm_features_v1',
+    'is_political',
+    platform='reddit',
+    dataset_id='reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079',
+)
+assert alias.prefix == p.prefix
+print('reddit FeaturePaths OK')
+"
+```
+
+Expected stdout: `reddit FeaturePaths OK`
+
+## Must fail
+
+- Changing `FEATURE_REGISTRY` default `engine_type` values.
+- Reddit campaign generation that omits platform or dataset id and inherits Bluesky defaults.
+- Campaign mode that still requires `spec.engine_type == "openai"` from the registry.
+- An `engine_type` field on `LabelRowMetadataModel`.
+- Watcher code that posts to GitHub.
+- Any file under `tests/`.

--- a/docs/plans/2026-09-07_reddit_campaign_engine_map_bedrock_156246/steps/step2.md
+++ b/docs/plans/2026-09-07_reddit_campaign_engine_map_bedrock_156246/steps/step2.md
@@ -1,0 +1,140 @@
+# Step 2: Generalize Bedrock Converse and add the Bedrock S3 campaign writer
+
+## Scope
+
+- **Caller:** `generate_campaign_feature` when `campaign_engine_type` returns `bedrock`, used by `generate_reddit_features` for `is_likely_spam`, `is_self_contained`, and `is_structurally_complete`.
+- **Task:** Build Bedrock JSON instructions from each `FeatureSpec` schema. Treat content filter as a typed failure. Label one 2,000 row part at a time with eight threads. Persist `active_bedrock_job.json`. Record content filter errors, then retry those ids through OpenAI Batch in the same command. Keep OpenAI campaign labeling for map entries with `openai`.
+- **Out of scope:** Full 400,000 row production, Reddit smoke module, watcher platform flags, registry engine defaults, pytest, GitHub posting.
+
+Phase 4 for this package is the offline and optional live smoke in Step 3, not pytest. Do not add files under `tests/`. Run unattended. Skip Phase 3 approval.
+
+## Files to inspect
+
+- `data_platform/generate_features/engines/bedrock_engine.py`
+- `data_platform/generate_features/generate_features.py`
+- `data_platform/generate_features/s3_feature_campaign.py`
+- `data_platform/generate_features/s3_feature_batches.py`
+- `data_platform/generate_features/engines/openai_engine.py`
+- `data_platform/generate_features/engines/base.py`
+- `lib/constants.py`
+
+## Files allowed to change
+
+- `data_platform/generate_features/engines/bedrock_engine.py`
+- `data_platform/generate_features/engines/bedrock_campaign.py` (new)
+- `data_platform/generate_features/generate_features.py`
+- `data_platform/generate_features/s3_feature_campaign.py`
+- `data_platform/generate_features/s3_feature_batches.py` (only if a helper is required for error reason or Bedrock batch write)
+
+## Files forbidden to change
+
+- `data_platform/generate_features/registry.py`
+- `data_platform/generate_features/models.py`
+- `data_platform/utils/storage.py`
+- Feature prompt modules
+- Any file under `tests/`
+- `data_platform/scripts/migrate_reddit_preprocessed_to_s3.py`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/**`
+- Step 3 smoke modules, including any new `smoke_reddit_campaign.py`
+
+## Locked contracts
+
+### Bedrock Converse
+
+Replace the hardcoded news or opinion JSON instruction with a JSON instruction derived from `spec.llm_output_schema`. Keep the feature `system_prompt` from the spec.
+
+Content filter is a failure. Raise a dedicated error type, for example `BedrockContentFilterError`, when the provider text contains `blocked by our content filters` or the Converse stop reason is a content filter. Do not map content filter to `neither`, `false`, or any other label. Do not retry content filter on Bedrock. Other invalid JSON may still retry inside Converse.
+
+### Bedrock campaign writer
+
+Reuse `write_batch`, `adopt_unrecorded_batch`, `consolidate_final`, and `append_errors`. Do not overwrite an existing `part-NNNNN.parquet`.
+
+Bedrock concurrency inside a part is 8. Force that value in the Bedrock campaign writer. Never start extra Bedrock processes from this code.
+
+`active_bedrock_job.json` minimum fields:
+
+| Field | Meaning |
+| ----- | ------- |
+| `logical_batch_index` | Zero based part index in progress |
+| `pending_source_record_ids` | Ordered ids still expected for this part |
+| `completed_source_record_ids` | Ids already labeled for this part |
+| `state` | `running`, `writing`, or `terminal` |
+
+Use the same conditional replace pattern as `active_openai_batch.json`. Delete the Bedrock job file only after the part object exists and the manifest records it. Never store Bedrock cursor state in `active_openai_batch.json`.
+
+Row metadata stays the six `LabelRowMetadataModel` fields plus the feature label field. `batch_id` is the Bedrock job id for Bedrock rows and the OpenAI batch id for retry rows. No parquet `engine_type` column.
+
+Tag `batches/` uploads with `intermediate-artifact=true`. Do not tag `final.parquet`, `manifest.json`, `progress.jsonl`, or `errors.jsonl`.
+
+### Content filter retry
+
+When Bedrock blocks a comment, append:
+
+```json
+{
+  "source_record_id": "<id>",
+  "reason": "bedrock_content_filter",
+  "engine_type": "bedrock",
+  "detail": "<provider message excerpt>",
+  "recorded_at": "<UTC timestamp>"
+}
+```
+
+The same command then submits those ids to OpenAI Batch using the existing OpenAI chunk writer and `active_openai_batch.json`. Successful retries write additional immutable batch objects. Other Bedrock failures stay failed and are not retried. After retries, the manifest keeps `engine_type` equal to `bedrock` and adds:
+
+```json
+"openai_content_filter_retry": {
+  "count": 0,
+  "model_id": "gpt-5.4-nano",
+  "provider_batch_ids": []
+}
+```
+
+`count` is the number of ids submitted to OpenAI retry. `model_id` is `lib.constants.DEFAULT_LLM_MODEL`. `provider_batch_ids` lists OpenAI batch ids from successful retry writes.
+
+On resume, retry content filter ids that still have no batch row.
+
+Do not write under the pinned campaign prefix during this step. Optional live proof uses only `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step2_bedrock/`.
+
+Keep functions under 20 lines. Named constants. Numpy docstrings.
+
+## Ordered units of work
+
+1. JSON instruction from schema and content filter error type in `bedrock_engine.py`.
+2. Per task Bedrock labeling that returns successes, content filter failures, and other failures.
+3. `active_bedrock_job.json` load, save, and delete helpers.
+4. Serial Bedrock part labeling with resume and immutable batch write.
+5. Content filter error records and OpenAI retry that updates `openai_content_filter_retry`.
+6. `generate_campaign_feature` routes Bedrock map entries to the new writer.
+
+## Must pass
+
+Offline import of the Bedrock campaign module and confirmation that content filter parsing no longer returns `neither`:
+
+```bash
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.engines.bedrock_engine import (
+    BedrockContentFilterError,
+    parse_json_object,
+)
+try:
+    parse_json_object('blocked by our content filters')
+except BedrockContentFilterError:
+    print('content_filter_is_failure OK')
+else:
+    raise SystemExit('content filter must not parse as a label')
+"
+```
+
+Expected stdout: `content_filter_is_failure OK`
+
+## Must fail
+
+- Hardcoded news or opinion JSON for every Bedrock feature.
+- Content filter stored as `neither` or boolean false.
+- Shared resume file for Bedrock and OpenAI.
+- Overwriting an existing batch object.
+- Writes under the pinned campaign `batches/` prefix.
+- An `engine_type` parquet column.
+- More than one Bedrock process started by this writer.
+- Any file under `tests/`.

--- a/docs/plans/2026-09-07_reddit_campaign_engine_map_bedrock_156246/steps/step3.md
+++ b/docs/plans/2026-09-07_reddit_campaign_engine_map_bedrock_156246/steps/step3.md
@@ -1,0 +1,165 @@
+# Step 3: Run offline smoke and confirm unused production prefixes
+
+## Scope
+
+- **Caller:** the offline commands below, run from `/workspace` after Steps 1 and 2.
+- **Task:** Prove the engine map, Reddit feature paths, Reddit campaign CLI flags, unchanged registry engines, and six parquet metadata columns. Print a disposable prefix helper. Confirm the pinned campaign batches prefix is empty. Optional tiny live Bedrock proof uses only the disposable smoke prefix and must be deleted before merge.
+- **Out of scope:** Full 400,000 row labeling, pytest, new smoke modules, GitHub posting, changelog (after the pull request).
+
+Do not add files under `tests/`. Do not write production `batches/` under the pinned campaign prefix.
+
+## Files to inspect
+
+Read only. No product edits unless a prior step failed and the fix stays in the allowed set from Steps 1 and 2.
+
+## Files allowed to change
+
+None, unless a correctness bug found by these commands requires a fix in the allowed product files from Steps 1 and 2.
+
+## Files forbidden to change
+
+- Any file under `tests/`
+- `data_platform/generate_features/registry.py`
+- `data_platform/utils/storage.py`
+- Pinned campaign objects under `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/`
+
+## Commands
+
+Export lab AWS keys as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` before any `aws` command. Never print secrets.
+
+### Engine map
+
+```bash
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.campaign_engine_map import campaign_engine_type
+assert campaign_engine_type('reddit_2026_09_03_233928_llm_features_v1', 'is_news_or_opinion') == 'openai'
+assert campaign_engine_type('reddit_2026_09_03_233928_llm_features_v1', 'is_political') == 'openai'
+assert campaign_engine_type('reddit_2026_09_03_233928_llm_features_v1', 'is_likely_spam') == 'bedrock'
+assert campaign_engine_type('reddit_2026_09_03_233928_llm_features_v1', 'political_stance') == 'openai'
+assert campaign_engine_type('bluesky_2026_09_03_235130_llm_features_v1', 'is_political') == 'openai'
+print('campaign_engine_map OK')
+"
+```
+
+Expected: `campaign_engine_map OK`
+
+### Reddit FeaturePaths
+
+```bash
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.s3_feature_campaign import FeaturePaths
+p = FeaturePaths.for_campaign(
+    'reddit_2026_09_03_233928_llm_features_v1',
+    'is_political',
+    platform='reddit',
+    dataset_id='reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079',
+)
+assert '/reddit/reddit_3d8a2c41' in p.prefix
+assert p.prefix.endswith('features/reddit_2026_09_03_233928_llm_features_v1/is_political/')
+print('reddit FeaturePaths OK')
+"
+```
+
+Expected: `reddit FeaturePaths OK`
+
+### Disposable prefix helper print
+
+Do not write pinned campaign batches.
+
+```bash
+DISPOSABLE_PREFIX=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step2_bedrock/
+
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.s3_feature_campaign import FeaturePaths
+from data_platform.generate_features.campaign_engine_map import campaign_engine_type
+feature = 'is_likely_spam'
+assert campaign_engine_type('reddit_2026_09_03_233928_llm_features_v1', feature) == 'bedrock'
+paths = FeaturePaths.from_root_uri('s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step2_bedrock/', feature)
+print('disposable_prefix=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step2_bedrock/')
+print('bedrock_feature=' + feature)
+print('active_bedrock_job_key=' + paths.prefix + 'active_bedrock_job.json')
+"
+```
+
+Expected stdout includes `disposable_prefix=`, `bedrock_feature=is_likely_spam`, and `active_bedrock_job_key=` ending in `active_bedrock_job.json`.
+
+Optional tiny live proof: at most ten rows, `max_concurrency=8`, one part, only under that disposable prefix. Then delete it.
+
+### Pinned campaign batches untouched
+
+```bash
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_political/batches/ 2>&1 || true
+```
+
+Expected: `NoSuchKey` or empty listing. No `part-*.parquet` from this pull request.
+
+### Reddit campaign CLI
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/generate_reddit_features.py --help
+```
+
+Expected: help text includes `--campaign-id` and `--preprocessed-run`.
+
+```bash
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.generate_reddit_features import generate_reddit_features
+import inspect
+assert 'campaign_id' in inspect.signature(generate_reddit_features).parameters
+assert 'preprocessed_run' in inspect.signature(generate_reddit_features).parameters
+print('generate_reddit_features campaign API OK')
+"
+```
+
+Expected: `generate_reddit_features campaign API OK`
+
+### Registry engine values unchanged
+
+```bash
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.registry import FEATURE_REGISTRY
+expected = {
+    'is_news_or_opinion': 'openai',
+    'is_political': 'openai',
+    'is_likely_spam': 'openai',
+    'is_self_contained': 'openai',
+    'is_structurally_complete': 'openai',
+    'is_toxic_tiered': 'thread_pool',
+    'llm_toxicity_tiered': 'openai',
+    'political_stance': 'openai',
+}
+got = {name: spec.engine_type for name, spec in FEATURE_REGISTRY.items()}
+assert got == expected, got
+print('FEATURE_REGISTRY engine_type unchanged')
+"
+```
+
+Expected: `FEATURE_REGISTRY engine_type unchanged`
+
+### No parquet engine type column
+
+```bash
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.models import LabelRowMetadataModel
+assert 'engine_type' not in LabelRowMetadataModel.model_fields
+print('LabelRowMetadataModel has no engine_type')
+"
+```
+
+Expected: `LabelRowMetadataModel has no engine_type`
+
+### Disposable prefix cleanup before merge, if live proof ran
+
+```bash
+aws s3 rm s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step2_bedrock/ --recursive
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step2_bedrock/ --recursive
+```
+
+Expected: `aws s3 ls` prints no lines.
+
+## Must fail
+
+- Live proof or any other write under the pinned campaign `batches/` prefix.
+- Leaving objects under the disposable smoke prefix if live proof ran.
+- Running pytest.
+- Running the 400,000 row production job.


### PR DESCRIPTION
Fixes #219

Part of #218

## Summary

Adds mixed-engine S3 campaign mode for Reddit LLM features on campaign `reddit_2026_09_03_233928_llm_features_v1`. Four features label through OpenAI Batch with the existing resume path. Three features label through Bedrock Converse with serial 2000 row parts and `active_bedrock_job.json` resume. Bedrock content-filter failures record `bedrock_content_filter` in `errors.jsonl` and retry through OpenAI Batch before final consolidation.

`generate_reddit_features.py` accepts `--campaign-id` and `--preprocessed-run` like the Bluesky entry point. `manifest.json` and local `metadata.json` record `engine_type`. Parquet rows keep the six `LabelRowMetadataModel` fields without an `engine_type` column.

The full 400000 comment job did not run. Optional live Bedrock proof used only `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step2_bedrock/` and that prefix was emptied before review.

## Purpose

Reddit has 400000 comments to label across seven LLM features. OpenAI Batch handles four features. Bedrock Converse handles three boolean structure features. The campaign engine map applies only to `reddit_2026_09_03_233928_llm_features_v1`, so Bluesky stays on OpenAI. Full production labeling and Step 3 smoke tooling are out of scope.

## Architecture

Components:

- `generate_reddit_features.py` is the Reddit campaign entry point.
- `campaign_engine_map.py` resolves `openai` or `bedrock` per feature for the pinned Reddit campaign only.
- `generate_campaign_feature` routes to the OpenAI Batch writer or the Bedrock part writer.
- `bedrock_engine.py` and `bedrock_campaign.py` label one part at a time with `max_concurrency=8`, use each feature prompt and schema, and record content-filter failures.
- `openai_engine.py` stays the path for OpenAI-mapped features and for Bedrock content-filter retries.
- `s3_feature_campaign.py` and `s3_feature_batches.py` share the same immutable batch, manifest, progress, and final layout for both engines.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    C1[generate_reddit_features] --> L1[Local feature runs only]
    G1[generate_campaign_feature] --> O1[OpenAI Batch only]
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    C2[generate_reddit_features] --> M[campaign_engine_map]
    M -->|bedrock features| B[Bedrock part writer]
    M -->|openai features| O2[OpenAI Batch writer]
    B --> S3[(S3 batches and manifest)]
    O2 --> S3
    B -->|content filter ids| E[errors.jsonl]
    E --> O2
    O2 --> S3
  end
```

## Interfaces

### Campaign engine map

Campaign id `reddit_2026_09_03_233928_llm_features_v1`:

| Feature | Engine |
|---------|--------|
| `is_news_or_opinion` | `openai` |
| `is_political` | `openai` |
| `political_stance` | `openai` |
| `llm_toxicity_tiered` | `openai` |
| `is_likely_spam` | `bedrock` |
| `is_self_contained` | `bedrock` |
| `is_structurally_complete` | `bedrock` |

### manifest.json additions

| Field | Type | Notes |
| ----- | ---- | ----- |
| `engine_type` | `openai` or `bedrock` | Identity field checked on resume |
| `openai_content_filter_retry` | object or absent | Present on Bedrock features after OpenAI retry of filtered ids |

### errors.jsonl filter record

| Field | Notes |
| ----- | ----- |
| `reason` | `bedrock_content_filter` |
| `source_record_id` | failed comment id |
| `engine_type` | `bedrock` |

### S3 state files

| File | Owner |
| ---- | ----- |
| `active_bedrock_job.json` | Bedrock features during an in-flight part |
| `active_openai_batch.json` | OpenAI features and Bedrock content-filter retry batches |

### CLI

```bash
PYTHONPATH=. uv run python data_platform/generate_features/generate_reddit_features.py \
  --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079 \
  --preprocessed-run 2026_09_03-23:39:28 \
  --campaign-id reddit_2026_09_03_233928_llm_features_v1 \
  --features is_political \
  --batch-size 2000
```

## How to run

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
PYTHONPATH=. uv run python -c "from data_platform.generate_features.campaign_engine_map import campaign_engine_type; print(campaign_engine_type('reddit_2026_09_03_233928_llm_features_v1', 'is_political'))"
```

Expected: prints `openai`.

Offline FeaturePaths and engine map checks from the step file pass. Optional live proof used only `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step2_bedrock/` and that prefix is empty. Do not run the full 400000 comment campaign in this pull request.

Plan: `docs/plans/2026-09-07_reddit_campaign_engine_map_bedrock_156246/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added campaign-based feature generation using OpenAI or Amazon Bedrock.
  - Added Reddit campaign support with resumable processing and immutable S3 batches.
  - Added campaign metadata recording the selected engine, model, prompt version, and run time.
  - Added automatic retry of Bedrock content-filtered records through OpenAI.

- **Bug Fixes**
  - Improved structured Bedrock outputs for different feature schemas.
  - Preserved successful records when individual labeling requests fail.
  - Improved campaign path and manifest consistency across platforms.
  - Improved campaign validation for supported engines and feature configurations.
  - Improved handling of completed batches that contain no records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->