### PR TITLE
Add Twitter LLM campaign config, S3 csv copy, and smoke tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2026-09-07
+
+1. The pinned Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_06_192847_llm_features_v1`, run a ten-post disposable smoke, scale cost math to 6,374 rows, and print watcher status without writing to GitHub. [PR #238](https://github.com/METResearchGroup/mirrorView-task/pull/238)
+
 ## 2026-09-06
 
 1. Operators can compare Amazon Nova Micro on Bedrock Converse with the OpenAI Batch runs that label posts as news, opinion, or neither. A smoke run, the matching size jobs, and the matching process jobs now record throughput and estimated cost, and live feature generation still uses OpenAI. [PR #212](https://github.com/METResearchGroup/mirrorView-task/pull/212)

--- a/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/s3_preprocessed_inventory.json
+++ b/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/s3_preprocessed_inventory.json
@@ -1,0 +1,16 @@
+{
+  "bucket": "mirrorview-experimental-artifacts",
+  "region": "us-east-2",
+  "dataset_id": "twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547",
+  "preprocessed_run": "2026_09_06-19:28:47",
+  "uploaded_at": "2026_09_07-03:07:06",
+  "object_count": 1,
+  "objects": [
+    {
+      "repo_relative_path": "data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv",
+      "s3_key": "data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv",
+      "bytes": 2584416,
+      "sha256": "7233223b21210d0937372d9d906abfd914962784402d6b167805952a7415fa4a"
+    }
+  ]
+}

--- a/data_platform/generate_features/campaign_cost_report.py
+++ b/data_platform/generate_features/campaign_cost_report.py
@@ -180,8 +180,12 @@ def aggregate_cost_reports(
     campaign_id: str,
     smoke_reports_dir: Path,
     features: tuple[str, ...] = CAMPAIGN_LLM_FEATURES,
+    full_run_row_count: int = FULL_RUN_POST_COUNT,
 ) -> dict[str, Any]:
     """Sum the per-feature smoke cost reports of ``features`` into one parent estimate.
+
+    ``full_run_row_count`` is recorded on the aggregate. It defaults to
+    ``FULL_RUN_POST_COUNT`` (200000). Twitter passes 6374.
 
     Raises
     ------
@@ -220,6 +224,7 @@ def aggregate_cost_reports(
     return {
         "campaign_id": campaign_id,
         "generated_at": get_current_timestamp(),
+        "full_run_row_count": full_run_row_count,
         "features_included": len(entries),
         "features": entries,
         "total_smoke_cost_usd": round(
@@ -239,14 +244,18 @@ def main(
     campaign_id: str = typer.Option(..., "--campaign-id"),
     smoke_reports_dir: Path = typer.Option(..., "--smoke-reports-dir"),
     output: Path = typer.Option(..., "--output"),
+    full_run_row_count: int = typer.Option(FULL_RUN_POST_COUNT, "--full-run-row-count"),
 ) -> None:
     """Sum the seven per-feature smoke cost reports into ``output`` and print the totals."""
     if not aggregate:
         raise typer.BadParameter("pass --aggregate; it is the only mode of this command")
-    document = aggregate_cost_reports(campaign_id, smoke_reports_dir)
+    document = aggregate_cost_reports(
+        campaign_id, smoke_reports_dir, full_run_row_count=full_run_row_count
+    )
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(f"{json.dumps(document, indent=JSON_INDENT)}\n", encoding="utf-8")
     print(f"features_included={document['features_included']}")
+    print(f"full_run_row_count={document['full_run_row_count']}")
     print(f"total_estimated_full_run_usd_avg={document['total_estimated_full_run_usd_avg']}")
     print(f"total_estimated_full_run_usd_max={document['total_estimated_full_run_usd_max']}")
     print(f"{output.name} written")

--- a/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml
+++ b/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml
@@ -1,0 +1,16 @@
+campaign_id: twitter_2026_09_06_192847_llm_features_v1
+platform: twitter
+dataset_id: twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547
+preprocessed_run: "2026_09_06-19:28:47"
+row_count: 6374
+batch_size: 2000
+engine_type: openai
+model_id: gpt-5.4-nano
+features:
+  - is_news_or_opinion
+  - is_political
+  - is_likely_spam
+  - is_self_contained
+  - is_structurally_complete
+  - political_stance
+  - llm_toxicity_tiered

--- a/data_platform/generate_features/deterministic_smoke_sample.py
+++ b/data_platform/generate_features/deterministic_smoke_sample.py
@@ -17,7 +17,7 @@ import pandas as pd
 import typer
 
 from data_platform.generate_features.generate_bluesky_features import BLUESKY_SPEC
-from data_platform.generate_features.platform_cli import load_pinned_preprocessed_records
+from data_platform.generate_features.platform_cli import FeaturePlatformSpec, load_pinned_preprocessed_records
 from data_platform.utils.platform_specific_columns import (
     STANDARDIZED_SOURCE_RECORD_ID_COLUMN,
     STANDARDIZED_TEXT_COLUMN,
@@ -51,9 +51,19 @@ def select_deterministic_sample(
     return ordered.head(count).reset_index(drop=True)
 
 
-def load_deterministic_ten_posts(dataset_id: str, preprocessed_run: str) -> pd.DataFrame:
-    """Load the pinned preprocessed run and return its ten smoke rows with every column."""
-    records = load_pinned_preprocessed_records(BLUESKY_SPEC, dataset_id, preprocessed_run)
+def load_deterministic_ten_posts(
+    dataset_id: str,
+    preprocessed_run: str,
+    spec: FeaturePlatformSpec | None = None,
+) -> pd.DataFrame:
+    """Load the pinned preprocessed run and return its ten smoke rows with every column.
+
+    ``spec`` selects the platform storage and model. None keeps today's Bluesky
+    spec so existing Bluesky callers stay valid.
+    """
+    records = load_pinned_preprocessed_records(
+        spec or BLUESKY_SPEC, dataset_id, preprocessed_run
+    )
     return select_deterministic_sample(records)
 
 

--- a/data_platform/generate_features/feature_progress_watcher.py
+++ b/data_platform/generate_features/feature_progress_watcher.py
@@ -27,6 +27,8 @@ from data_platform.generate_features.progress_record import (
     parse_batch_records,
 )
 from data_platform.generate_features.s3_feature_campaign import (
+    DEFAULT_CAMPAIGN_DATASET_ID,
+    DEFAULT_CAMPAIGN_PLATFORM,
     CampaignObjectStore,
     FeaturePaths,
     load_active_state,
@@ -56,11 +58,21 @@ class WatcherOutcome:
 
 
 def resolve_feature_paths(
-    campaign_id: str, feature: str, smoke_prefix: str | None
+    campaign_id: str,
+    feature: str,
+    smoke_prefix: str | None,
+    *,
+    platform: str = DEFAULT_CAMPAIGN_PLATFORM,
+    dataset_id: str = DEFAULT_CAMPAIGN_DATASET_ID,
 ) -> FeaturePaths:
-    """Return the canonical feature paths, or the paths under ``smoke_prefix/{feature}/`` when given."""
+    """Return campaign feature paths, or the paths under ``smoke_prefix/{feature}/`` when given.
+
+    Omitted ``platform`` and ``dataset_id`` keep today's Bluesky defaults.
+    """
     if smoke_prefix is None:
-        return FeaturePaths.canonical(campaign_id, feature)
+        return FeaturePaths.for_campaign(
+            campaign_id, feature, platform=platform, dataset_id=dataset_id
+        )
     return FeaturePaths.from_root_uri(smoke_prefix, feature)
 
 
@@ -197,15 +209,24 @@ def main(
     dry_render: bool = typer.Option(False, "--dry-render"),
     once: bool = typer.Option(False, "--once"),
     github_comment_id: int | None = typer.Option(None, "--github-comment-id"),
+    platform: str = typer.Option(DEFAULT_CAMPAIGN_PLATFORM, "--platform"),
+    dataset_id: str = typer.Option(DEFAULT_CAMPAIGN_DATASET_ID, "--dataset-id"),
 ) -> None:
     """Run the watcher once and print its outcome lines.
 
     ``--dry-render`` is accepted so the step spec's command lines run as
-    written. The command never writes to GitHub in any mode.
+    written. The command never writes to GitHub in any mode. Omitted
+    ``--platform`` and ``--dataset-id`` keep today's Bluesky defaults.
     """
     if not once:
         raise typer.BadParameter("pass --once; it is the only mode of this command")
-    paths = resolve_feature_paths(campaign_id, feature, smoke_prefix)
+    paths = resolve_feature_paths(
+        campaign_id,
+        feature,
+        smoke_prefix,
+        platform=platform,
+        dataset_id=dataset_id,
+    )
     store = CampaignObjectStore(paths.bucket)
     outcome = run_watcher_once(store, paths, github_comment_id=github_comment_id)
     for line in output_lines(outcome):

--- a/data_platform/generate_features/generate_twitter_features.py
+++ b/data_platform/generate_features/generate_twitter_features.py
@@ -7,6 +7,15 @@ Run from the repo root:
 
     PYTHONPATH=. uv run python data_platform/generate_features/generate_twitter_features.py \\
         --dataset-id twitter_<uuid> --checkpoint 2026_05_30-12:00:00
+
+Campaign mode writes immutable 2,000-row batch objects to S3 and resumes from
+that prefix on restart:
+
+    PYTHONPATH=. uv run python data_platform/generate_features/generate_twitter_features.py \\
+        --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \\
+        --preprocessed-run 2026_09_06-19:28:47 \\
+        --campaign-id twitter_2026_09_06_192847_llm_features_v1 \\
+        --features is_news_or_opinion --batch-size 2000
 """
 
 from __future__ import annotations
@@ -20,6 +29,7 @@ from data_platform.generate_features.platform_cli import (
     build_feature_cli_app,
     build_feature_cli_main,
     build_feature_config,
+    generate_platform_campaign_feature,
     generate_platform_features,
     load_preprocessed_records,
 )
@@ -55,28 +65,50 @@ def generate_twitter_features(
     max_concurrency: int = 80,
     feature_subset: list[str] | None = None,
     checkpoint: str | None = None,
-) -> dict[str, Path]:
-    """Generate Twitter feature labels in a new or unfinished feature run.
+    campaign_id: str | None = None,
+    preprocessed_run: str | None = None,
+) -> dict[str, Path | str]:
+    """Generate Twitter feature labels in a new or unfinished feature run, or in S3 campaign mode.
 
     Parameters
     ----------
     dataset_id
         Dataset identifier from ingestion YAML.
     batch_size
-        Label batch size.
+        Label batch size. Campaign mode requires 2000.
     max_concurrency
         Engine concurrency cap.
     feature_subset
-        Optional registry subset. None runs every feature.
+        Optional registry subset. None runs every feature. Campaign mode
+        requires exactly one feature.
     checkpoint
         Named unfinished feature run timestamp. Pass None to start a new
-        feature run.
+        feature run. Not allowed in campaign mode.
+    campaign_id
+        S3 campaign id. Pass together with ``preprocessed_run`` to write
+        immutable batch objects under the campaign feature prefix and resume
+        from that prefix.
+    preprocessed_run
+        Preprocessed run timestamp that campaign mode labels.
 
     Returns
     -------
-    dict[str, Path]
-        Feature name to the label file written in the feature run folder.
+    dict[str, Path | str]
+        Feature name to the label file written in the feature run folder, or
+        to the S3 feature prefix URI in campaign mode.
     """
+    if campaign_id is not None or preprocessed_run is not None:
+        feature_names = feature_subset or []
+        prefix_uri = generate_platform_campaign_feature(
+            TWITTER_SPEC,
+            dataset_id,
+            campaign_id=campaign_id,
+            preprocessed_run=preprocessed_run,
+            feature_subset=feature_subset,
+            batch_size=batch_size,
+            checkpoint=checkpoint,
+        )
+        return {feature_names[0]: prefix_uri}
     return generate_platform_features(
         TWITTER_SPEC,
         dataset_id,

--- a/data_platform/generate_features/smoke_twitter_campaign.py
+++ b/data_platform/generate_features/smoke_twitter_campaign.py
@@ -1,5 +1,9 @@
 """Ten-post smoke for one feature of the Twitter LLM campaign, with interrupt-and-resume.
 
+The Bluesky smoke module cannot be imported in this tree because it still
+names helpers that were renamed. This file keeps the same interrupt, resume,
+and S3-check flow using ``attach_row_metadata`` and ``campaign_row_columns``.
+
 Run from the repo root:
 
     PYTHONPATH=. uv run python data_platform/generate_features/smoke_twitter_campaign.py \\
@@ -9,69 +13,162 @@ Run from the repo root:
         --feature is_news_or_opinion \\
         --smoke-prefix s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/twitter_step1_campaign_smoke/ \\
         --output-dir docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/_step1_disposable
-
-Pass ``--smoke-prefix s3://bucket/root/`` to write under ``root/{feature}/smoke/``
-instead of the primary campaign feature prefix.
 """
 
 from __future__ import annotations
 
+import json
+import logging
 import tempfile
+import time
+from collections import Counter
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
+import pandas as pd
 import typer
+from openai.types import Batch
 
 from data_platform.generate_features.campaign_cost_report import (
     CAMPAIGN_LLM_FEATURES,
+    COST_REPORT_SUFFIX,
     DEFAULT_BATCH_INPUT_USD_PER_MILLION_TOKENS,
     DEFAULT_BATCH_OUTPUT_USD_PER_MILLION_TOKENS,
     PRICING_SOURCE_URL,
     BatchPricing,
+    RequestUsage,
     build_feature_cost_report,
+    request_usages_from_output_text,
 )
 from data_platform.generate_features.deterministic_smoke_sample import (
+    SMOKE_POST_COUNT,
     load_deterministic_ten_posts,
 )
 from data_platform.generate_features.engines.openai_engine import (
+    CUSTOM_ID_INDEX_WIDTH,
+    CUSTOM_ID_PREFIX,
     DEFAULT_OPENAI_BATCH_ENGINE_CONFIG,
     OpenAIBatchClient,
+    OpenAIBatchEngine,
     create_openai_client,
+    submit_active_batch,
 )
 from data_platform.generate_features.generate_features import CAMPAIGN_ENGINE_TYPE
 from data_platform.generate_features.generate_twitter_features import TWITTER_SPEC
+from data_platform.generate_features.models import FeatureRunConfig, FeatureSpec, LabelTask
+from data_platform.generate_features.openai_batch_state import load_active_batch_state
 from data_platform.generate_features.registry import FEATURE_REGISTRY
+from data_platform.generate_features.s3_feature_batches import (
+    attach_row_metadata,
+    campaign_row_columns,
+    parquet_rows,
+    rows_to_parquet_bytes,
+    validate_campaign_rows,
+)
 from data_platform.generate_features.s3_feature_campaign import (
     CampaignObjectStore,
     FeaturePaths,
     run_id_for_feature,
 )
-from data_platform.generate_features.smoke_bluesky_campaign import (
-    CHECK_CANONICAL_TOUCHED,
-    CHECK_NO_BATCHES,
-    CHECK_RESUME_EVIDENCE_OK,
-    CHECK_SMOKE_OUTPUT_OK,
-    CountingOpenAIClient,
-    SmokePaths,
-    SmokeResult,
-    build_resume_evidence,
-    checks_passed,
-    resume_and_collect_rows,
-    run_s3_checks,
-    submit_and_interrupt,
-    write_git_copies,
-    write_smoke_objects,
-)
 from data_platform.generate_features.twitter_campaign_config import (
     load_twitter_campaign_config,
 )
+from data_platform.utils.platform_specific_columns import (
+    STANDARDIZED_SOURCE_RECORD_ID_COLUMN,
+    STANDARDIZED_TEXT_COLUMN,
+)
 from lib.constants import REPO_ROOT
+from lib.timestamp_utils import get_current_timestamp
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_SMOKE_REPORTS_DIR = (
     REPO_ROOT / "docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke"
 )
+FILES_CREATE_CALL = "files.create"
+BATCHES_CREATE_CALL = "batches.create"
+SMOKE_BATCH_INDEX = 0
+SMOKE_ATTEMPT_COUNT = 1
+RESUME_EVIDENCE_SUFFIX = "_resume_evidence.json"
+S3_CHECKS_SUFFIX = "_s3_checks.txt"
+JSON_INDENT = 2
+CHECK_SMOKE_OBJECTS_UNTAGGED = "smoke_objects_exist_untagged"
+CHECK_SMOKE_OUTPUT_OK = "s3_smoke_output_ok"
+CHECK_RESUME_EVIDENCE_OK = "s3_smoke_resume_evidence_ok"
+CHECK_NO_BATCHES = "no_batches_prefix_objects"
 CHECK_PRIMARY_TOUCHED = "primary_smoke_prefix_touched"
 SMOKE_RUN_DIR_PREFIX = "smoke_twitter_campaign_"
+
+
+class _CountingNamespace:
+    """Delegates to ``client.files`` or ``client.batches`` and counts ``create`` calls."""
+
+    def __init__(self, target: Any, calls: Counter[str], call_name: str) -> None:
+        self._target = target
+        self._calls = calls
+        self._call_name = call_name
+
+    def __getattr__(self, name: str) -> Any:
+        attribute = getattr(self._target, name)
+        if name != "create":
+            return attribute
+
+        def counted_create(*args: Any, **kwargs: Any) -> Any:
+            self._calls[self._call_name] += 1
+            return attribute(*args, **kwargs)
+
+        return counted_create
+
+
+class CountingOpenAIClient:
+    """OpenAI client wrapper whose ``calls`` counter records every upload and batch creation."""
+
+    def __init__(self, client: OpenAIBatchClient) -> None:
+        self.calls: Counter[str] = Counter()
+        self.files: Any = _CountingNamespace(client.files, self.calls, FILES_CREATE_CALL)
+        self.batches: Any = _CountingNamespace(client.batches, self.calls, BATCHES_CREATE_CALL)
+
+
+@dataclass(frozen=True)
+class SmokePaths:
+    """Smoke paths in use plus the primary paths they must not overlap."""
+
+    paths: FeaturePaths
+    primary: FeaturePaths
+    smoke_prefix_uri: str
+
+
+@dataclass(frozen=True)
+class InterruptedJob:
+    """The provider job state saved before the deliberate interruption, and the calls it took."""
+
+    state: dict[str, Any]
+    submit_calls: dict[str, int]
+    interrupted_at: str
+
+
+@dataclass(frozen=True)
+class ResumedJob:
+    """Rows and usage collected by the engine that reattached to the interrupted job."""
+
+    rows: list[dict[str, Any]]
+    request_usages: list[RequestUsage]
+    last_batch: Batch
+    resume_calls: dict[str, int]
+    resumed_at: str
+
+
+@dataclass(frozen=True)
+class SmokeResult:
+    """Everything one smoke run produced, for printing and for the Git copies."""
+
+    smoke_prefix_uri: str
+    cost_report: dict[str, Any]
+    resume_evidence: dict[str, Any]
+    checks: dict[str, bool]
+    cost_report_path: Path
 
 
 def build_twitter_smoke_paths(
@@ -94,7 +191,7 @@ def build_twitter_smoke_paths(
     if smoke_prefix is None:
         return SmokePaths(
             paths=primary,
-            canonical=primary,
+            primary=primary,
             smoke_prefix_uri=primary.uri(primary.smoke_prefix),
         )
     paths = FeaturePaths.from_root_uri(smoke_prefix, feature)
@@ -107,7 +204,266 @@ def build_twitter_smoke_paths(
             f"smoke prefix {smoke_prefix!r} overlaps the primary feature prefix "
             f"{primary.uri(primary.prefix)}"
         )
-    return SmokePaths(paths=paths, canonical=primary, smoke_prefix_uri=smoke_prefix)
+    return SmokePaths(paths=paths, primary=primary, smoke_prefix_uri=smoke_prefix)
+
+
+def _tasks(posts: pd.DataFrame) -> list[LabelTask]:
+    return [
+        LabelTask(
+            uri=str(row[STANDARDIZED_SOURCE_RECORD_ID_COLUMN]),
+            text=str(row[STANDARDIZED_TEXT_COLUMN]),
+        )
+        for _, row in posts.iterrows()
+    ]
+
+
+def _submit_calls(client: CountingOpenAIClient) -> dict[str, int]:
+    return {name: client.calls[name] for name in (FILES_CREATE_CALL, BATCHES_CREATE_CALL)}
+
+
+def submit_and_interrupt(
+    client: CountingOpenAIClient,
+    spec: FeatureSpec,
+    posts: pd.DataFrame,
+    *,
+    run_dir: Path,
+) -> InterruptedJob:
+    """Upload the ten requests, create one provider batch, save its polling state, and stop."""
+    state = submit_active_batch(
+        client,
+        spec,
+        DEFAULT_OPENAI_BATCH_ENGINE_CONFIG,
+        _tasks(posts),
+        run_dir=run_dir,
+        feature_name=spec.name,
+        batch_index=SMOKE_BATCH_INDEX,
+        attempt_count=SMOKE_ATTEMPT_COUNT,
+    )
+    logger.info(
+        "Deliberate smoke interruption after provider submit",
+        extra={"batch_id": state["batch_id"], "feature_name": spec.name},
+    )
+    return InterruptedJob(
+        state=state,
+        submit_calls=_submit_calls(client),
+        interrupted_at=get_current_timestamp(),
+    )
+
+
+def resume_and_collect_rows(
+    client: CountingOpenAIClient,
+    spec: FeatureSpec,
+    posts: pd.DataFrame,
+    *,
+    run_dir: Path,
+    run_id: str,
+) -> ResumedJob:
+    """Let a fresh engine reattach to the saved job and return Q44 rows and per-request usage.
+
+    Raises
+    ------
+    RuntimeError
+        When any post ends without a valid row, or the engine reports no
+        completed batch.
+    """
+    tasks = _tasks(posts)
+    engine = OpenAIBatchEngine(
+        spec,
+        FeatureRunConfig(batch_size=len(tasks)),
+        client,
+        DEFAULT_OPENAI_BATCH_ENGINE_CONFIG,
+        time.sleep,
+    )
+    rows_by_id: dict[str, dict[str, Any]] = {}
+    last_state: dict[str, Any] = {}
+
+    def write_rows(rows: list[dict[str, Any]]) -> None:
+        state = load_active_batch_state(run_dir, spec.name)
+        if state is None:
+            raise RuntimeError("engine delivered rows without an active batch state")
+        last_state.clear()
+        last_state.update(state)
+        request_ids = {
+            uri: f"{CUSTOM_ID_PREFIX}{index:0{CUSTOM_ID_INDEX_WIDTH}d}"
+            for index, uri in enumerate(state["pending_source_record_ids"])
+        }
+        with_metadata = attach_row_metadata(
+            rows,
+            run_id=run_id,
+            batch_id=state["batch_id"],
+            request_ids=request_ids,
+            attempt_count=int(state["attempt_count"]),
+        )
+        rows_by_id.update({row["source_record_id"]: row for row in with_metadata})
+
+    resumed_at = get_current_timestamp()
+    failures = engine.label_chunk(
+        tasks,
+        feature_name=spec.name,
+        run_dir=run_dir,
+        batch_index=SMOKE_BATCH_INDEX,
+        write_rows=write_rows,
+    )
+    if failures:
+        detail = "; ".join(f"{failure.source_record_id}: {failure.error}" for failure in failures)
+        raise RuntimeError(f"smoke left {len(failures)} posts unlabeled: {detail}")
+    missing = [task.uri for task in tasks if task.uri not in rows_by_id]
+    if missing:
+        raise RuntimeError(f"smoke produced no row for {missing}")
+    last_batch = engine.last_batch
+    if last_batch is None or last_batch.output_file_id is None:
+        raise RuntimeError("resumed engine reported no completed batch with output")
+    output_text = client.files.content(last_batch.output_file_id).text
+    return ResumedJob(
+        rows=[rows_by_id[task.uri] for task in tasks],
+        request_usages=request_usages_from_output_text(
+            output_text, list(last_state["pending_source_record_ids"])
+        ),
+        last_batch=last_batch,
+        resume_calls=_submit_calls(client),
+        resumed_at=resumed_at,
+    )
+
+
+def build_resume_evidence(
+    *,
+    feature: str,
+    run_id: str,
+    interrupted: InterruptedJob,
+    resumed: ResumedJob,
+) -> dict[str, Any]:
+    """Return the interrupt-and-resume proof for ``resume_evidence.json``."""
+    same_batch = resumed.last_batch.id == interrupted.state["batch_id"]
+    no_new_jobs = all(count == 0 for count in resumed.resume_calls.values())
+    return {
+        "feature": feature,
+        "run_id": run_id,
+        "batch_id": interrupted.state["batch_id"],
+        "input_file_id": interrupted.state["input_file_id"],
+        "submitted_at": interrupted.state["submitted_at"],
+        "interrupted_at": interrupted.interrupted_at,
+        "state_at_interrupt": interrupted.state,
+        "resumed_at": resumed.resumed_at,
+        "submit_calls_before_interrupt": interrupted.submit_calls,
+        "submit_calls_after_resume": resumed.resume_calls,
+        "resumed_batch_id": resumed.last_batch.id,
+        "reattached_same_batch_id": same_batch,
+        "resumed_batch_status": resumed.last_batch.status,
+        "rows_written": len(resumed.rows),
+        "provider_batch_ids_in_output": sorted({str(row["batch_id"]) for row in resumed.rows}),
+        "resume_ok": no_new_jobs and same_batch and len(resumed.rows) == SMOKE_POST_COUNT,
+    }
+
+
+def _json_bytes(document: dict[str, Any]) -> bytes:
+    return f"{json.dumps(document, indent=JSON_INDENT)}\n".encode("utf-8")
+
+
+def write_smoke_objects(
+    store: CampaignObjectStore,
+    paths: FeaturePaths,
+    *,
+    posts: pd.DataFrame,
+    rows: list[dict[str, Any]],
+    spec: FeatureSpec,
+    run_id: str,
+    cost_report: dict[str, Any],
+    resume_evidence: dict[str, Any],
+) -> None:
+    """Put the four untagged smoke objects under ``paths.smoke_prefix`` with If-None-Match *.
+
+    Raises
+    ------
+    FileExistsError
+        When any of the four objects already exists.
+    ValueError
+        When ``rows`` fail campaign row validation.
+    """
+    validate_campaign_rows(rows, spec, run_id=run_id)
+    store.put_new(
+        paths.smoke_input_key,
+        rows_to_parquet_bytes(posts.to_dict(orient="records"), list(posts.columns)),
+    )
+    store.put_new(paths.smoke_output_key, rows_to_parquet_bytes(rows, campaign_row_columns(spec)))
+    store.put_new(paths.smoke_cost_report_key, _json_bytes(cost_report))
+    store.put_new(paths.smoke_resume_evidence_key, _json_bytes(resume_evidence))
+
+
+def _exists_untagged(store: CampaignObjectStore, key: str) -> tuple[bool, bool]:
+    exists = store.get(key) is not None
+    untagged = exists and store.get_tags(key) == {}
+    return exists, untagged
+
+
+def run_s3_checks(
+    store: CampaignObjectStore,
+    smoke_paths: SmokePaths,
+    *,
+    spec: FeatureSpec,
+    primary_smoke_keys_before: list[str],
+) -> tuple[dict[str, bool], list[str]]:
+    """Verify the smoke objects and return named checks plus one text line per observation."""
+    paths = smoke_paths.paths
+    lines: list[str] = []
+    all_untagged = True
+    for key in (
+        paths.smoke_input_key,
+        paths.smoke_output_key,
+        paths.smoke_cost_report_key,
+        paths.smoke_resume_evidence_key,
+    ):
+        exists, untagged = _exists_untagged(store, key)
+        all_untagged = all_untagged and exists and untagged
+        lines.append(f"exists {paths.uri(key)}={str(exists).lower()}")
+        lines.append(f"untagged {paths.uri(key)}={str(untagged).lower()}")
+    output = store.get(paths.smoke_output_key)
+    output_ok = False
+    if output is not None:
+        frame = parquet_rows(output.body)
+        output_ok = len(frame) == SMOKE_POST_COUNT and list(frame.columns) == campaign_row_columns(
+            spec
+        )
+        lines.append(f"output_rows={len(frame)}")
+        lines.append(f"output_columns={list(frame.columns)}")
+    evidence = store.get(paths.smoke_resume_evidence_key)
+    resume_ok = False
+    if evidence is not None:
+        resume_ok = bool(json.loads(evidence.body.decode("utf-8")).get("resume_ok"))
+    batch_keys = store.list_keys(paths.batches_prefix)
+    lines.append(f"batches_prefix={paths.uri(paths.batches_prefix)} objects={len(batch_keys)}")
+    primary_after = store.list_keys(smoke_paths.primary.smoke_prefix)
+    lines.append(
+        f"primary_smoke_prefix={smoke_paths.primary.uri(smoke_paths.primary.smoke_prefix)} "
+        f"objects_before={len(primary_smoke_keys_before)} objects_after={len(primary_after)}"
+    )
+    checks = {
+        CHECK_SMOKE_OBJECTS_UNTAGGED: all_untagged,
+        CHECK_SMOKE_OUTPUT_OK: output_ok and all_untagged,
+        CHECK_RESUME_EVIDENCE_OK: resume_ok and all_untagged,
+        CHECK_NO_BATCHES: not batch_keys,
+        CHECK_PRIMARY_TOUCHED: primary_after != primary_smoke_keys_before,
+    }
+    lines.extend(f"{name}={str(value).lower()}" for name, value in checks.items())
+    return checks, lines
+
+
+def write_git_copies(
+    output_dir: Path,
+    feature: str,
+    *,
+    cost_report: dict[str, Any],
+    resume_evidence: dict[str, Any],
+    check_lines: list[str],
+) -> Path:
+    """Write the cost report, resume evidence, and S3 check lines under ``output_dir``."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / f"{feature}{COST_REPORT_SUFFIX}"
+    report_path.write_bytes(_json_bytes(cost_report))
+    (output_dir / f"{feature}{RESUME_EVIDENCE_SUFFIX}").write_bytes(_json_bytes(resume_evidence))
+    (output_dir / f"{feature}{S3_CHECKS_SUFFIX}").write_text(
+        "".join(f"{line}\n" for line in check_lines), encoding="utf-8"
+    )
+    return report_path
 
 
 def run_twitter_campaign_smoke(
@@ -121,24 +477,7 @@ def run_twitter_campaign_smoke(
     pricing: BatchPricing,
     client_factory: Callable[[], OpenAIBatchClient] | None = None,
 ) -> SmokeResult:
-    """Label the ten smoke posts for ``feature`` with one deliberate interruption and resume.
-
-    Order of work: build the smoke paths and refuse a smoke prefix that
-    overlaps the primary feature prefix, load the ten posts, submit one
-    provider job and save its polling state, discard that engine, let a
-    new engine reattach to the saved job and collect the rows, build the
-    cost report and the resume evidence, write the four untagged smoke
-    objects, run the S3 checks, and write the Git copies under ``output_dir``.
-
-    Raises
-    ------
-    ValueError
-        When ``feature`` is not an OpenAI feature, ``campaign_id`` is not the
-        locked Twitter campaign id, or ``smoke_prefix`` overlaps the primary
-        feature prefix.
-    RuntimeError
-        When the resumed job leaves any of the ten posts without a valid row.
-    """
+    """Label the ten smoke posts for ``feature`` with one deliberate interruption and resume."""
     spec = FEATURE_REGISTRY.get(feature)
     if spec is None or spec.engine_type != CAMPAIGN_ENGINE_TYPE:
         raise ValueError(
@@ -148,7 +487,7 @@ def run_twitter_campaign_smoke(
     campaign = load_twitter_campaign_config(campaign_id)
     smoke_paths = build_twitter_smoke_paths(campaign_id, dataset_id, feature, smoke_prefix)
     store = CampaignObjectStore(smoke_paths.paths.bucket)
-    canonical_smoke_keys_before = store.list_keys(smoke_paths.canonical.smoke_prefix)
+    primary_smoke_keys_before = store.list_keys(smoke_paths.primary.smoke_prefix)
     posts = load_deterministic_ten_posts(dataset_id, preprocessed_run, spec=TWITTER_SPEC)
     run_id = run_id_for_feature(campaign_id, feature)
     make_client = client_factory or create_openai_client
@@ -190,7 +529,7 @@ def run_twitter_campaign_smoke(
         store,
         smoke_paths,
         spec=spec,
-        canonical_smoke_keys_before=canonical_smoke_keys_before,
+        primary_smoke_keys_before=primary_smoke_keys_before,
     )
     cost_report_path = write_git_copies(
         output_dir,
@@ -232,9 +571,22 @@ def summary_lines(result: SmokeResult) -> list[str]:
         f"{CHECK_SMOKE_OUTPUT_OK}={str(checks[CHECK_SMOKE_OUTPUT_OK]).lower()}",
         f"{CHECK_RESUME_EVIDENCE_OK}={str(checks[CHECK_RESUME_EVIDENCE_OK]).lower()}",
         f"{CHECK_NO_BATCHES}={str(checks[CHECK_NO_BATCHES]).lower()}",
-        f"{CHECK_PRIMARY_TOUCHED}={str(checks[CHECK_CANONICAL_TOUCHED]).lower()}",
+        f"{CHECK_PRIMARY_TOUCHED}={str(checks[CHECK_PRIMARY_TOUCHED]).lower()}",
         f"cost_report={_display_path(result.cost_report_path)}",
     ]
+
+
+def checks_passed(checks: dict[str, bool]) -> bool:
+    """True when every smoke object check holds and no batches object exists."""
+    return all(
+        checks[name]
+        for name in (
+            CHECK_SMOKE_OBJECTS_UNTAGGED,
+            CHECK_SMOKE_OUTPUT_OK,
+            CHECK_RESUME_EVIDENCE_OK,
+            CHECK_NO_BATCHES,
+        )
+    )
 
 
 def main(

--- a/data_platform/generate_features/smoke_twitter_campaign.py
+++ b/data_platform/generate_features/smoke_twitter_campaign.py
@@ -1,0 +1,275 @@
+"""Ten-post smoke for one feature of the Twitter LLM campaign, with interrupt-and-resume.
+
+Run from the repo root:
+
+    PYTHONPATH=. uv run python data_platform/generate_features/smoke_twitter_campaign.py \\
+        --campaign-id twitter_2026_09_06_192847_llm_features_v1 \\
+        --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \\
+        --preprocessed-run 2026_09_06-19:28:47 \\
+        --feature is_news_or_opinion \\
+        --smoke-prefix s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/twitter_step1_campaign_smoke/ \\
+        --output-dir docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/_step1_disposable
+
+Pass ``--smoke-prefix s3://bucket/root/`` to write under ``root/{feature}/smoke/``
+instead of the primary campaign feature prefix.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+import typer
+
+from data_platform.generate_features.campaign_cost_report import (
+    CAMPAIGN_LLM_FEATURES,
+    DEFAULT_BATCH_INPUT_USD_PER_MILLION_TOKENS,
+    DEFAULT_BATCH_OUTPUT_USD_PER_MILLION_TOKENS,
+    PRICING_SOURCE_URL,
+    BatchPricing,
+    build_feature_cost_report,
+)
+from data_platform.generate_features.deterministic_smoke_sample import (
+    load_deterministic_ten_posts,
+)
+from data_platform.generate_features.engines.openai_engine import (
+    DEFAULT_OPENAI_BATCH_ENGINE_CONFIG,
+    OpenAIBatchClient,
+    create_openai_client,
+)
+from data_platform.generate_features.generate_features import CAMPAIGN_ENGINE_TYPE
+from data_platform.generate_features.generate_twitter_features import TWITTER_SPEC
+from data_platform.generate_features.registry import FEATURE_REGISTRY
+from data_platform.generate_features.s3_feature_campaign import (
+    CampaignObjectStore,
+    FeaturePaths,
+    run_id_for_feature,
+)
+from data_platform.generate_features.smoke_bluesky_campaign import (
+    CHECK_CANONICAL_TOUCHED,
+    CHECK_NO_BATCHES,
+    CHECK_RESUME_EVIDENCE_OK,
+    CHECK_SMOKE_OUTPUT_OK,
+    CountingOpenAIClient,
+    SmokePaths,
+    SmokeResult,
+    build_resume_evidence,
+    checks_passed,
+    resume_and_collect_rows,
+    run_s3_checks,
+    submit_and_interrupt,
+    write_git_copies,
+    write_smoke_objects,
+)
+from data_platform.generate_features.twitter_campaign_config import (
+    load_twitter_campaign_config,
+)
+from lib.constants import REPO_ROOT
+
+DEFAULT_SMOKE_REPORTS_DIR = (
+    REPO_ROOT / "docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke"
+)
+CHECK_PRIMARY_TOUCHED = "primary_smoke_prefix_touched"
+SMOKE_RUN_DIR_PREFIX = "smoke_twitter_campaign_"
+
+
+def build_twitter_smoke_paths(
+    campaign_id: str, dataset_id: str, feature: str, smoke_prefix: str | None
+) -> SmokePaths:
+    """Return the primary Twitter feature paths, or paths under ``smoke_prefix`` when given.
+
+    Raises
+    ------
+    ValueError
+        When ``smoke_prefix`` is not an ``s3://`` URI, or when it lands on or
+        inside the primary feature prefix, or contains it.
+    """
+    primary = FeaturePaths.for_campaign(
+        campaign_id,
+        feature,
+        platform=TWITTER_SPEC.platform,
+        dataset_id=dataset_id,
+    )
+    if smoke_prefix is None:
+        return SmokePaths(
+            paths=primary,
+            canonical=primary,
+            smoke_prefix_uri=primary.uri(primary.smoke_prefix),
+        )
+    paths = FeaturePaths.from_root_uri(smoke_prefix, feature)
+    same_bucket = paths.bucket == primary.bucket
+    overlaps = paths.prefix.startswith(primary.prefix) or primary.prefix.startswith(
+        paths.prefix
+    )
+    if same_bucket and overlaps:
+        raise ValueError(
+            f"smoke prefix {smoke_prefix!r} overlaps the primary feature prefix "
+            f"{primary.uri(primary.prefix)}"
+        )
+    return SmokePaths(paths=paths, canonical=primary, smoke_prefix_uri=smoke_prefix)
+
+
+def run_twitter_campaign_smoke(
+    *,
+    campaign_id: str,
+    dataset_id: str,
+    preprocessed_run: str,
+    feature: str,
+    smoke_prefix: str | None,
+    output_dir: Path,
+    pricing: BatchPricing,
+    client_factory: Callable[[], OpenAIBatchClient] | None = None,
+) -> SmokeResult:
+    """Label the ten smoke posts for ``feature`` with one deliberate interruption and resume.
+
+    Order of work: build the smoke paths and refuse a smoke prefix that
+    overlaps the primary feature prefix, load the ten posts, submit one
+    provider job and save its polling state, discard that engine, let a
+    new engine reattach to the saved job and collect the rows, build the
+    cost report and the resume evidence, write the four untagged smoke
+    objects, run the S3 checks, and write the Git copies under ``output_dir``.
+
+    Raises
+    ------
+    ValueError
+        When ``feature`` is not an OpenAI feature, ``campaign_id`` is not the
+        locked Twitter campaign id, or ``smoke_prefix`` overlaps the primary
+        feature prefix.
+    RuntimeError
+        When the resumed job leaves any of the ten posts without a valid row.
+    """
+    spec = FEATURE_REGISTRY.get(feature)
+    if spec is None or spec.engine_type != CAMPAIGN_ENGINE_TYPE:
+        raise ValueError(
+            f"smoke requires one of the OpenAI features {list(CAMPAIGN_LLM_FEATURES)}, "
+            f"got {feature!r}"
+        )
+    campaign = load_twitter_campaign_config(campaign_id)
+    smoke_paths = build_twitter_smoke_paths(campaign_id, dataset_id, feature, smoke_prefix)
+    store = CampaignObjectStore(smoke_paths.paths.bucket)
+    canonical_smoke_keys_before = store.list_keys(smoke_paths.canonical.smoke_prefix)
+    posts = load_deterministic_ten_posts(dataset_id, preprocessed_run, spec=TWITTER_SPEC)
+    run_id = run_id_for_feature(campaign_id, feature)
+    make_client = client_factory or create_openai_client
+    with tempfile.TemporaryDirectory(prefix=SMOKE_RUN_DIR_PREFIX) as run_dir_name:
+        run_dir = Path(run_dir_name)
+        interrupted = submit_and_interrupt(
+            CountingOpenAIClient(make_client()), spec, posts, run_dir=run_dir
+        )
+        resumed = resume_and_collect_rows(
+            CountingOpenAIClient(make_client()), spec, posts, run_dir=run_dir, run_id=run_id
+        )
+    cost_report = build_feature_cost_report(
+        campaign_id=campaign_id,
+        dataset_id=dataset_id,
+        preprocessed_run=preprocessed_run,
+        feature=feature,
+        model=DEFAULT_OPENAI_BATCH_ENGINE_CONFIG.model,
+        smoke_uri=smoke_paths.paths.uri(smoke_paths.paths.smoke_prefix),
+        batch_id=interrupted.state["batch_id"],
+        batch_usage=resumed.last_batch.usage,
+        request_usages=resumed.request_usages,
+        pricing=pricing,
+        full_run_post_count=int(campaign["row_count"]),
+    )
+    resume_evidence = build_resume_evidence(
+        feature=feature, run_id=run_id, interrupted=interrupted, resumed=resumed
+    )
+    write_smoke_objects(
+        store,
+        smoke_paths.paths,
+        posts=posts,
+        rows=resumed.rows,
+        spec=spec,
+        run_id=run_id,
+        cost_report=cost_report,
+        resume_evidence=resume_evidence,
+    )
+    checks, check_lines = run_s3_checks(
+        store,
+        smoke_paths,
+        spec=spec,
+        canonical_smoke_keys_before=canonical_smoke_keys_before,
+    )
+    cost_report_path = write_git_copies(
+        output_dir,
+        feature,
+        cost_report=cost_report,
+        resume_evidence=resume_evidence,
+        check_lines=check_lines,
+    )
+    return SmokeResult(
+        smoke_prefix_uri=smoke_paths.smoke_prefix_uri,
+        cost_report=cost_report,
+        resume_evidence=resume_evidence,
+        checks=checks,
+        cost_report_path=cost_report_path,
+    )
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def summary_lines(result: SmokeResult) -> list[str]:
+    """Return the stdout lines of one Twitter smoke run."""
+    report = result.cost_report
+    checks = result.checks
+    return [
+        f"smoke_prefix={result.smoke_prefix_uri}",
+        f"smoke_rows={result.resume_evidence['rows_written']}",
+        f"full_run_row_count={report['full_run_post_count']}",
+        f"avg_input_tokens={report['avg_input_tokens_per_request']}",
+        f"max_input_tokens={report['max_input_tokens_per_request']}",
+        f"avg_output_tokens={report['avg_output_tokens_per_request']}",
+        f"max_output_tokens={report['max_output_tokens_per_request']}",
+        f"estimated_full_run_usd_avg={report['estimated_full_run_usd_avg']}",
+        f"estimated_full_run_usd_max={report['estimated_full_run_usd_max']}",
+        f"{CHECK_SMOKE_OUTPUT_OK}={str(checks[CHECK_SMOKE_OUTPUT_OK]).lower()}",
+        f"{CHECK_RESUME_EVIDENCE_OK}={str(checks[CHECK_RESUME_EVIDENCE_OK]).lower()}",
+        f"{CHECK_NO_BATCHES}={str(checks[CHECK_NO_BATCHES]).lower()}",
+        f"{CHECK_PRIMARY_TOUCHED}={str(checks[CHECK_CANONICAL_TOUCHED]).lower()}",
+        f"cost_report={_display_path(result.cost_report_path)}",
+    ]
+
+
+def main(
+    campaign_id: str = typer.Option(..., "--campaign-id"),
+    dataset_id: str = typer.Option(..., "--dataset-id"),
+    preprocessed_run: str = typer.Option(..., "--preprocessed-run"),
+    feature: str = typer.Option(..., "--feature"),
+    smoke_prefix: str | None = typer.Option(None, "--smoke-prefix"),
+    output_dir: Path | None = typer.Option(None, "--output-dir"),
+    input_usd_per_million_tokens: float = typer.Option(
+        DEFAULT_BATCH_INPUT_USD_PER_MILLION_TOKENS, "--input-usd-per-million-tokens"
+    ),
+    output_usd_per_million_tokens: float = typer.Option(
+        DEFAULT_BATCH_OUTPUT_USD_PER_MILLION_TOKENS, "--output-usd-per-million-tokens"
+    ),
+) -> None:
+    """Run the ten-post smoke for one feature, print the summary lines, and exit 1 when an S3 check fails."""
+    result = run_twitter_campaign_smoke(
+        campaign_id=campaign_id,
+        dataset_id=dataset_id,
+        preprocessed_run=preprocessed_run,
+        feature=feature,
+        smoke_prefix=smoke_prefix,
+        output_dir=output_dir or DEFAULT_SMOKE_REPORTS_DIR / feature,
+        pricing=BatchPricing(
+            source_url=PRICING_SOURCE_URL,
+            input_usd_per_million_tokens=input_usd_per_million_tokens,
+            output_usd_per_million_tokens=output_usd_per_million_tokens,
+        ),
+    )
+    for line in summary_lines(result):
+        print(line)
+    if not checks_passed(result.checks):
+        raise typer.Exit(code=1)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/data_platform/generate_features/smoke_twitter_campaign.py
+++ b/data_platform/generate_features/smoke_twitter_campaign.py
@@ -1,8 +1,12 @@
-"""Ten-post smoke for one feature of the Twitter LLM campaign, with interrupt-and-resume.
+"""Ten-post smoke for one feature of the Twitter LLM campaign.
+
+Interrupt-and-resume, including ``resume_evidence.json``, runs only for
+``is_news_or_opinion``. The other six features submit one OpenAI Batch job
+and wait. They write input, output, and cost objects only.
 
 The Bluesky smoke module cannot be imported in this tree because it still
-names helpers that were renamed. This file keeps the same interrupt, resume,
-and S3-check flow using ``attach_row_metadata`` and ``campaign_row_columns``.
+names helpers that were renamed. This file keeps the same labeling flow
+using ``attach_row_metadata`` and ``campaign_row_columns``.
 
 Run from the repo root:
 
@@ -97,8 +101,10 @@ JSON_INDENT = 2
 CHECK_SMOKE_OBJECTS_UNTAGGED = "smoke_objects_exist_untagged"
 CHECK_SMOKE_OUTPUT_OK = "s3_smoke_output_ok"
 CHECK_RESUME_EVIDENCE_OK = "s3_smoke_resume_evidence_ok"
+CHECK_RESUME_EVIDENCE_ABSENT = "resume_evidence_absent"
 CHECK_NO_BATCHES = "no_batches_prefix_objects"
 CHECK_PRIMARY_TOUCHED = "primary_smoke_prefix_touched"
+INTERRUPT_AND_RESUME_FEATURE = "is_news_or_opinion"
 SMOKE_RUN_DIR_PREFIX = "smoke_twitter_campaign_"
 
 
@@ -166,9 +172,11 @@ class SmokeResult:
 
     smoke_prefix_uri: str
     cost_report: dict[str, Any]
-    resume_evidence: dict[str, Any]
+    resume_evidence: dict[str, Any] | None
     checks: dict[str, bool]
     cost_report_path: Path
+    rows_written: int
+    require_resume_evidence: bool
 
 
 def build_twitter_smoke_paths(
@@ -219,6 +227,11 @@ def _tasks(posts: pd.DataFrame) -> list[LabelTask]:
 
 def _submit_calls(client: CountingOpenAIClient) -> dict[str, int]:
     return {name: client.calls[name] for name in (FILES_CREATE_CALL, BATCHES_CREATE_CALL)}
+
+
+def interrupt_and_resume_enabled(feature: str) -> bool:
+    """True only for ``is_news_or_opinion``, the one feature that writes resume evidence."""
+    return feature == INTERRUPT_AND_RESUME_FEATURE
 
 
 def submit_and_interrupt(
@@ -368,14 +381,16 @@ def write_smoke_objects(
     spec: FeatureSpec,
     run_id: str,
     cost_report: dict[str, Any],
-    resume_evidence: dict[str, Any],
+    resume_evidence: dict[str, Any] | None,
 ) -> None:
-    """Put the four untagged smoke objects under ``paths.smoke_prefix`` with If-None-Match *.
+    """Put untagged smoke objects under ``paths.smoke_prefix`` with If-None-Match *.
+
+    Writes ``resume_evidence.json`` only when ``resume_evidence`` is not None.
 
     Raises
     ------
     FileExistsError
-        When any of the four objects already exists.
+        When any of the objects already exists.
     ValueError
         When ``rows`` fail campaign row validation.
     """
@@ -386,7 +401,8 @@ def write_smoke_objects(
     )
     store.put_new(paths.smoke_output_key, rows_to_parquet_bytes(rows, campaign_row_columns(spec)))
     store.put_new(paths.smoke_cost_report_key, _json_bytes(cost_report))
-    store.put_new(paths.smoke_resume_evidence_key, _json_bytes(resume_evidence))
+    if resume_evidence is not None:
+        store.put_new(paths.smoke_resume_evidence_key, _json_bytes(resume_evidence))
 
 
 def _exists_untagged(store: CampaignObjectStore, key: str) -> tuple[bool, bool]:
@@ -401,17 +417,20 @@ def run_s3_checks(
     *,
     spec: FeatureSpec,
     primary_smoke_keys_before: list[str],
+    require_resume_evidence: bool,
 ) -> tuple[dict[str, bool], list[str]]:
     """Verify the smoke objects and return named checks plus one text line per observation."""
     paths = smoke_paths.paths
     lines: list[str] = []
-    all_untagged = True
-    for key in (
+    required_keys = [
         paths.smoke_input_key,
         paths.smoke_output_key,
         paths.smoke_cost_report_key,
-        paths.smoke_resume_evidence_key,
-    ):
+    ]
+    if require_resume_evidence:
+        required_keys.append(paths.smoke_resume_evidence_key)
+    all_untagged = True
+    for key in required_keys:
         exists, untagged = _exists_untagged(store, key)
         all_untagged = all_untagged and exists and untagged
         lines.append(f"exists {paths.uri(key)}={str(exists).lower()}")
@@ -426,8 +445,13 @@ def run_s3_checks(
         lines.append(f"output_rows={len(frame)}")
         lines.append(f"output_columns={list(frame.columns)}")
     evidence = store.get(paths.smoke_resume_evidence_key)
+    resume_present = evidence is not None
+    if not require_resume_evidence:
+        lines.append(
+            f"exists {paths.uri(paths.smoke_resume_evidence_key)}={str(resume_present).lower()}"
+        )
     resume_ok = False
-    if evidence is not None:
+    if require_resume_evidence and evidence is not None:
         resume_ok = bool(json.loads(evidence.body.decode("utf-8")).get("resume_ok"))
     batch_keys = store.list_keys(paths.batches_prefix)
     lines.append(f"batches_prefix={paths.uri(paths.batches_prefix)} objects={len(batch_keys)}")
@@ -439,10 +463,13 @@ def run_s3_checks(
     checks = {
         CHECK_SMOKE_OBJECTS_UNTAGGED: all_untagged,
         CHECK_SMOKE_OUTPUT_OK: output_ok and all_untagged,
-        CHECK_RESUME_EVIDENCE_OK: resume_ok and all_untagged,
         CHECK_NO_BATCHES: not batch_keys,
         CHECK_PRIMARY_TOUCHED: primary_after != primary_smoke_keys_before,
     }
+    if require_resume_evidence:
+        checks[CHECK_RESUME_EVIDENCE_OK] = resume_ok and all_untagged
+    else:
+        checks[CHECK_RESUME_EVIDENCE_ABSENT] = not resume_present
     lines.extend(f"{name}={str(value).lower()}" for name, value in checks.items())
     return checks, lines
 
@@ -452,14 +479,15 @@ def write_git_copies(
     feature: str,
     *,
     cost_report: dict[str, Any],
-    resume_evidence: dict[str, Any],
+    resume_evidence: dict[str, Any] | None,
     check_lines: list[str],
 ) -> Path:
-    """Write the cost report, resume evidence, and S3 check lines under ``output_dir``."""
+    """Write the cost report, optional resume evidence, and S3 check lines under ``output_dir``."""
     output_dir.mkdir(parents=True, exist_ok=True)
     report_path = output_dir / f"{feature}{COST_REPORT_SUFFIX}"
     report_path.write_bytes(_json_bytes(cost_report))
-    (output_dir / f"{feature}{RESUME_EVIDENCE_SUFFIX}").write_bytes(_json_bytes(resume_evidence))
+    if resume_evidence is not None:
+        (output_dir / f"{feature}{RESUME_EVIDENCE_SUFFIX}").write_bytes(_json_bytes(resume_evidence))
     (output_dir / f"{feature}{S3_CHECKS_SUFFIX}").write_text(
         "".join(f"{line}\n" for line in check_lines), encoding="utf-8"
     )
@@ -477,7 +505,11 @@ def run_twitter_campaign_smoke(
     pricing: BatchPricing,
     client_factory: Callable[[], OpenAIBatchClient] | None = None,
 ) -> SmokeResult:
-    """Label the ten smoke posts for ``feature`` with one deliberate interruption and resume."""
+    """Label the ten smoke posts for ``feature``.
+
+    ``is_news_or_opinion`` submits, interrupts, and resumes on a second client.
+    Every other OpenAI feature submits one job and waits on the same client.
+    """
     spec = FEATURE_REGISTRY.get(feature)
     if spec is None or spec.engine_type != CAMPAIGN_ENGINE_TYPE:
         raise ValueError(
@@ -491,14 +523,26 @@ def run_twitter_campaign_smoke(
     posts = load_deterministic_ten_posts(dataset_id, preprocessed_run, spec=TWITTER_SPEC)
     run_id = run_id_for_feature(campaign_id, feature)
     make_client = client_factory or create_openai_client
+    require_resume_evidence = interrupt_and_resume_enabled(feature)
     with tempfile.TemporaryDirectory(prefix=SMOKE_RUN_DIR_PREFIX) as run_dir_name:
         run_dir = Path(run_dir_name)
-        interrupted = submit_and_interrupt(
-            CountingOpenAIClient(make_client()), spec, posts, run_dir=run_dir
-        )
-        resumed = resume_and_collect_rows(
-            CountingOpenAIClient(make_client()), spec, posts, run_dir=run_dir, run_id=run_id
-        )
+        if require_resume_evidence:
+            interrupted = submit_and_interrupt(
+                CountingOpenAIClient(make_client()), spec, posts, run_dir=run_dir
+            )
+            collected = resume_and_collect_rows(
+                CountingOpenAIClient(make_client()), spec, posts, run_dir=run_dir, run_id=run_id
+            )
+            resume_evidence = build_resume_evidence(
+                feature=feature, run_id=run_id, interrupted=interrupted, resumed=collected
+            )
+            batch_id = interrupted.state["batch_id"]
+        else:
+            collected = resume_and_collect_rows(
+                CountingOpenAIClient(make_client()), spec, posts, run_dir=run_dir, run_id=run_id
+            )
+            resume_evidence = None
+            batch_id = collected.last_batch.id
     cost_report = build_feature_cost_report(
         campaign_id=campaign_id,
         dataset_id=dataset_id,
@@ -506,20 +550,17 @@ def run_twitter_campaign_smoke(
         feature=feature,
         model=DEFAULT_OPENAI_BATCH_ENGINE_CONFIG.model,
         smoke_uri=smoke_paths.paths.uri(smoke_paths.paths.smoke_prefix),
-        batch_id=interrupted.state["batch_id"],
-        batch_usage=resumed.last_batch.usage,
-        request_usages=resumed.request_usages,
+        batch_id=batch_id,
+        batch_usage=collected.last_batch.usage,
+        request_usages=collected.request_usages,
         pricing=pricing,
         full_run_post_count=int(campaign["row_count"]),
-    )
-    resume_evidence = build_resume_evidence(
-        feature=feature, run_id=run_id, interrupted=interrupted, resumed=resumed
     )
     write_smoke_objects(
         store,
         smoke_paths.paths,
         posts=posts,
-        rows=resumed.rows,
+        rows=collected.rows,
         spec=spec,
         run_id=run_id,
         cost_report=cost_report,
@@ -530,6 +571,7 @@ def run_twitter_campaign_smoke(
         smoke_paths,
         spec=spec,
         primary_smoke_keys_before=primary_smoke_keys_before,
+        require_resume_evidence=require_resume_evidence,
     )
     cost_report_path = write_git_copies(
         output_dir,
@@ -544,6 +586,8 @@ def run_twitter_campaign_smoke(
         resume_evidence=resume_evidence,
         checks=checks,
         cost_report_path=cost_report_path,
+        rows_written=len(collected.rows),
+        require_resume_evidence=require_resume_evidence,
     )
 
 
@@ -558,9 +602,9 @@ def summary_lines(result: SmokeResult) -> list[str]:
     """Return the stdout lines of one Twitter smoke run."""
     report = result.cost_report
     checks = result.checks
-    return [
+    lines = [
         f"smoke_prefix={result.smoke_prefix_uri}",
-        f"smoke_rows={result.resume_evidence['rows_written']}",
+        f"smoke_rows={result.rows_written}",
         f"full_run_row_count={report['full_run_post_count']}",
         f"avg_input_tokens={report['avg_input_tokens_per_request']}",
         f"max_input_tokens={report['max_input_tokens_per_request']}",
@@ -569,24 +613,41 @@ def summary_lines(result: SmokeResult) -> list[str]:
         f"estimated_full_run_usd_avg={report['estimated_full_run_usd_avg']}",
         f"estimated_full_run_usd_max={report['estimated_full_run_usd_max']}",
         f"{CHECK_SMOKE_OUTPUT_OK}={str(checks[CHECK_SMOKE_OUTPUT_OK]).lower()}",
-        f"{CHECK_RESUME_EVIDENCE_OK}={str(checks[CHECK_RESUME_EVIDENCE_OK]).lower()}",
-        f"{CHECK_NO_BATCHES}={str(checks[CHECK_NO_BATCHES]).lower()}",
-        f"{CHECK_PRIMARY_TOUCHED}={str(checks[CHECK_PRIMARY_TOUCHED]).lower()}",
-        f"cost_report={_display_path(result.cost_report_path)}",
     ]
-
-
-def checks_passed(checks: dict[str, bool]) -> bool:
-    """True when every smoke object check holds and no batches object exists."""
-    return all(
-        checks[name]
-        for name in (
-            CHECK_SMOKE_OBJECTS_UNTAGGED,
-            CHECK_SMOKE_OUTPUT_OK,
-            CHECK_RESUME_EVIDENCE_OK,
-            CHECK_NO_BATCHES,
+    if result.require_resume_evidence:
+        lines.append(
+            f"{CHECK_RESUME_EVIDENCE_OK}={str(checks[CHECK_RESUME_EVIDENCE_OK]).lower()}"
         )
+    else:
+        lines.append(
+            f"{CHECK_RESUME_EVIDENCE_ABSENT}={str(checks[CHECK_RESUME_EVIDENCE_ABSENT]).lower()}"
+        )
+    lines.extend(
+        [
+            f"{CHECK_NO_BATCHES}={str(checks[CHECK_NO_BATCHES]).lower()}",
+            f"{CHECK_PRIMARY_TOUCHED}={str(checks[CHECK_PRIMARY_TOUCHED]).lower()}",
+            f"cost_report={_display_path(result.cost_report_path)}",
+        ]
     )
+    return lines
+
+
+def checks_passed(checks: dict[str, bool], *, require_resume_evidence: bool) -> bool:
+    """True when the required smoke objects exist and no batches object exists.
+
+    Resume evidence is required only for ``is_news_or_opinion``. Other features
+    must not have ``resume_evidence.json``.
+    """
+    names = [
+        CHECK_SMOKE_OBJECTS_UNTAGGED,
+        CHECK_SMOKE_OUTPUT_OK,
+        CHECK_NO_BATCHES,
+    ]
+    if require_resume_evidence:
+        names.append(CHECK_RESUME_EVIDENCE_OK)
+    else:
+        names.append(CHECK_RESUME_EVIDENCE_ABSENT)
+    return all(checks[name] for name in names)
 
 
 def main(
@@ -619,7 +680,9 @@ def main(
     )
     for line in summary_lines(result):
         print(line)
-    if not checks_passed(result.checks):
+    if not checks_passed(
+        result.checks, require_resume_evidence=result.require_resume_evidence
+    ):
         raise typer.Exit(code=1)
 
 

--- a/data_platform/generate_features/twitter_campaign_config.py
+++ b/data_platform/generate_features/twitter_campaign_config.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
+from data_platform.utils.config_paths import load_yaml_config
 from lib.constants import REPO_ROOT
 
 ACCEPTED_CAMPAIGN_ID = "twitter_2026_09_06_192847_llm_features_v1"
@@ -23,4 +23,6 @@ def load_twitter_campaign_config(campaign_id: str) -> dict[str, Any]:
         If ``campaign_id`` is not the accepted Twitter campaign id. The
         message names the rejected id.
     """
-    raise NotImplementedError
+    if campaign_id != ACCEPTED_CAMPAIGN_ID:
+        raise ValueError(f"unsupported twitter campaign id: {campaign_id}")
+    return load_yaml_config(CAMPAIGN_YAML_PATH)

--- a/data_platform/generate_features/twitter_campaign_config.py
+++ b/data_platform/generate_features/twitter_campaign_config.py
@@ -1,0 +1,26 @@
+"""Load the Twitter LLM campaign YAML for one locked campaign id."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from lib.constants import REPO_ROOT
+
+ACCEPTED_CAMPAIGN_ID = "twitter_2026_09_06_192847_llm_features_v1"
+CAMPAIGN_YAML_PATH = (
+    REPO_ROOT
+    / "data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml"
+)
+
+
+def load_twitter_campaign_config(campaign_id: str) -> dict[str, Any]:
+    """Return the campaign YAML for the locked Twitter campaign id.
+
+    Raises
+    ------
+    ValueError
+        If ``campaign_id`` is not the accepted Twitter campaign id. The
+        message names the rejected id.
+    """
+    raise NotImplementedError

--- a/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
@@ -9,11 +9,15 @@ Run from the repo root:
 
 from __future__ import annotations
 
+import hashlib
+import json
+import subprocess
 from collections.abc import Sequence
 from pathlib import Path
 
 from lib.aws.s3 import S3
 from lib.constants import REPO_ROOT
+from lib.timestamp_utils import get_current_timestamp
 
 BUCKET = "mirrorview-experimental-artifacts"
 REGION = "us-east-2"
@@ -21,23 +25,46 @@ DATASET_ID = "twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547"
 PREPROCESSED_RUN = "2026_09_06-19:28:47"
 EXPECTED_OBJECT_COUNT = 1
 LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1"
+DUPLICATE_PREFIX = "data_platform/data_platform/"
 
 DATASET_ROOT = f"data_platform/data/twitter/{DATASET_ID}"
-POSTS_CSV_PATH = (
-    f"{DATASET_ROOT}/preprocessed/{PREPROCESSED_RUN}/posts.csv"
-)
+POSTS_CSV_PATH = f"{DATASET_ROOT}/preprocessed/{PREPROCESSED_RUN}/posts.csv"
 INVENTORY_PATH = REPO_ROOT / DATASET_ROOT / "s3_preprocessed_inventory.json"
 LFS_INCLUDE_PATTERNS: tuple[str, ...] = (POSTS_CSV_PATH,)
 
 
 def scoped_repo_relative_paths() -> list[str]:
-    """Return the locked upload paths. Must have length EXPECTED_OBJECT_COUNT."""
-    raise NotImplementedError
+    """Return the locked upload paths. Must have length EXPECTED_OBJECT_COUNT.
+
+    Raises
+    ------
+    RuntimeError
+        If the list does not have exactly ``EXPECTED_OBJECT_COUNT`` entries
+        or the path is missing on disk.
+    """
+    paths = [POSTS_CSV_PATH]
+    if len(paths) != EXPECTED_OBJECT_COUNT:
+        raise RuntimeError(f"expected {EXPECTED_OBJECT_COUNT} scoped paths, built {len(paths)}")
+    missing = [path for path in paths if not (REPO_ROOT / path).is_file()]
+    if missing:
+        raise RuntimeError(f"scoped paths missing on disk: {missing}")
+    return paths
 
 
 def run_git_lfs_pull(patterns: Sequence[str]) -> None:
-    """Fetch and check out Git LFS blobs for each include pattern."""
-    raise NotImplementedError
+    """Fetch and check out Git LFS blobs for each include pattern.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If any ``git lfs pull`` call exits non-zero.
+    """
+    for pattern in patterns:
+        subprocess.run(
+            ["git", "lfs", "pull", "--include", pattern],
+            cwd=REPO_ROOT,
+            check=True,
+        )
 
 
 def read_scoped_bytes(repo_relative_path: str) -> bytes:
@@ -48,40 +75,89 @@ def read_scoped_bytes(repo_relative_path: str) -> bytes:
     ValueError
         If the file still starts with the Git LFS pointer header.
     """
-    raise NotImplementedError
+    data = (REPO_ROOT / repo_relative_path).read_bytes()
+    if data.startswith(LFS_POINTER_PREFIX):
+        raise ValueError(f"Git LFS pointer was not resolved to bytes: {repo_relative_path}")
+    return data
 
 
 def sha256_hex(data: bytes) -> str:
     """Return the lowercase hex SHA-256 digest of the bytes."""
-    raise NotImplementedError
+    return hashlib.sha256(data).hexdigest()
 
 
 def content_type_for(repo_relative_path: str) -> str:
     """Return application/json for .json and application/octet-stream otherwise."""
-    raise NotImplementedError
+    if repo_relative_path.endswith(".json"):
+        return "application/json"
+    return "application/octet-stream"
 
 
 def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:
     """Upload bytes to the key equal to the path and confirm the remote SHA-256.
 
-    The S3 ETag is never used as a content hash.
+    The object is re-downloaded after the upload. The S3 ETag is never used as
+    a content hash.
 
     Returns
     -------
     dict
-        Inventory row with repo_relative_path, s3_key, bytes, and sha256.
+        Inventory row with ``repo_relative_path``, ``s3_key``, ``bytes``, and
+        ``sha256``.
+
+    Raises
+    ------
+    ValueError
+        If the key starts with ``data_platform/data_platform/``.
+    RuntimeError
+        If the re-downloaded object differs in length or SHA-256.
     """
-    raise NotImplementedError
+    key = repo_relative_path
+    if key.startswith(DUPLICATE_PREFIX):
+        raise ValueError(f"refusing duplicated data_platform prefix: {key}")
+    local_sha256 = sha256_hex(data)
+    s3.upload_bytes(key, data, content_type=content_type_for(repo_relative_path))
+    remote = s3.get_bytes(key)
+    remote_sha256 = sha256_hex(remote)
+    if len(remote) != len(data) or remote_sha256 != local_sha256:
+        raise RuntimeError(
+            f"remote object differs for {key}: "
+            f"{len(remote)} bytes {remote_sha256} != {len(data)} bytes {local_sha256}"
+        )
+    return {
+        "repo_relative_path": repo_relative_path,
+        "s3_key": key,
+        "bytes": len(data),
+        "sha256": local_sha256,
+    }
 
 
 def write_inventory(rows: list[dict], path: Path) -> None:
     """Write inventory JSON including bucket, region, dataset_id, and preprocessed_run."""
-    raise NotImplementedError
+    inventory = {
+        "bucket": BUCKET,
+        "region": REGION,
+        "dataset_id": DATASET_ID,
+        "preprocessed_run": PREPROCESSED_RUN,
+        "uploaded_at": get_current_timestamp(),
+        "object_count": len(rows),
+        "objects": sorted(rows, key=lambda row: row["repo_relative_path"]),
+    }
+    path.write_text(json.dumps(inventory, indent=2) + "\n")
 
 
 def main() -> None:
     """Pull LFS, upload the scoped csv, write inventory, and print the object count."""
-    raise NotImplementedError
+    paths = scoped_repo_relative_paths()
+    run_git_lfs_pull(LFS_INCLUDE_PATTERNS)
+    s3 = S3(BUCKET, region_name=REGION)
+    rows = []
+    for path in paths:
+        row = upload_and_verify(s3, path, read_scoped_bytes(path))
+        print(f"verified s3://{BUCKET}/{row['s3_key']} ({row['bytes']} bytes)")
+        rows.append(row)
+    write_inventory(rows, INVENTORY_PATH)
+    print(f"uploaded {len(rows)} object")
 
 
 if __name__ == "__main__":

--- a/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
@@ -1,0 +1,69 @@
+"""Copy the pinned Twitter preprocessed posts csv from Git LFS to S3.
+
+Run from the repo root:
+
+    export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+    export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+    PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from lib.constants import REPO_ROOT
+
+BUCKET = "mirrorview-experimental-artifacts"
+REGION = "us-east-2"
+DATASET_ID = "twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547"
+PREPROCESSED_RUN = "2026_09_06-19:28:47"
+EXPECTED_OBJECT_COUNT = 1
+LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1"
+
+DATASET_ROOT = f"data_platform/data/twitter/{DATASET_ID}"
+POSTS_CSV_PATH = (
+    f"{DATASET_ROOT}/preprocessed/{PREPROCESSED_RUN}/posts.csv"
+)
+INVENTORY_PATH = REPO_ROOT / DATASET_ROOT / "s3_preprocessed_inventory.json"
+LFS_INCLUDE_PATTERNS: tuple[str, ...] = (POSTS_CSV_PATH,)
+
+
+def scoped_repo_relative_paths() -> list[str]:
+    raise NotImplementedError
+
+
+def run_git_lfs_pull(patterns: Sequence[str]) -> None:
+    raise NotImplementedError
+
+
+def read_scoped_bytes(repo_relative_path: str) -> bytes:
+    raise NotImplementedError
+
+
+def sha256_hex(data: bytes) -> str:
+    raise NotImplementedError
+
+
+def content_type_for(repo_relative_path: str) -> str:
+    raise NotImplementedError
+
+
+def upload_and_verify(s3, repo_relative_path: str, data: bytes) -> dict:
+    raise NotImplementedError
+
+
+def write_inventory(rows: list[dict], path: Path) -> None:
+    raise NotImplementedError
+
+
+def main() -> None:
+    paths = scoped_repo_relative_paths()
+    run_git_lfs_pull(LFS_INCLUDE_PATTERNS)
+    rows = [upload_and_verify(None, path, read_scoped_bytes(path)) for path in paths]
+    write_inventory(rows, INVENTORY_PATH)
+    print(f"uploaded {len(rows)} object")
+
+
+if __name__ == "__main__":
+    main()

--- a/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from pathlib import Path
 
+from lib.aws.s3 import S3
 from lib.constants import REPO_ROOT
 
 BUCKET = "mirrorview-experimental-artifacts"
@@ -30,39 +31,57 @@ LFS_INCLUDE_PATTERNS: tuple[str, ...] = (POSTS_CSV_PATH,)
 
 
 def scoped_repo_relative_paths() -> list[str]:
+    """Return the locked upload paths. Must have length EXPECTED_OBJECT_COUNT."""
     raise NotImplementedError
 
 
 def run_git_lfs_pull(patterns: Sequence[str]) -> None:
+    """Fetch and check out Git LFS blobs for each include pattern."""
     raise NotImplementedError
 
 
 def read_scoped_bytes(repo_relative_path: str) -> bytes:
+    """Read a scoped file and refuse Git LFS pointer text.
+
+    Raises
+    ------
+    ValueError
+        If the file still starts with the Git LFS pointer header.
+    """
     raise NotImplementedError
 
 
 def sha256_hex(data: bytes) -> str:
+    """Return the lowercase hex SHA-256 digest of the bytes."""
     raise NotImplementedError
 
 
 def content_type_for(repo_relative_path: str) -> str:
+    """Return application/json for .json and application/octet-stream otherwise."""
     raise NotImplementedError
 
 
-def upload_and_verify(s3, repo_relative_path: str, data: bytes) -> dict:
+def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:
+    """Upload bytes to the key equal to the path and confirm the remote SHA-256.
+
+    The S3 ETag is never used as a content hash.
+
+    Returns
+    -------
+    dict
+        Inventory row with repo_relative_path, s3_key, bytes, and sha256.
+    """
     raise NotImplementedError
 
 
 def write_inventory(rows: list[dict], path: Path) -> None:
+    """Write inventory JSON including bucket, region, dataset_id, and preprocessed_run."""
     raise NotImplementedError
 
 
 def main() -> None:
-    paths = scoped_repo_relative_paths()
-    run_git_lfs_pull(LFS_INCLUDE_PATTERNS)
-    rows = [upload_and_verify(None, path, read_scoped_bytes(path)) for path in paths]
-    write_inventory(rows, INVENTORY_PATH)
-    print(f"uploaded {len(rows)} object")
+    """Pull LFS, upload the scoped csv, write inventory, and print the object count."""
+    raise NotImplementedError
 
 
 if __name__ == "__main__":

--- a/data_platform/scripts/verify_twitter_preprocessed_s3.py
+++ b/data_platform/scripts/verify_twitter_preprocessed_s3.py
@@ -9,14 +9,19 @@ Run from the repo root:
 
 from __future__ import annotations
 
-from lib.aws.s3 import S3
+import json
+
+from botocore.exceptions import ClientError
 
 from data_platform.scripts.migrate_twitter_preprocessed_to_s3 import (
     BUCKET,
     EXPECTED_OBJECT_COUNT,
     INVENTORY_PATH,
+    PREPROCESSED_RUN,
     REGION,
+    sha256_hex,
 )
+from lib.aws.s3 import S3
 
 
 def verify_inventory(inventory: dict, s3: S3) -> list[str]:
@@ -28,12 +33,51 @@ def verify_inventory(inventory: dict, s3: S3) -> list[str]:
         One message per missing or mismatched object. Empty when every object
         matches.
     """
-    raise NotImplementedError
+    problems: list[str] = []
+    for row in inventory["objects"]:
+        key = row["s3_key"]
+        try:
+            remote = s3.get_bytes(key)
+        except ClientError as exc:
+            problems.append(f"missing {key}: {exc.response['Error']['Code']}")
+            continue
+        if len(remote) != row["bytes"]:
+            problems.append(f"length mismatch {key}: {len(remote)} != {row['bytes']}")
+        remote_sha256 = sha256_hex(remote)
+        if remote_sha256 != row["sha256"]:
+            problems.append(f"sha256 mismatch {key}: {remote_sha256} != {row['sha256']}")
+    return problems
 
 
 def main() -> None:
     """Load the inventory, confirm bucket and count, and print OK or FAIL."""
-    raise NotImplementedError
+    inventory = json.loads(INVENTORY_PATH.read_text())
+    objects = inventory["objects"]
+    if inventory["bucket"] != BUCKET or inventory["region"] != REGION:
+        print(
+            f"FAIL: inventory targets {inventory['bucket']} in {inventory['region']}, "
+            f"expected {BUCKET} in {REGION}"
+        )
+        raise SystemExit(1)
+    if inventory.get("preprocessed_run") != PREPROCESSED_RUN:
+        print(
+            f"FAIL: inventory preprocessed_run {inventory.get('preprocessed_run')!r}, "
+            f"expected {PREPROCESSED_RUN!r}"
+        )
+        raise SystemExit(1)
+    if inventory["object_count"] != EXPECTED_OBJECT_COUNT or len(objects) != EXPECTED_OBJECT_COUNT:
+        print(
+            f"FAIL: inventory lists {inventory['object_count']} objects with "
+            f"{len(objects)} rows, expected {EXPECTED_OBJECT_COUNT}"
+        )
+        raise SystemExit(1)
+    problems = verify_inventory(inventory, S3(BUCKET, region_name=REGION))
+    if problems:
+        for problem in problems:
+            print(problem)
+        print(f"FAIL: {len(problems)} of {len(objects)} objects did not match")
+        raise SystemExit(1)
+    print(f"OK: {len(objects)}/{EXPECTED_OBJECT_COUNT} objects present with matching sha256")
 
 
 if __name__ == "__main__":

--- a/data_platform/scripts/verify_twitter_preprocessed_s3.py
+++ b/data_platform/scripts/verify_twitter_preprocessed_s3.py
@@ -1,0 +1,24 @@
+"""Check the Twitter preprocessed S3 inventory against the bucket.
+
+Run from the repo root:
+
+    export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+    export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+    PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py
+"""
+
+from __future__ import annotations
+
+from lib.aws.s3 import S3
+
+
+def verify_inventory(inventory: dict, s3: S3) -> list[str]:
+    raise NotImplementedError
+
+
+def main() -> None:
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    main()

--- a/data_platform/scripts/verify_twitter_preprocessed_s3.py
+++ b/data_platform/scripts/verify_twitter_preprocessed_s3.py
@@ -11,12 +11,28 @@ from __future__ import annotations
 
 from lib.aws.s3 import S3
 
+from data_platform.scripts.migrate_twitter_preprocessed_to_s3 import (
+    BUCKET,
+    EXPECTED_OBJECT_COUNT,
+    INVENTORY_PATH,
+    REGION,
+)
+
 
 def verify_inventory(inventory: dict, s3: S3) -> list[str]:
+    """Re-download every inventory object and report length or SHA-256 mismatches.
+
+    Returns
+    -------
+    list[str]
+        One message per missing or mismatched object. Empty when every object
+        matches.
+    """
     raise NotImplementedError
 
 
 def main() -> None:
+    """Load the inventory, confirm bucket and count, and print OK or FAIL."""
     raise NotImplementedError
 
 

--- a/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/plan.md
+++ b/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/plan.md
@@ -1,0 +1,70 @@
+# Add Twitter campaign config, S3 csv copy, and smoke tooling
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, frequent commits
+- Use only the approved smoke and runtime checks. Do not add or run automated tests.
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Campaign workers need the pinned Twitter posts file on S3, a campaign config for this campaign only, Twitter campaign mode, a ten-post smoke caller, cost math scaled to 6,374 rows, and watcher flags that resolve Twitter feature paths. This pull request ships that product code. It does not label all 6,374 posts.
+
+## Happy flow
+
+An operator copies the pinned preprocessed csv to S3, loads this campaign's YAML, and runs a ten-post smoke on a disposable prefix. The watcher prints a status comment and does not write to GitHub.
+
+```mermaid
+flowchart TD
+    A[Pull Git LFS csv] --> B[Upload one object to S3]
+    B --> C[Write inventory with SHA-256]
+    C --> D[Load this campaign YAML]
+    D --> E[Ten post smoke on disposable prefix]
+    E --> F[Watcher prints status]
+    F --> G[Delete disposable smoke objects]
+```
+
+## Approach
+
+Copy the Bluesky migrate, campaign Python API, smoke, cost, and watcher patterns. Keep the work to this campaign's identities. Upload only `posts.csv`. Keep Git LFS. Keep `dataset.json` as csv. Do not convert the file to parquet. Do not change registry defaults. Do not write production batch objects.
+
+## Decisions
+
+- Pinned identities and YAML fields come from `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/campaign_contract.md`.
+- The YAML loader accepts only `twitter_2026_09_06_192847_llm_features_v1`. Any other id raises `ValueError` naming the rejected id.
+- Twitter smoke imports helpers from the Bluesky smoke module. It does not edit that module. Path building uses `FeaturePaths.for_campaign` with platform `twitter`.
+- The ten-row sample loader takes an optional platform spec. Omitting it keeps today's Bluesky behavior. Twitter smoke passes `TWITTER_SPEC`.
+- Cost aggregate adds `--full-run-row-count` with default `200000`. Twitter smoke and later aggregate calls pass `6374`.
+- Watcher `--platform` and `--dataset-id` default to today's Bluesky values. The watcher calls `FeaturePaths.for_campaign` and never posts to GitHub.
+- Live smoke uses only `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/twitter_step1_campaign_smoke/`. Delete that prefix and local `_step1_disposable` copies before the PR is ready.
+- Phase 4 of implement-from-spec is given/when/then smoke and runtime checks in the step files. Do not add or run pytest.
+
+## Steps
+
+### Step 1: Upload the pinned csv and write the inventory
+
+Add migrate and verify scripts for one frozen csv path. Pull LFS, reject pointer text, upload, hash with SHA-256 of full object bytes, and write the inventory. See [steps/step1.md](steps/step1.md).
+
+### Step 2: Add the campaign YAML and the one-id loader
+
+Add the Twitter campaign YAML and a loader that returns this campaign's fields. Reject any other campaign id. See [steps/step2.md](steps/step2.md).
+
+### Step 3: Add campaign mode to the Twitter feature generator
+
+Add `campaign_id` and `preprocessed_run` to `generate_twitter_features()` the same way Bluesky campaign mode works. See [steps/step3.md](steps/step3.md).
+
+### Step 4: Wire smoke, cost row count, and watcher flags
+
+Parameterize the ten-row sample loader, add `smoke_twitter_campaign.py`, add `--full-run-row-count` on the cost aggregator, and add watcher `--platform` and `--dataset-id`. Run the live smoke commands. Delete the disposable prefix and Git copies. See [steps/step4.md](steps/step4.md).
+
+## What "done" looks like
+
+1. `posts.csv` is on S3 at the repo-relative key. The inventory SHA-256 matches the object bytes.
+2. Git still tracks the csv as LFS. `dataset.json` still says `format: csv`. No Bluesky or Reddit path was uploaded.
+3. The YAML loader returns seven OpenAI features for this campaign id and rejects any other id.
+4. `generate_twitter_features.py` accepts `--campaign-id` with `--preprocessed-run`.
+5. Disposable-prefix smoke writes ten rows, prints `full_run_row_count=6374`, and writes no production batch objects.
+6. The watcher resolves Twitter paths through `FeaturePaths.for_campaign` and does not post to GitHub.
+7. The disposable smoke prefix and `_step1_disposable` Git copies are deleted.
+8. No pytest file was added or run. No production `batches/part-*.parquet` object was written.

--- a/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/plan.md
+++ b/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/plan.md
@@ -9,7 +9,7 @@
 
 ## Overview
 
-Campaign workers need the pinned Twitter posts file on S3, a campaign config for this campaign only, Twitter campaign mode, a ten-post smoke caller, cost math scaled to 6,374 rows, and watcher flags that resolve Twitter feature paths. This pull request ships that product code. It does not label all 6,374 posts.
+Campaign workers need the pinned Twitter posts file on S3, a campaign config for one campaign, Twitter campaign mode, a ten-post smoke caller, cost math scaled to 6,374 rows, and watcher flags that resolve Twitter feature paths. The pull request ships that product code and does not label all 6,374 posts.
 
 ## Happy flow
 
@@ -27,18 +27,19 @@ flowchart TD
 
 ## Approach
 
-Copy the Bluesky migrate, campaign Python API, smoke, cost, and watcher patterns. Keep the work to this campaign's identities. Upload only `posts.csv`. Keep Git LFS. Keep `dataset.json` as csv. Do not convert the file to parquet. Do not change registry defaults. Do not write production batch objects.
+Reuse the Bluesky migrate, campaign Python API, smoke, cost, and watcher patterns for this campaign's identities only. Upload only the pinned `posts.csv`. Keep Git LFS. Keep the dataset format as csv. Do not convert the file to parquet. Do not change registry defaults. Do not write production batch objects.
 
 ## Decisions
 
-- Pinned identities and YAML fields come from `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/campaign_contract.md`.
-- The YAML loader accepts only `twitter_2026_09_06_192847_llm_features_v1`. Any other id raises `ValueError` naming the rejected id.
-- Twitter smoke imports helpers from the Bluesky smoke module. It does not edit that module. Path building uses `FeaturePaths.for_campaign` with platform `twitter`.
-- The ten-row sample loader takes an optional platform spec. Omitting it keeps today's Bluesky behavior. Twitter smoke passes `TWITTER_SPEC`.
-- Cost aggregate adds `--full-run-row-count` with default `200000`. Twitter smoke and later aggregate calls pass `6374`.
-- Watcher `--platform` and `--dataset-id` default to today's Bluesky values. The watcher calls `FeaturePaths.for_campaign` and never posts to GitHub.
-- Live smoke uses only `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/twitter_step1_campaign_smoke/`. Delete that prefix and local `_step1_disposable` copies before the PR is ready.
-- Phase 4 of implement-from-spec is given/when/then smoke and runtime checks in the step files. Do not add or run pytest.
+- Pinned identities and YAML fields live in `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/campaign_contract.md`.
+- The YAML loader accepts only campaign id `twitter_2026_09_06_192847_llm_features_v1`. Any other id raises an error that names the rejected id.
+- Twitter smoke imports helpers from the Bluesky smoke module and does not edit that module. Path building uses the existing campaign path helper with platform `twitter`.
+- The ten-row sample loader takes an optional platform spec. Omitting the spec keeps today's Bluesky behavior.
+- Cost aggregate adds a full-run row-count flag whose default stays `200000`. Twitter smoke and later aggregate calls pass `6374`.
+- Watcher platform and dataset flags default to today's Bluesky values. The watcher uses the campaign path helper and never posts to GitHub.
+- Live smoke uses only `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/twitter_step1_campaign_smoke/`. Delete that prefix and local disposable copies before the PR is ready.
+- Implement-from-spec Phase 4 is the given/when/then smoke and runtime checks in the step files. Do not add or run pytest.
+- Do not add a shared campaign-config framework, a `FeaturePaths.canonical` alias, or a third smoke module. Import Bluesky smoke helpers. Keep the Twitter loader on this campaign id only.
 
 ## Steps
 
@@ -52,19 +53,19 @@ Add the Twitter campaign YAML and a loader that returns this campaign's fields. 
 
 ### Step 3: Add campaign mode to the Twitter feature generator
 
-Add `campaign_id` and `preprocessed_run` to `generate_twitter_features()` the same way Bluesky campaign mode works. See [steps/step3.md](steps/step3.md).
+Add campaign id and preprocessed run arguments to the Twitter feature generator the same way Bluesky campaign mode works. See [steps/step3.md](steps/step3.md).
 
 ### Step 4: Wire smoke, cost row count, and watcher flags
 
-Parameterize the ten-row sample loader, add `smoke_twitter_campaign.py`, add `--full-run-row-count` on the cost aggregator, and add watcher `--platform` and `--dataset-id`. Run the live smoke commands. Delete the disposable prefix and Git copies. See [steps/step4.md](steps/step4.md).
+Parameterize the ten-row sample loader, add the Twitter smoke caller, add the full-run row-count flag on the cost aggregator, and add watcher platform and dataset flags. Run the live smoke commands. Delete the disposable prefix and Git copies. See [steps/step4.md](steps/step4.md).
 
 ## What "done" looks like
 
 1. `posts.csv` is on S3 at the repo-relative key. The inventory SHA-256 matches the object bytes.
-2. Git still tracks the csv as LFS. `dataset.json` still says `format: csv`. No Bluesky or Reddit path was uploaded.
+2. Git still tracks the csv as LFS. The dataset file still says format csv. No Bluesky or Reddit path was uploaded.
 3. The YAML loader returns seven OpenAI features for this campaign id and rejects any other id.
-4. `generate_twitter_features.py` accepts `--campaign-id` with `--preprocessed-run`.
-5. Disposable-prefix smoke writes ten rows, prints `full_run_row_count=6374`, and writes no production batch objects.
-6. The watcher resolves Twitter paths through `FeaturePaths.for_campaign` and does not post to GitHub.
-7. The disposable smoke prefix and `_step1_disposable` Git copies are deleted.
-8. No pytest file was added or run. No production `batches/part-*.parquet` object was written.
+4. The Twitter feature generator accepts campaign id together with preprocessed run.
+5. Disposable-prefix smoke writes ten rows, reports a full-run row count of 6374, and writes no production batch objects.
+6. The watcher resolves Twitter paths through the campaign path helper and does not post to GitHub.
+7. The disposable smoke prefix and local disposable Git copies are deleted.
+8. No pytest file was added or run. No production batch parquet object was written.

--- a/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step1.md
+++ b/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step1.md
@@ -1,0 +1,172 @@
+# Step 1: Upload the pinned csv and write the inventory
+
+## Scope
+
+- **Caller:** `data_platform/scripts/migrate_twitter_preprocessed_to_s3.py` `main`, then `data_platform/scripts/verify_twitter_preprocessed_s3.py` `main`.
+- **Task:** Copy the single pinned Twitter `posts.csv` to S3 at the repo-relative key, refuse Git LFS pointer text, hash with SHA-256 of full object bytes, write the inventory JSON, and verify the remote object.
+- **Out of scope:** Campaign YAML, Twitter campaign CLI, smoke, watcher, labeling 6,374 rows, converting csv to parquet, dropping Git LFS, uploading Bluesky or Reddit paths, pytest.
+
+## Files to inspect (read-only)
+
+- `/workspace/data_platform/scripts/migrate_bluesky_lfs_to_s3.py` (upload, LFS pull, pointer rejection, SHA-256, inventory writer)
+- `/workspace/data_platform/scripts/verify_bluesky_s3_migration.py` (re-download and compare SHA-256, never ETag)
+- `/workspace/lib/aws/s3.py` (`upload_bytes`, `get_bytes`)
+- `/workspace/lib/timestamp_utils.py` (`get_current_timestamp`)
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/dataset.json` (must stay `format: csv`)
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/metadata.json` (row count 6374)
+- `/workspace/.gitattributes` (Twitter csv LFS rule; do not edit)
+
+## Files allowed to change
+
+- `/workspace/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py` (new)
+- `/workspace/data_platform/scripts/verify_twitter_preprocessed_s3.py` (new)
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/s3_preprocessed_inventory.json` (new, after a successful upload)
+
+## Files forbidden to change
+
+- `/workspace/data_platform/utils/storage.py`
+- `/workspace/.gitattributes`
+- `/workspace/.gitignore`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/dataset.json`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/raw/**`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/**`
+- `/workspace/data_platform/data/bluesky/**`
+- `/workspace/data_platform/data/reddit/**`
+- `/workspace/data_platform/generate_features/registry.py`
+- `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml`
+- Any file under `/workspace/tests/`
+- Any file outside the allowed list
+
+## Locked identities
+
+| Field | Value |
+|-------|-------|
+| Bucket | `mirrorview-experimental-artifacts` |
+| Region | `us-east-2` |
+| Dataset id | `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` |
+| Preprocessed run | `2026_09_06-19:28:47` |
+| Upload scope | `data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv` |
+| Object count | `1` |
+| Hash | SHA-256 lowercase hex of full object bytes. Never use S3 ETag as a content hash. |
+| Inventory path | `data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/s3_preprocessed_inventory.json` |
+
+Primary S3 object:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv`
+
+Inventory JSON shape:
+
+```json
+{
+  "bucket": "mirrorview-experimental-artifacts",
+  "region": "us-east-2",
+  "dataset_id": "twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547",
+  "preprocessed_run": "2026_09_06-19:28:47",
+  "uploaded_at": "<UTC from lib.timestamp_utils.get_current_timestamp>",
+  "object_count": 1,
+  "objects": [
+    {
+      "repo_relative_path": "data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv",
+      "s3_key": "data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv",
+      "bytes": 2584416,
+      "sha256": "<lowercase hex of full object bytes>"
+    }
+  ]
+}
+```
+
+`bytes` must be the actual file length after a successful LFS pull. The size 2584416 is the expected nearby value, not a value to hard-code if the live file differs.
+
+## Work
+
+Copy the Bluesky migrate and verify scripts. Change them to one path.
+
+1. `run_git_lfs_pull` with include pattern `data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv`.
+2. `read_scoped_bytes` aborts with `ValueError` if the file begins with `version https://git-lfs.github.com/spec/v1`.
+3. Upload with key equal to the repo-relative path. Re-download. Compare length and SHA-256. Never use ETag.
+4. Refuse a key that starts with `data_platform/data_platform/`.
+5. Write inventory after a successful upload. Include `preprocessed_run`.
+6. Verifier loads the inventory, checks bucket, region, `object_count == 1`, re-downloads, and compares SHA-256.
+
+Content type for non-json follows `migrate_bluesky_lfs_to_s3.py` (`application/octet-stream`).
+
+## Contracts (implement-from-spec Phase 3)
+
+- `BUCKET = "mirrorview-experimental-artifacts"`
+- `REGION = "us-east-2"`
+- `EXPECTED_OBJECT_COUNT = 1`
+- `LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1"`
+- Inventory includes `preprocessed_run`.
+- Hash helper is SHA-256 of full bytes.
+
+## Given / when / then (Phase 4, no pytest)
+
+```text
+given AWS credentials exported from LAB_AWS_ACCESS_KEY_ID and LAB_AWS_ACCESS_KEY_SECRET
+when aws sts get-caller-identity
+then exit 0 and JSON Arn contains the lab IAM user
+
+given the Twitter posts.csv Git LFS pointer in the working tree
+when git lfs pull --include "data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv"
+then the file is larger than 2000 bytes and does not start with the LFS pointer header
+and printed size is near 2584416
+
+given the smudged csv on disk
+when PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+then stdout contains "uploaded 1 object"
+and the inventory lists one object at the repo-relative key
+and that object's sha256 is the SHA-256 of the local file bytes
+
+given the written inventory
+when PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py
+then stdout is "OK: 1/1 objects present with matching sha256"
+
+given git LFS tracking for the Twitter dataset csv files
+when git lfs ls-files | grep "twitter_fba4ddb2" | grep "posts.csv"
+then the preprocessed posts.csv line remains
+```
+
+## Must pass
+
+From the repo root:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+aws sts get-caller-identity
+git lfs pull --include "data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv"
+python3 -c "
+from pathlib import Path
+p = Path('data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv')
+head = p.read_bytes()[:40]
+assert not head.startswith(b'version https://git-lfs.github.com/spec/v1'), head
+assert p.stat().st_size > 2000, p.stat().st_size
+print('csv smudged ok', p.stat().st_size)
+"
+PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py
+git lfs ls-files | grep "twitter_fba4ddb2" | grep "posts.csv"
+```
+
+Expected:
+
+- `csv smudged ok` plus a byte size near 2584416
+- migrate reports `uploaded 1 object`
+- verifier prints `OK: 1/1 objects present with matching sha256`
+- `git lfs ls-files` still lists the preprocessed `posts.csv`
+
+Copy migrate and verify stdout to `/opt/cursor/artifacts/`.
+
+Commit the inventory only after verify succeeds.
+
+## Must fail
+
+- Using S3 ETag as the content hash
+- Uploading while the local file is still an LFS pointer
+- An S3 key that starts with `data_platform/data_platform/`
+- Inventory rows for raw Twitter csv, `metadata.json`, Bluesky paths, or Reddit paths
+- Removing the Git LFS pointer from git
+
+## Done when
+
+The scoped csv exists in S3 with a matching inventory SHA-256. Git still tracks the csv as LFS. No pytest was added or run.

--- a/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step1.md
+++ b/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step1.md
@@ -79,7 +79,7 @@ Inventory JSON shape:
 
 ## Work
 
-Copy the Bluesky migrate and verify scripts. Change them to one path.
+Start from the Bluesky migrate and verify scripts, then keep only one path.
 
 1. `run_git_lfs_pull` with include pattern `data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv`.
 2. `read_scoped_bytes` aborts with `ValueError` if the file begins with `version https://git-lfs.github.com/spec/v1`.

--- a/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step2.md
+++ b/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step2.md
@@ -1,0 +1,107 @@
+# Step 2: Add the campaign YAML and the one-id loader
+
+## Scope
+
+- **Caller:** `data_platform.generate_features.twitter_campaign_config.load_twitter_campaign_config`
+- **Task:** Check in the campaign YAML and load it only for campaign id `twitter_2026_09_06_192847_llm_features_v1`.
+- **Out of scope:** S3 upload, `generate_twitter_features` campaign flags, smoke, watcher, changing `FEATURE_REGISTRY`, pytest.
+
+## Files to inspect (read-only)
+
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/campaign_contract.md` (required YAML fields)
+- `/workspace/data_platform/generate_features/registry.py` (do not change defaults; confirm the seven feature names)
+
+## Files allowed to change
+
+- `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml` (new)
+- `/workspace/data_platform/generate_features/twitter_campaign_config.py` (new)
+
+## Files forbidden to change
+
+- `/workspace/data_platform/generate_features/registry.py`
+- `/workspace/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py`
+- `/workspace/data_platform/scripts/verify_twitter_preprocessed_s3.py`
+- Any file under `/workspace/tests/`
+- Any file outside the allowed list
+
+## YAML contents (exact)
+
+Path: `data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml`
+
+```yaml
+campaign_id: twitter_2026_09_06_192847_llm_features_v1
+platform: twitter
+dataset_id: twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547
+preprocessed_run: "2026_09_06-19:28:47"
+row_count: 6374
+batch_size: 2000
+engine_type: openai
+model_id: gpt-5.4-nano
+features:
+  - is_news_or_opinion
+  - is_political
+  - is_likely_spam
+  - is_self_contained
+  - is_structurally_complete
+  - political_stance
+  - llm_toxicity_tiered
+```
+
+Quote `preprocessed_run` so YAML keeps the timestamp as a string.
+
+Feature order is the serial run order. Do not add Perspective or Bedrock features.
+
+## Work
+
+1. Write the YAML with the fields above and no extra keys.
+2. Add `load_twitter_campaign_config(campaign_id: str) -> dict`.
+3. If `campaign_id` is not `twitter_2026_09_06_192847_llm_features_v1`, raise `ValueError` that names the rejected id.
+4. On the accepted id, read the YAML and return a dict with at least `row_count`, `engine_type`, and `features` so the check command prints `6374 openai 7`.
+5. Do not call `FEATURE_REGISTRY` to rewrite defaults.
+
+The Twitter feature generator does not load this YAML. Bluesky campaign mode also takes campaign id from the command line. The loader is the identity check for this campaign.
+
+## Contracts (implement-from-spec Phase 3)
+
+- Accepted campaign id: `twitter_2026_09_06_192847_llm_features_v1`
+- Return type: `dict` with YAML keys
+- Rejected id: `ValueError` whose message contains the bad id string
+
+## Given / when / then (Phase 4, no pytest)
+
+```text
+given the checked-in Twitter campaign YAML
+when load_twitter_campaign_config("twitter_2026_09_06_192847_llm_features_v1")
+then row_count is 6374, engine_type is openai, and features has length 7
+
+given the same loader
+when load_twitter_campaign_config("bluesky_2026_09_03_235130_llm_features_v1")
+then raise ValueError naming bluesky_2026_09_03_235130_llm_features_v1
+and the process exit code is non-zero
+```
+
+## Must pass
+
+```bash
+PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; c=load_twitter_campaign_config('twitter_2026_09_06_192847_llm_features_v1'); print(c['row_count'], c['engine_type'], len(c['features']))"
+```
+
+Expected: `6374 openai 7`
+
+```bash
+PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; load_twitter_campaign_config('bluesky_2026_09_03_235130_llm_features_v1')"
+```
+
+Expected: non-zero exit and `ValueError` naming `bluesky_2026_09_03_235130_llm_features_v1`.
+
+Copy both command outputs to `/opt/cursor/artifacts/`.
+
+## Must fail
+
+- Accepting any campaign id other than `twitter_2026_09_06_192847_llm_features_v1`
+- Changing `FEATURE_REGISTRY` defaults
+- Adding pytest files
+
+## Done when
+
+The YAML is checked in. The loader returns the seven features for this campaign id and rejects any other id.

--- a/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step2.md
+++ b/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step2.md
@@ -59,7 +59,7 @@ Feature order is the serial run order. Do not add Perspective or Bedrock feature
 4. On the accepted id, read the YAML and return a dict with at least `row_count`, `engine_type`, and `features` so the check command prints `6374 openai 7`.
 5. Do not call `FEATURE_REGISTRY` to rewrite defaults.
 
-The Twitter feature generator does not load this YAML. Bluesky campaign mode also takes campaign id from the command line. The loader is the identity check for this campaign.
+The Twitter feature generator does not load this YAML. Bluesky campaign mode also takes campaign id from the command line, so the loader is only the identity check for this campaign.
 
 ## Contracts (implement-from-spec Phase 3)
 

--- a/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step3.md
+++ b/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step3.md
@@ -26,7 +26,7 @@
 
 ## Work
 
-Copy the campaign branch from `generate_bluesky_features()`.
+Match the campaign branch in `generate_bluesky_features()`.
 
 1. Add optional `campaign_id: str | None = None` and `preprocessed_run: str | None = None` to `generate_twitter_features()`.
 2. When either is not `None`, call `generate_platform_campaign_feature` with `TWITTER_SPEC` and return `{feature_name: prefix_uri}`.
@@ -46,7 +46,7 @@ Do not run that production command in this pull request.
 
 Return type becomes `dict[str, Path | str]` to match Bluesky.
 
-Do not call `load_twitter_campaign_config` from this function. Campaign mode takes ids from the caller, as Bluesky does.
+Do not call `load_twitter_campaign_config` from this function. Campaign mode takes ids from the caller, matching Bluesky.
 
 ## Contracts (implement-from-spec Phase 3)
 

--- a/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step3.md
+++ b/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step3.md
@@ -1,0 +1,101 @@
+# Step 3: Add campaign mode to the Twitter feature generator
+
+## Scope
+
+- **Caller:** `data_platform.generate_features.generate_twitter_features.generate_twitter_features` and the existing Typer `main` from `build_feature_cli_main(TWITTER_SPEC, ...)`.
+- **Task:** Add `campaign_id` and `preprocessed_run` to the Python API the same way `generate_bluesky_features()` does. The CLI already passes those flags through `platform_cli.py`.
+- **Out of scope:** YAML loader, S3 migrate scripts, smoke, watcher, labeling 6,374 rows, writing production `batches/part-*.parquet` in this PR, pytest.
+
+## Files to inspect (read-only)
+
+- `/workspace/data_platform/generate_features/generate_bluesky_features.py` (campaign Python API to copy)
+- `/workspace/data_platform/generate_features/generate_twitter_features.py` (missing `campaign_id` today)
+- `/workspace/data_platform/generate_features/platform_cli.py` (`build_feature_cli_main` already has `--campaign-id` and `--preprocessed-run`; `generate_platform_campaign_feature` already passes `spec.platform`)
+
+## Files allowed to change
+
+- `/workspace/data_platform/generate_features/generate_twitter_features.py`
+
+## Files forbidden to change
+
+- `/workspace/data_platform/generate_features/platform_cli.py`
+- `/workspace/data_platform/generate_features/generate_bluesky_features.py`
+- `/workspace/data_platform/generate_features/registry.py`
+- Any file under `/workspace/tests/`
+- Any file outside the allowed list
+
+## Work
+
+Copy the campaign branch from `generate_bluesky_features()`.
+
+1. Add optional `campaign_id: str | None = None` and `preprocessed_run: str | None = None` to `generate_twitter_features()`.
+2. When either is not `None`, call `generate_platform_campaign_feature` with `TWITTER_SPEC` and return `{feature_name: prefix_uri}`.
+3. When both are `None`, keep the existing `generate_platform_features` local-run path.
+4. Update the module docstring with the campaign command:
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/generate_twitter_features.py \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --features is_news_or_opinion \
+  --batch-size 2000
+```
+
+Do not run that production command in this pull request.
+
+Return type becomes `dict[str, Path | str]` to match Bluesky.
+
+Do not call `load_twitter_campaign_config` from this function. Campaign mode takes ids from the caller, as Bluesky does.
+
+## Contracts (implement-from-spec Phase 3)
+
+```python
+def generate_twitter_features(
+    dataset_id: str,
+    *,
+    batch_size: int = 64,
+    max_concurrency: int = 80,
+    feature_subset: list[str] | None = None,
+    checkpoint: str | None = None,
+    campaign_id: str | None = None,
+    preprocessed_run: str | None = None,
+) -> dict[str, Path | str]:
+```
+
+Import `generate_platform_campaign_feature` from `platform_cli`.
+
+## Given / when / then (Phase 4, no pytest)
+
+```text
+given generate_twitter_features.py after this step
+when inspecting the signature of generate_twitter_features
+then campaign_id and preprocessed_run exist as optional keyword arguments
+
+given the Typer main from build_feature_cli_main
+when the operator passes --campaign-id with --preprocessed-run
+then the existing platform_cli campaign path runs with TWITTER_SPEC
+and this PR does not execute a 6374-row production run
+```
+
+## Must pass
+
+A runtime import check that the function accepts the campaign keywords:
+
+```bash
+PYTHONPATH=. uv run python -c "import inspect; from data_platform.generate_features.generate_twitter_features import generate_twitter_features; p=inspect.signature(generate_twitter_features).parameters; assert 'campaign_id' in p and 'preprocessed_run' in p; print('campaign kwargs ok')"
+```
+
+Expected: `campaign kwargs ok`
+
+Do not run the production campaign command.
+
+## Must fail
+
+- Writing primary campaign `batches/part-*.parquet` in this PR
+- Changing `platform_cli.py` or `FEATURE_REGISTRY`
+- Adding pytest files
+
+## Done when
+
+`generate_twitter_features()` accepts `campaign_id` and `preprocessed_run` and delegates to `generate_platform_campaign_feature` the same way Bluesky does. No production feature run has been started.

--- a/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step4.md
+++ b/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step4.md
@@ -65,7 +65,7 @@ no_batches_prefix_objects=true
 primary_smoke_prefix_touched=false
 ```
 
-Use `primary_smoke_prefix_touched` rather than the Bluesky name `canonical_smoke_prefix_touched`.
+Print `primary_smoke_prefix_touched`. Do not print the Bluesky name `canonical_smoke_prefix_touched`.
 
 Required flags: `--campaign-id`, `--dataset-id`, `--preprocessed-run`, `--feature`, `--smoke-prefix`, `--output-dir`.
 
@@ -77,7 +77,7 @@ Disposable prefix (only prefix allowed for this PR's live smoke):
 
 Add `--full-run-row-count` to `campaign_cost_report.py` aggregate mode. Default remains `200000` (`FULL_RUN_POST_COUNT`). Include `full_run_row_count` in the aggregate JSON. Print `full_run_row_count=<n>`. Do not change the Bluesky default.
 
-This PR does not run the seven-feature aggregate. Step 2 of the parent epic will pass `--full-run-row-count 6374`.
+The seven-feature aggregate is not part of this pull request. Step 2 of the parent epic will pass `--full-run-row-count 6374`.
 
 ### Watcher
 

--- a/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step4.md
+++ b/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step4.md
@@ -52,7 +52,7 @@ Call `load_deterministic_ten_posts(..., spec=TWITTER_SPEC)`.
 
 Call `build_feature_cost_report` with `full_run_post_count` equal to YAML `row_count` `6374`, not `FULL_RUN_POST_COUNT`.
 
-Interrupt and resume only the OpenAI Batch job for the requested feature. Default live proof uses `is_news_or_opinion`.
+Interrupt and resume only for `is_news_or_opinion`. The other six features submit one OpenAI Batch job, wait, and do not write `resume_evidence.json`. Default live proof uses `is_news_or_opinion`.
 
 Write untagged smoke objects under the disposable prefix. Never write `batches/part-*.parquet`.
 

--- a/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step4.md
+++ b/docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/steps/step4.md
@@ -1,0 +1,169 @@
+# Step 4: Wire smoke, cost row count, and watcher flags
+
+## Scope
+
+- **Caller:** `data_platform/generate_features/smoke_twitter_campaign.py` `main`, then `data_platform/generate_features/feature_progress_watcher.py` `main`.
+- **Task:** Twitter ten-post smoke on a disposable S3 prefix, cost aggregate `--full-run-row-count`, and watcher `--platform` / `--dataset-id` that call `FeaturePaths.for_campaign`.
+- **Out of scope:** Labeling 6,374 rows, official seven-feature smoke on the primary campaign prefix, posting to GitHub, pytest, editing `smoke_bluesky_campaign.py`.
+
+## Files to inspect (read-only)
+
+- `/workspace/data_platform/generate_features/smoke_bluesky_campaign.py` (helpers to import: interrupt, resume, S3 writes, S3 checks)
+- `/workspace/data_platform/generate_features/deterministic_smoke_sample.py` (hard-coded `BLUESKY_SPEC` today)
+- `/workspace/data_platform/generate_features/campaign_cost_report.py` (`FULL_RUN_POST_COUNT = 200000`, `build_feature_cost_report(..., full_run_post_count=...)`)
+- `/workspace/data_platform/generate_features/feature_progress_watcher.py` (calls missing `FeaturePaths.canonical`)
+- `/workspace/data_platform/generate_features/s3_feature_campaign.py` (`FeaturePaths.for_campaign`, `DEFAULT_CAMPAIGN_PLATFORM`, `DEFAULT_CAMPAIGN_DATASET_ID`)
+- `/workspace/data_platform/generate_features/generate_twitter_features.py` (`TWITTER_SPEC`)
+- `/workspace/data_platform/generate_features/twitter_campaign_config.py` (`row_count` 6374)
+
+## Files allowed to change
+
+- `/workspace/data_platform/generate_features/deterministic_smoke_sample.py`
+- `/workspace/data_platform/generate_features/smoke_twitter_campaign.py` (new)
+- `/workspace/data_platform/generate_features/campaign_cost_report.py`
+- `/workspace/data_platform/generate_features/feature_progress_watcher.py`
+
+Temporary Git copies under `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/_step1_disposable/` may exist during the live run and must be deleted before the PR is ready.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/generate_features/smoke_bluesky_campaign.py`
+- `/workspace/data_platform/generate_features/s3_feature_campaign.py`
+- `/workspace/data_platform/generate_features/registry.py`
+- `/workspace/data_platform/generate_features/generate_features.py`
+- Any file under `/workspace/tests/`
+- Any file outside the allowed list
+
+## Work
+
+### Ten-row sample
+
+Add an optional platform spec argument to `load_deterministic_ten_posts`. Default remains `BLUESKY_SPEC` so existing Bluesky callers stay valid without editing `smoke_bluesky_campaign.py`. Twitter smoke passes `TWITTER_SPEC`.
+
+Selection rule is unchanged: keep rows with non-empty `text`, sort by ascending `source_record_id`, take the first ten.
+
+### Twitter smoke
+
+Add `smoke_twitter_campaign.py`. Import interrupt, resume, object write, and S3 check helpers from `smoke_bluesky_campaign.py`. Do not copy those function bodies.
+
+Rebuild smoke paths with `FeaturePaths.for_campaign(campaign_id, feature, platform="twitter", dataset_id=dataset_id)` instead of the missing `FeaturePaths.canonical`. Refuse a `--smoke-prefix` that overlaps that primary feature prefix.
+
+Call `load_deterministic_ten_posts(..., spec=TWITTER_SPEC)`.
+
+Call `build_feature_cost_report` with `full_run_post_count` equal to YAML `row_count` `6374`, not `FULL_RUN_POST_COUNT`.
+
+Interrupt and resume only the OpenAI Batch job for the requested feature. Default live proof uses `is_news_or_opinion`.
+
+Write untagged smoke objects under the disposable prefix. Never write `batches/part-*.parquet`.
+
+Stdout must include:
+
+```text
+smoke_rows=10
+full_run_row_count=6374
+no_batches_prefix_objects=true
+primary_smoke_prefix_touched=false
+```
+
+Use `primary_smoke_prefix_touched` rather than the Bluesky name `canonical_smoke_prefix_touched`.
+
+Required flags: `--campaign-id`, `--dataset-id`, `--preprocessed-run`, `--feature`, `--smoke-prefix`, `--output-dir`.
+
+Disposable prefix (only prefix allowed for this PR's live smoke):
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/twitter_step1_campaign_smoke/`
+
+### Cost aggregate
+
+Add `--full-run-row-count` to `campaign_cost_report.py` aggregate mode. Default remains `200000` (`FULL_RUN_POST_COUNT`). Include `full_run_row_count` in the aggregate JSON. Print `full_run_row_count=<n>`. Do not change the Bluesky default.
+
+This PR does not run the seven-feature aggregate. Step 2 of the parent epic will pass `--full-run-row-count 6374`.
+
+### Watcher
+
+Add `--platform` and `--dataset-id`. When omitted, use `DEFAULT_CAMPAIGN_PLATFORM` and `DEFAULT_CAMPAIGN_DATASET_ID` from `s3_feature_campaign.py` so existing Bluesky commands still work.
+
+Replace `FeaturePaths.canonical` with `FeaturePaths.for_campaign(campaign_id, feature, platform=platform, dataset_id=dataset_id)`.
+
+Keep `--once` as the only mode. Never post to GitHub. Stdout stays the existing key=value lines plus an optional markdown fence when a 10,000-row boundary is reached. At 6,374 rows that boundary never fires. `github_write_skipped=true` must still print.
+
+## Contracts (implement-from-spec Phase 3)
+
+- `load_deterministic_ten_posts(dataset_id, preprocessed_run, spec=None)`
+- `smoke_twitter_campaign.main` flags listed above
+- `campaign_cost_report.main` gains `--full-run-row-count` default `FULL_RUN_POST_COUNT`
+- `feature_progress_watcher.main` gains `--platform` and `--dataset-id` with Bluesky defaults
+- `resolve_feature_paths` calls `FeaturePaths.for_campaign`
+
+## Given / when / then (Phase 4, no pytest)
+
+```text
+given the pinned Twitter preprocessed csv already on S3 from step 1
+and OPENAI_API_KEY set
+and disposable prefix s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/twitter_step1_campaign_smoke/
+when PYTHONPATH=. uv run python data_platform/generate_features/smoke_twitter_campaign.py \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --feature is_news_or_opinion \
+  --smoke-prefix s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/twitter_step1_campaign_smoke/ \
+  --output-dir docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/_step1_disposable
+then stdout includes smoke_rows=10, full_run_row_count=6374, no_batches_prefix_objects=true, primary_smoke_prefix_touched=false
+and no production batches/part-*.parquet object was written
+and the command may take several minutes because it waits on OpenAI Batch
+
+given watcher flags for this Twitter campaign
+when PYTHONPATH=. uv run python data_platform/generate_features/feature_progress_watcher.py \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --feature is_news_or_opinion \
+  --platform twitter \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --once
+then exit 0
+and stdout includes github_write_skipped=true
+and the process does not call the GitHub API
+
+given the live smoke has been verified
+when deleting the disposable S3 prefix and the _step1_disposable Git directory
+then those objects and files are gone before the PR is marked ready
+```
+
+## Must pass
+
+Export AWS credentials first. Wait for OpenAI Batch. Do not skip the smoke.
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+DISPOSABLE_PREFIX=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/twitter_step1_campaign_smoke/
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_twitter_campaign.py \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --feature is_news_or_opinion \
+  --smoke-prefix "$DISPOSABLE_PREFIX" \
+  --output-dir docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/_step1_disposable
+PYTHONPATH=. uv run python data_platform/generate_features/feature_progress_watcher.py \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --feature is_news_or_opinion \
+  --platform twitter \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --once
+```
+
+Copy smoke and watcher stdout to `/opt/cursor/artifacts/`.
+
+Then delete the disposable prefix and `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/smoke/_step1_disposable`.
+
+## Must fail
+
+- Smoke that writes primary campaign `batches/` objects
+- Watcher posting to GitHub
+- Changing `FEATURE_REGISTRY` defaults
+- Editing `smoke_bluesky_campaign.py`
+- Adding or running pytest
+- Leaving `_step1_disposable` files in the PR
+
+## Done when
+
+Disposable-prefix smoke labels ten posts for `is_news_or_opinion`, cost math uses 6374 rows, the watcher resolves Twitter paths through `FeaturePaths.for_campaign`, and disposable evidence is deleted.


### PR DESCRIPTION
Fixes #233

Part of #232

## Summary

Adds Twitter campaign config, copies the pinned preprocessed `posts.csv` to S3, and wires smoke, cost, and watcher tooling for campaign `twitter_2026_09_06_192847_llm_features_v1`.

Operators upload one csv object, load this campaign id only, run a ten-post OpenAI Batch smoke on a disposable prefix, and print watcher status without writing to GitHub.

## Purpose

Pull request 215 left 6,374 preprocessed Twitter posts in Git LFS csv. Campaign workers need those bytes on `mirrorview-experimental-artifacts`, a Twitter campaign id, and smoke tooling before anyone labels the full set.

The pull request ships that product code. Changing `StorageManager`, converting the dataset to parquet, dropping Git LFS, changing `FEATURE_REGISTRY`, or labeling 6,374 rows is out of scope.

## Architecture

Components:

- `migrate_twitter_preprocessed_to_s3.py` pulls Git LFS, rejects pointer text, uploads one csv, and writes SHA-256 inventory.
- `verify_twitter_preprocessed_s3.py` re-downloads the object and compares SHA-256. Never uses ETag as a content hash.
- `twitter_campaign_config.py` loads the campaign YAML for this campaign id only.
- `generate_twitter_features.py` campaign mode through the existing platform CLI.
- `smoke_twitter_campaign.py` ten-post interrupt-and-resume smoke on a disposable prefix.
- `campaign_cost_report.py` aggregate `--full-run-row-count`, default still 200000.
- `feature_progress_watcher.py` `--platform` and `--dataset-id`, paths from `FeaturePaths.for_campaign`.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    LFS[Git LFS csv] --> Local[Local Twitter feature CLI]
    Watcher[Watcher] --> Missing[Missing FeaturePaths.canonical]
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    LFS[Git LFS csv] --> Migrate[Migrate one object]
    Migrate --> S3[(S3 posts.csv)]
    YAML[Campaign YAML] --> Loader[One-id loader]
    S3 --> Smoke[Ten-post disposable smoke]
    Loader --> Smoke
    Smoke --> Watcher[Watcher for_campaign]
  end
```

## Interfaces

### Campaign YAML

`data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml`

Required fields: `campaign_id`, `platform`, `dataset_id`, `preprocessed_run`, `row_count` 6374, `batch_size` 2000, `engine_type` openai, `model_id` gpt-5.4-nano, and the seven LLM features in serial order.

`load_twitter_campaign_config` accepts only `twitter_2026_09_06_192847_llm_features_v1`. Any other id raises `ValueError` naming the rejected id.

### Inventory

`data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/s3_preprocessed_inventory.json`

Primary object:

`s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv`

Hash is SHA-256 of full object bytes.

### CLI

```bash
PYTHONPATH=. uv run python data_platform/generate_features/generate_twitter_features.py \
  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
  --preprocessed-run 2026_09_06-19:28:47 \
  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
  --features is_news_or_opinion \
  --batch-size 2000
```

Do not run that production command in this pull request.

Watcher: `--platform` and `--dataset-id` default to today's Bluesky values. `--once` is the only mode. No GitHub write.

Cost aggregate: `--full-run-row-count` default `200000`.

## How to run

From the repo root:

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
git lfs pull --include "data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv"
PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py
```

Expected: `uploaded 1 object`, then `OK: 1/1 objects present with matching sha256`.

```bash
PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; c=load_twitter_campaign_config('twitter_2026_09_06_192847_llm_features_v1'); print(c['row_count'], c['engine_type'], len(c['features']))"
```

Expected: `6374 openai 7`.

Plan: `docs/plans/2026-09-07_twitter_campaign_config_smoke_71dfb9/plan.md`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Twitter campaign configuration and feature-generation support.
  - Added a Twitter campaign smoke workflow with deterministic sampling, resumable processing, integrity checks, and local reports.
  - Added migration and verification tools for securely uploading and validating preprocessed Twitter data.
  - Added a new Twitter LLM feature configuration.

- **Improvements**
  - Cost reports now support configurable full-run row counts.
  - Progress monitoring and smoke sampling now support selectable platforms and datasets while preserving existing defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->