### PR TITLE
Add Reddit campaign smoke, mixed-engine cost aggregate, and watcher platform flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 3. The pinned Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_06_192847_llm_features_v1`, run a ten-post disposable smoke, scale cost math to 6,374 rows, and print watcher status without writing to GitHub. [PR #238](https://github.com/METResearchGroup/mirrorView-task/pull/238)
 4. The pinned Reddit preprocessed comments parquet (400,000 comments, run `2026_09_03-23:39:28`) now exists in the `mirrorview-experimental-artifacts` S3 bucket at the repo-relative key, and a committed inventory records the SHA-256 of the single object. Git LFS still holds the local copy. [PR #230](https://github.com/METResearchGroup/mirrorView-task/pull/230)
 5. Reddit campaign `reddit_2026_09_03_233928_llm_features_v1` can label four LLM features through OpenAI Batch and three through Bedrock Converse, with Bedrock content-filter failures retried through OpenAI Batch, while Bluesky campaigns stay on OpenAI. Bedrock part 0 keeps the ten smoke labels unchanged and labels the rest of that chunk. [PR #236](https://github.com/METResearchGroup/mirrorView-task/pull/236)
+6. Operators can smoke-label the same ten Reddit comments for a campaign feature, estimate mixed OpenAI Batch and Bedrock on-demand cost at 400,000 rows, and point the progress watcher at Reddit S3 prefixes with `--platform` and `--dataset-id`. [PR #239](https://github.com/METResearchGroup/mirrorView-task/pull/239)
 
 ## 2026-09-06
 

--- a/data_platform/generate_features/campaign_cost_report.py
+++ b/data_platform/generate_features/campaign_cost_report.py
@@ -19,6 +19,13 @@ from typing import Any
 import typer
 from openai.types import BatchUsage
 
+from data_platform.generate_features.campaign_engine_map import (
+    BEDROCK_ENGINE_TYPE,
+    OPENAI_ENGINE_TYPE,
+    REDDIT_CAMPAIGN_ENGINE_BY_FEATURE,
+    REDDIT_LLM_FEATURES_CAMPAIGN_ID,
+    campaign_engine_type,
+)
 from data_platform.generate_features.engines.openai_engine import (
     CUSTOM_ID_INDEX_WIDTH,
     CUSTOM_ID_PREFIX,
@@ -28,8 +35,11 @@ from data_platform.generate_features.s3_feature_campaign import run_id_for_featu
 from lib.timestamp_utils import get_current_timestamp
 
 PRICING_SOURCE_URL = "https://developers.openai.com/api/docs/pricing"
+BEDROCK_PRICING_SOURCE_URL = "https://aws.amazon.com/bedrock/pricing/"
 DEFAULT_BATCH_INPUT_USD_PER_MILLION_TOKENS = 0.10
 DEFAULT_BATCH_OUTPUT_USD_PER_MILLION_TOKENS = 0.625
+DEFAULT_BEDROCK_INPUT_USD_PER_MILLION_TOKENS = 0.035
+DEFAULT_BEDROCK_OUTPUT_USD_PER_MILLION_TOKENS = 0.14
 FULL_RUN_POST_COUNT = 200_000
 CAMPAIGN_LLM_FEATURES = tuple(
     name for name, spec in FEATURE_REGISTRY.items() if spec.engine_type == "openai"
@@ -114,6 +124,8 @@ def build_feature_cost_report(
     request_usages: list[RequestUsage],
     pricing: BatchPricing,
     full_run_post_count: int = FULL_RUN_POST_COUNT,
+    full_run_row_count: int | None = None,
+    engine_type: str = OPENAI_ENGINE_TYPE,
 ) -> dict[str, Any]:
     """Return the per-feature smoke cost report.
 
@@ -176,10 +188,15 @@ def cost_report_path(smoke_reports_dir: Path, feature: str) -> Path:
     return smoke_reports_dir / feature / f"{feature}{COST_REPORT_SUFFIX}"
 
 
+def features_for_campaign_aggregate(campaign_id: str) -> tuple[str, ...]:
+    """Return the feature names the parent aggregate must read for ``campaign_id``."""
+    raise NotImplementedError
+
+
 def aggregate_cost_reports(
     campaign_id: str,
     smoke_reports_dir: Path,
-    features: tuple[str, ...] = CAMPAIGN_LLM_FEATURES,
+    features: tuple[str, ...] | None = None,
     full_run_row_count: int = FULL_RUN_POST_COUNT,
 ) -> dict[str, Any]:
     """Sum the per-feature smoke cost reports of ``features`` into one parent estimate.
@@ -194,7 +211,11 @@ def aggregate_cost_reports(
     ValueError
         When a report describes a different campaign or feature than its path.
     """
-    paths = {feature: cost_report_path(smoke_reports_dir, feature) for feature in features}
+    resolved_features = features or CAMPAIGN_LLM_FEATURES
+    del full_run_row_count
+    paths = {
+        feature: cost_report_path(smoke_reports_dir, feature) for feature in resolved_features
+    }
     missing = [str(path) for path in paths.values() if not path.exists()]
     if missing:
         raise FileNotFoundError(f"missing {len(missing)} cost reports: {missing}")

--- a/data_platform/generate_features/campaign_cost_report.py
+++ b/data_platform/generate_features/campaign_cost_report.py
@@ -131,7 +131,11 @@ def build_feature_cost_report(
 
     Averages divide the per-request totals by the request count, maximums are
     the largest single request, and the two full-run estimates multiply
-    ``full_run_post_count`` by the per-post cost under each assumption.
+    ``full_run_row_count`` by the per-row cost under each assumption.
+
+    ``full_run_row_count`` defaults to ``full_run_post_count``. Both fields are
+    written with that integer so existing watchers can still read
+    ``full_run_post_count``.
 
     Raises
     ------
@@ -140,6 +144,7 @@ def build_feature_cost_report(
     """
     if not request_usages:
         raise ValueError("cannot build a cost report without per-request usage")
+    row_count = full_run_post_count if full_run_row_count is None else full_run_row_count
     request_count = len(request_usages)
     input_total = sum(usage.input_tokens for usage in request_usages)
     output_total = sum(usage.output_tokens for usage in request_usages)
@@ -154,6 +159,7 @@ def build_feature_cost_report(
         "feature": feature,
         "run_id": run_id_for_feature(campaign_id, feature),
         "model": model,
+        "engine_type": engine_type,
         "smoke_uri": smoke_uri,
         "generated_at": get_current_timestamp(),
         "batch_id": batch_id,
@@ -172,12 +178,13 @@ def build_feature_cost_report(
         "max_input_tokens_per_request": max_input,
         "max_output_tokens_per_request": max_output,
         "smoke_cost_usd": round(pricing.cost_usd(input_total, output_total), USD_DECIMALS),
-        "full_run_post_count": full_run_post_count,
+        "full_run_post_count": row_count,
+        "full_run_row_count": row_count,
         "estimated_full_run_usd_avg": round(
-            full_run_post_count * pricing.cost_usd(avg_input, avg_output), USD_DECIMALS
+            row_count * pricing.cost_usd(avg_input, avg_output), USD_DECIMALS
         ),
         "estimated_full_run_usd_max": round(
-            full_run_post_count * pricing.cost_usd(max_input, max_output), USD_DECIMALS
+            row_count * pricing.cost_usd(max_input, max_output), USD_DECIMALS
         ),
         "source_record_ids": [usage.source_record_id for usage in request_usages],
     }
@@ -189,8 +196,66 @@ def cost_report_path(smoke_reports_dir: Path, feature: str) -> Path:
 
 
 def features_for_campaign_aggregate(campaign_id: str) -> tuple[str, ...]:
-    """Return the feature names the parent aggregate must read for ``campaign_id``."""
-    raise NotImplementedError
+    """Return the feature names the parent aggregate must read for ``campaign_id``.
+
+    The pinned Reddit campaign uses the campaign engine map. Every other
+    campaign id keeps the OpenAI registry list so Bluesky aggregate stays
+    unchanged.
+    """
+    if campaign_id == REDDIT_LLM_FEATURES_CAMPAIGN_ID:
+        return tuple(REDDIT_CAMPAIGN_ENGINE_BY_FEATURE)
+    return CAMPAIGN_LLM_FEATURES
+
+
+def pricing_for_engine_type(engine_type: str) -> BatchPricing:
+    """Return OpenAI Batch or Bedrock on-demand prices for ``engine_type``.
+
+    Raises
+    ------
+    ValueError
+        When ``engine_type`` is not ``openai`` or ``bedrock``.
+    """
+    if engine_type == BEDROCK_ENGINE_TYPE:
+        return BatchPricing(
+            source_url=BEDROCK_PRICING_SOURCE_URL,
+            input_usd_per_million_tokens=DEFAULT_BEDROCK_INPUT_USD_PER_MILLION_TOKENS,
+            output_usd_per_million_tokens=DEFAULT_BEDROCK_OUTPUT_USD_PER_MILLION_TOKENS,
+        )
+    if engine_type == OPENAI_ENGINE_TYPE:
+        return BatchPricing(
+            source_url=PRICING_SOURCE_URL,
+            input_usd_per_million_tokens=DEFAULT_BATCH_INPUT_USD_PER_MILLION_TOKENS,
+            output_usd_per_million_tokens=DEFAULT_BATCH_OUTPUT_USD_PER_MILLION_TOKENS,
+        )
+    raise ValueError(f"unsupported engine_type {engine_type!r}")
+
+
+def _sum_usd(entries: list[dict[str, Any]], field: str, engine_type: str | None = None) -> float:
+    selected = (
+        entries
+        if engine_type is None
+        else [entry for entry in entries if entry["engine_type"] == engine_type]
+    )
+    return round(sum(entry[field] for entry in selected), USD_DECIMALS)
+
+
+def _feature_aggregate_entry(
+    campaign_id: str, feature: str, path: Path, report: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "feature": feature,
+        "report_path": str(path),
+        "model": report["model"],
+        "engine_type": campaign_engine_type(campaign_id, feature),
+        "request_count": report["request_count"],
+        "avg_input_tokens_per_request": report["avg_input_tokens_per_request"],
+        "avg_output_tokens_per_request": report["avg_output_tokens_per_request"],
+        "max_input_tokens_per_request": report["max_input_tokens_per_request"],
+        "max_output_tokens_per_request": report["max_output_tokens_per_request"],
+        "smoke_cost_usd": report["smoke_cost_usd"],
+        "estimated_full_run_usd_avg": report["estimated_full_run_usd_avg"],
+        "estimated_full_run_usd_max": report["estimated_full_run_usd_max"],
+    }
 
 
 def aggregate_cost_reports(
@@ -204,6 +269,9 @@ def aggregate_cost_reports(
     ``full_run_row_count`` is recorded on the aggregate. It defaults to
     ``FULL_RUN_POST_COUNT`` (200000). Twitter passes 6374.
 
+    Engine subtotals use ``campaign_engine_type`` for ``campaign_id``, not
+    registry default ``engine_type`` values.
+
     Raises
     ------
     FileNotFoundError
@@ -211,8 +279,7 @@ def aggregate_cost_reports(
     ValueError
         When a report describes a different campaign or feature than its path.
     """
-    resolved_features = features or CAMPAIGN_LLM_FEATURES
-    del full_run_row_count
+    resolved_features = features or features_for_campaign_aggregate(campaign_id)
     paths = {
         feature: cost_report_path(smoke_reports_dir, feature) for feature in resolved_features
     }
@@ -227,35 +294,32 @@ def aggregate_cost_reports(
                 f"{path} describes campaign {report.get('campaign_id')!r} feature "
                 f"{report.get('feature')!r}, expected {campaign_id!r} {feature!r}"
             )
-        entries.append(
-            {
-                "feature": feature,
-                "report_path": str(path),
-                "model": report["model"],
-                "request_count": report["request_count"],
-                "avg_input_tokens_per_request": report["avg_input_tokens_per_request"],
-                "avg_output_tokens_per_request": report["avg_output_tokens_per_request"],
-                "max_input_tokens_per_request": report["max_input_tokens_per_request"],
-                "max_output_tokens_per_request": report["max_output_tokens_per_request"],
-                "smoke_cost_usd": report["smoke_cost_usd"],
-                "estimated_full_run_usd_avg": report["estimated_full_run_usd_avg"],
-                "estimated_full_run_usd_max": report["estimated_full_run_usd_max"],
-            }
-        )
+        entries.append(_feature_aggregate_entry(campaign_id, feature, path, report))
+    openai_count = sum(entry["engine_type"] == OPENAI_ENGINE_TYPE for entry in entries)
+    bedrock_count = sum(entry["engine_type"] == BEDROCK_ENGINE_TYPE for entry in entries)
     return {
         "campaign_id": campaign_id,
         "generated_at": get_current_timestamp(),
         "full_run_row_count": full_run_row_count,
         "features_included": len(entries),
+        "openai_features": openai_count,
+        "bedrock_features": bedrock_count,
+        "full_run_row_count": full_run_row_count,
         "features": entries,
-        "total_smoke_cost_usd": round(
-            sum(entry["smoke_cost_usd"] for entry in entries), USD_DECIMALS
+        "total_smoke_cost_usd": _sum_usd(entries, "smoke_cost_usd"),
+        "total_estimated_full_run_usd_avg": _sum_usd(entries, "estimated_full_run_usd_avg"),
+        "total_estimated_full_run_usd_max": _sum_usd(entries, "estimated_full_run_usd_max"),
+        "openai_estimated_full_run_usd_avg": _sum_usd(
+            entries, "estimated_full_run_usd_avg", OPENAI_ENGINE_TYPE
         ),
-        "total_estimated_full_run_usd_avg": round(
-            sum(entry["estimated_full_run_usd_avg"] for entry in entries), USD_DECIMALS
+        "openai_estimated_full_run_usd_max": _sum_usd(
+            entries, "estimated_full_run_usd_max", OPENAI_ENGINE_TYPE
         ),
-        "total_estimated_full_run_usd_max": round(
-            sum(entry["estimated_full_run_usd_max"] for entry in entries), USD_DECIMALS
+        "bedrock_estimated_full_run_usd_avg": _sum_usd(
+            entries, "estimated_full_run_usd_avg", BEDROCK_ENGINE_TYPE
+        ),
+        "bedrock_estimated_full_run_usd_max": _sum_usd(
+            entries, "estimated_full_run_usd_max", BEDROCK_ENGINE_TYPE
         ),
     }
 
@@ -276,9 +340,11 @@ def main(
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(f"{json.dumps(document, indent=JSON_INDENT)}\n", encoding="utf-8")
     print(f"features_included={document['features_included']}")
-    print(f"full_run_row_count={document['full_run_row_count']}")
+    print(f"openai_features={document['openai_features']}")
+    print(f"bedrock_features={document['bedrock_features']}")
     print(f"total_estimated_full_run_usd_avg={document['total_estimated_full_run_usd_avg']}")
     print(f"total_estimated_full_run_usd_max={document['total_estimated_full_run_usd_max']}")
+    print(f"full_run_row_count={document['full_run_row_count']}")
     print(f"{output.name} written")
 
 

--- a/data_platform/generate_features/deterministic_smoke_sample.py
+++ b/data_platform/generate_features/deterministic_smoke_sample.py
@@ -17,11 +17,17 @@ import pandas as pd
 import typer
 
 from data_platform.generate_features.generate_bluesky_features import BLUESKY_SPEC
-from data_platform.generate_features.platform_cli import FeaturePlatformSpec, load_pinned_preprocessed_records
+from data_platform.generate_features.platform_cli import (
+    FeaturePlatformSpec,
+    load_pinned_preprocessed_records,
+)
 from data_platform.utils.platform_specific_columns import (
     STANDARDIZED_SOURCE_RECORD_ID_COLUMN,
     STANDARDIZED_TEXT_COLUMN,
 )
+
+PLATFORM_BLUESKY = "bluesky"
+PLATFORM_REDDIT = "reddit"
 
 SMOKE_POST_COUNT = 10
 SELECTION_RULE = (
@@ -51,51 +57,54 @@ def select_deterministic_sample(
     return ordered.head(count).reset_index(drop=True)
 
 
-def load_deterministic_ten_posts(
-    dataset_id: str,
-    preprocessed_run: str,
-    spec: FeaturePlatformSpec | None = None,
+def load_deterministic_ten_posts_for_spec(
+    spec: FeaturePlatformSpec, dataset_id: str, preprocessed_run: str
 ) -> pd.DataFrame:
-    """Load the pinned preprocessed run and return its ten smoke rows with every column.
+    """Load one pinned preprocessed run through ``spec`` and return its ten smoke rows."""
+    raise NotImplementedError
 
-    ``spec`` selects the platform storage and model. None keeps today's Bluesky
-    spec so existing Bluesky callers stay valid.
-    """
-    records = load_pinned_preprocessed_records(
-        spec or BLUESKY_SPEC, dataset_id, preprocessed_run
-    )
-    return select_deterministic_sample(records)
+
+def load_deterministic_ten_post_ids_for_spec(
+    spec: FeaturePlatformSpec, dataset_id: str, preprocessed_run: str
+) -> list[str]:
+    """Return the ten smoke ``source_record_id`` values for ``spec`` in ascending order."""
+    raise NotImplementedError
+
+
+def write_deterministic_ten_post_ids_for_spec(
+    spec: FeaturePlatformSpec, dataset_id: str, preprocessed_run: str, output: Path
+) -> Path:
+    """Write the ten ids for ``spec`` with the dataset, run, and selection rule as JSON."""
+    raise NotImplementedError
+
+
+def load_deterministic_ten_posts(dataset_id: str, preprocessed_run: str) -> pd.DataFrame:
+    """Load the pinned Bluesky preprocessed run and return its ten smoke rows with every column."""
+    return load_deterministic_ten_posts_for_spec(BLUESKY_SPEC, dataset_id, preprocessed_run)
 
 
 def load_deterministic_ten_post_ids(dataset_id: str, preprocessed_run: str) -> list[str]:
-    """Return the ten smoke ``source_record_id`` values in ascending order."""
-    posts = load_deterministic_ten_posts(dataset_id, preprocessed_run)
-    return posts[STANDARDIZED_SOURCE_RECORD_ID_COLUMN].astype(str).tolist()
+    """Return the ten Bluesky smoke ``source_record_id`` values in ascending order."""
+    return load_deterministic_ten_post_ids_for_spec(BLUESKY_SPEC, dataset_id, preprocessed_run)
 
 
 def write_deterministic_ten_post_ids(
     dataset_id: str, preprocessed_run: str, output: Path
 ) -> Path:
-    """Write the ten ids with the dataset, run, and selection rule as JSON and return ``output``."""
-    document = {
-        "dataset_id": dataset_id,
-        "preprocessed_run": preprocessed_run,
-        "selection_rule": SELECTION_RULE,
-        "source_record_ids": load_deterministic_ten_post_ids(dataset_id, preprocessed_run),
-    }
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(f"{json.dumps(document, indent=JSON_INDENT)}\n", encoding="utf-8")
-    return output
+    """Write the ten Bluesky ids with the dataset, run, and selection rule as JSON and return ``output``."""
+    return write_deterministic_ten_post_ids_for_spec(
+        BLUESKY_SPEC, dataset_id, preprocessed_run, output
+    )
 
 
 def main(
     dataset_id: str = typer.Option(..., "--dataset-id"),
     preprocessed_run: str = typer.Option(..., "--preprocessed-run"),
     output: Path = typer.Option(..., "--output"),
+    platform: str = typer.Option(PLATFORM_BLUESKY, "--platform"),
 ) -> None:
-    """Write the deterministic ten-post ids of one preprocessed run to a JSON file."""
-    written = write_deterministic_ten_post_ids(dataset_id, preprocessed_run, output)
-    print(f"deterministic_ten_post_ids={written}")
+    """Write the deterministic ten-row ids of one preprocessed run to a JSON file."""
+    raise NotImplementedError(platform)
 
 
 if __name__ == "__main__":

--- a/data_platform/generate_features/deterministic_smoke_sample.py
+++ b/data_platform/generate_features/deterministic_smoke_sample.py
@@ -61,7 +61,18 @@ def select_deterministic_sample(
 def load_deterministic_ten_posts_for_spec(
     spec: FeaturePlatformSpec, dataset_id: str, preprocessed_run: str
 ) -> pd.DataFrame:
-    """Load one pinned preprocessed run through ``spec`` and return its ten smoke rows."""
+    """Load one pinned preprocessed run through ``spec`` and return its ten smoke rows.
+
+    Parameters
+    ----------
+    spec
+        Platform storage and column settings. Bluesky callers pass ``BLUESKY_SPEC``.
+        Reddit callers pass ``REDDIT_SPEC``.
+    dataset_id
+        Dataset folder name under the platform's preprocessed tree.
+    preprocessed_run
+        Single preprocessed run directory name.
+    """
     records = load_pinned_preprocessed_records(spec, dataset_id, preprocessed_run)
     return select_deterministic_sample(records)
 

--- a/data_platform/generate_features/deterministic_smoke_sample.py
+++ b/data_platform/generate_features/deterministic_smoke_sample.py
@@ -102,9 +102,19 @@ def write_deterministic_ten_post_ids_for_spec(
     return output
 
 
-def load_deterministic_ten_posts(dataset_id: str, preprocessed_run: str) -> pd.DataFrame:
-    """Load the pinned Bluesky preprocessed run and return its ten smoke rows with every column."""
-    return load_deterministic_ten_posts_for_spec(BLUESKY_SPEC, dataset_id, preprocessed_run)
+def load_deterministic_ten_posts(
+    dataset_id: str,
+    preprocessed_run: str,
+    spec: FeaturePlatformSpec | None = None,
+) -> pd.DataFrame:
+    """Load the pinned preprocessed run and return its ten smoke rows with every column.
+
+    ``spec`` selects the platform storage. None keeps the Bluesky spec so
+    existing Bluesky callers stay valid. Twitter passes ``TWITTER_SPEC``.
+    """
+    return load_deterministic_ten_posts_for_spec(
+        spec or BLUESKY_SPEC, dataset_id, preprocessed_run
+    )
 
 
 def load_deterministic_ten_post_ids(dataset_id: str, preprocessed_run: str) -> list[str]:

--- a/data_platform/generate_features/deterministic_smoke_sample.py
+++ b/data_platform/generate_features/deterministic_smoke_sample.py
@@ -1,11 +1,12 @@
-"""Deterministic ten-post smoke sample shared by every feature of a Bluesky campaign.
+"""Deterministic ten-row smoke sample shared by every feature of a campaign.
 
-Run from the repo root to write the committed ids file:
+Run from the repo root to write the committed Reddit ids file:
 
     PYTHONPATH=. uv run python data_platform/generate_features/deterministic_smoke_sample.py \\
-        --dataset-id bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73 \\
-        --preprocessed-run 2026_09_03-23:51:30 \\
-        --output docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/smoke/deterministic_ten_post_ids.json
+        --platform reddit \\
+        --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079 \\
+        --preprocessed-run 2026_09_03-23:39:28 \\
+        --output docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/deterministic_ten_comment_ids.json
 """
 
 from __future__ import annotations
@@ -61,21 +62,33 @@ def load_deterministic_ten_posts_for_spec(
     spec: FeaturePlatformSpec, dataset_id: str, preprocessed_run: str
 ) -> pd.DataFrame:
     """Load one pinned preprocessed run through ``spec`` and return its ten smoke rows."""
-    raise NotImplementedError
+    records = load_pinned_preprocessed_records(spec, dataset_id, preprocessed_run)
+    return select_deterministic_sample(records)
 
 
 def load_deterministic_ten_post_ids_for_spec(
     spec: FeaturePlatformSpec, dataset_id: str, preprocessed_run: str
 ) -> list[str]:
     """Return the ten smoke ``source_record_id`` values for ``spec`` in ascending order."""
-    raise NotImplementedError
+    posts = load_deterministic_ten_posts_for_spec(spec, dataset_id, preprocessed_run)
+    return posts[STANDARDIZED_SOURCE_RECORD_ID_COLUMN].astype(str).tolist()
 
 
 def write_deterministic_ten_post_ids_for_spec(
     spec: FeaturePlatformSpec, dataset_id: str, preprocessed_run: str, output: Path
 ) -> Path:
     """Write the ten ids for ``spec`` with the dataset, run, and selection rule as JSON."""
-    raise NotImplementedError
+    document = {
+        "dataset_id": dataset_id,
+        "preprocessed_run": preprocessed_run,
+        "selection_rule": SELECTION_RULE,
+        "source_record_ids": load_deterministic_ten_post_ids_for_spec(
+            spec, dataset_id, preprocessed_run
+        ),
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(f"{json.dumps(document, indent=JSON_INDENT)}\n", encoding="utf-8")
+    return output
 
 
 def load_deterministic_ten_posts(dataset_id: str, preprocessed_run: str) -> pd.DataFrame:
@@ -97,6 +110,16 @@ def write_deterministic_ten_post_ids(
     )
 
 
+def _spec_for_platform(platform: str) -> FeaturePlatformSpec:
+    if platform == PLATFORM_BLUESKY:
+        return BLUESKY_SPEC
+    if platform == PLATFORM_REDDIT:
+        from data_platform.generate_features.generate_reddit_features import REDDIT_SPEC
+
+        return REDDIT_SPEC
+    raise typer.BadParameter(f"platform must be {PLATFORM_BLUESKY} or {PLATFORM_REDDIT}")
+
+
 def main(
     dataset_id: str = typer.Option(..., "--dataset-id"),
     preprocessed_run: str = typer.Option(..., "--preprocessed-run"),
@@ -104,7 +127,10 @@ def main(
     platform: str = typer.Option(PLATFORM_BLUESKY, "--platform"),
 ) -> None:
     """Write the deterministic ten-row ids of one preprocessed run to a JSON file."""
-    raise NotImplementedError(platform)
+    written = write_deterministic_ten_post_ids_for_spec(
+        _spec_for_platform(platform), dataset_id, preprocessed_run, output
+    )
+    print(f"deterministic_ten_post_ids={written}")
 
 
 if __name__ == "__main__":

--- a/data_platform/generate_features/feature_progress_watcher.py
+++ b/data_platform/generate_features/feature_progress_watcher.py
@@ -215,8 +215,6 @@ def main(
     dry_render: bool = typer.Option(False, "--dry-render"),
     once: bool = typer.Option(False, "--once"),
     github_comment_id: int | None = typer.Option(None, "--github-comment-id"),
-    platform: str = typer.Option(DEFAULT_CAMPAIGN_PLATFORM, "--platform"),
-    dataset_id: str = typer.Option(DEFAULT_CAMPAIGN_DATASET_ID, "--dataset-id"),
 ) -> None:
     """Run the watcher once and print its outcome lines.
 

--- a/data_platform/generate_features/feature_progress_watcher.py
+++ b/data_platform/generate_features/feature_progress_watcher.py
@@ -77,7 +77,6 @@ def resolve_feature_paths(
             platform=platform,
             dataset_id=dataset_id,
         )
-        )
     return FeaturePaths.from_root_uri(smoke_prefix, feature)
 
 

--- a/data_platform/generate_features/feature_progress_watcher.py
+++ b/data_platform/generate_features/feature_progress_watcher.py
@@ -67,11 +67,16 @@ def resolve_feature_paths(
 ) -> FeaturePaths:
     """Return campaign feature paths, or the paths under ``smoke_prefix/{feature}/`` when given.
 
-    Omitted ``platform`` and ``dataset_id`` keep today's Bluesky defaults.
+    Callers that serve Reddit must pass ``platform`` and ``dataset_id``.
+    Omitting them keeps the historical Bluesky defaults.
     """
     if smoke_prefix is None:
         return FeaturePaths.for_campaign(
-            campaign_id, feature, platform=platform, dataset_id=dataset_id
+            campaign_id,
+            feature,
+            platform=platform,
+            dataset_id=dataset_id,
+        )
         )
     return FeaturePaths.from_root_uri(smoke_prefix, feature)
 
@@ -206,6 +211,8 @@ def main(
     campaign_id: str = typer.Option(..., "--campaign-id"),
     feature: str = typer.Option(..., "--feature"),
     smoke_prefix: str | None = typer.Option(None, "--smoke-prefix"),
+    platform: str = typer.Option(DEFAULT_CAMPAIGN_PLATFORM, "--platform"),
+    dataset_id: str = typer.Option(DEFAULT_CAMPAIGN_DATASET_ID, "--dataset-id"),
     dry_render: bool = typer.Option(False, "--dry-render"),
     once: bool = typer.Option(False, "--once"),
     github_comment_id: int | None = typer.Option(None, "--github-comment-id"),

--- a/data_platform/generate_features/smoke_bluesky_campaign.py
+++ b/data_platform/generate_features/smoke_bluesky_campaign.py
@@ -57,11 +57,11 @@ from data_platform.generate_features.models import FeatureRunConfig, FeatureSpec
 from data_platform.generate_features.openai_batch_state import load_active_batch_state
 from data_platform.generate_features.registry import FEATURE_REGISTRY
 from data_platform.generate_features.s3_feature_batches import (
-    attach_provenance,
+    attach_row_metadata as attach_provenance,
+    campaign_row_columns as q44_columns,
     parquet_rows,
-    q44_columns,
     rows_to_parquet_bytes,
-    validate_q44_rows,
+    validate_campaign_rows as validate_q44_rows,
 )
 from data_platform.generate_features.s3_feature_campaign import (
     DEFAULT_CAMPAIGN_PLATFORM,

--- a/data_platform/generate_features/smoke_reddit_campaign.py
+++ b/data_platform/generate_features/smoke_reddit_campaign.py
@@ -1,0 +1,579 @@
+"""Ten-comment smoke for one feature of the Reddit LLM campaign, with interrupt-and-resume.
+
+Run from the repo root:
+
+    PYTHONPATH=. uv run python data_platform/generate_features/smoke_reddit_campaign.py \\
+        --campaign-id reddit_2026_09_03_233928_llm_features_v1 \\
+        --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079 \\
+        --preprocessed-run 2026_09_03-23:39:28 \\
+        --feature is_political
+
+Pass ``--smoke-prefix s3://bucket/root/`` to write under ``root/{feature}/smoke/``
+instead of the primary campaign feature prefix.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+import threading
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import typer
+
+from data_platform.generate_features.campaign_cost_report import (
+    RequestUsage,
+    build_feature_cost_report,
+    pricing_for_engine_type,
+)
+from data_platform.generate_features.campaign_engine_map import (
+    BEDROCK_ENGINE_TYPE,
+    OPENAI_ENGINE_TYPE,
+    campaign_engine_type,
+)
+from data_platform.generate_features.deterministic_smoke_sample import (
+    SMOKE_POST_COUNT,
+    load_deterministic_ten_posts_for_spec,
+)
+from data_platform.generate_features.engines.bedrock_engine import (
+    BedrockConverseEngine,
+    BedrockRuntimeClient,
+    create_bedrock_runtime_client,
+)
+from data_platform.generate_features.engines.openai_engine import (
+    DEFAULT_OPENAI_BATCH_ENGINE_CONFIG,
+    OpenAIBatchClient,
+    create_openai_client,
+)
+from data_platform.generate_features.generate_reddit_features import REDDIT_SPEC
+from data_platform.generate_features.models import FeatureRunConfig, FeatureSpec, LabelTask
+from data_platform.generate_features.registry import FEATURE_REGISTRY
+from data_platform.generate_features.s3_feature_batches import attach_row_metadata
+from data_platform.generate_features.s3_feature_campaign import (
+    CampaignObjectStore,
+    FeaturePaths,
+    run_id_for_feature,
+)
+from data_platform.generate_features.smoke_bluesky_campaign import (
+    CHECK_CANONICAL_TOUCHED,
+    CHECK_NO_BATCHES,
+    CHECK_RESUME_EVIDENCE_OK,
+    CHECK_SMOKE_OUTPUT_OK,
+    CountingOpenAIClient,
+    InterruptedJob,
+    ResumedJob,
+    SmokePaths,
+    SmokeResult,
+    _tasks,
+    build_resume_evidence,
+    checks_passed,
+    resume_and_collect_rows,
+    run_s3_checks,
+    submit_and_interrupt,
+    write_git_copies,
+    write_smoke_objects,
+)
+from lib.constants import DEFAULT_BEDROCK_NOVA_MICRO, REPO_ROOT
+from lib.timestamp_utils import get_current_timestamp
+
+logger = logging.getLogger(__name__)
+
+REDDIT_PLATFORM = "reddit"
+FULL_RUN_ROW_COUNT = 400_000
+DEFAULT_SMOKE_REPORTS_DIR = (
+    REPO_ROOT
+    / "docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke"
+)
+CONVERSE_CALL = "converse"
+BEDROCK_SMOKE_BATCH_ID = "bedrock-smoke"
+BEDROCK_REQUEST_ID_PREFIX = "bedrock-"
+BEDROCK_REQUEST_ID_WIDTH = 5
+BEDROCK_SMOKE_ATTEMPT_COUNT = 1
+BEDROCK_SMOKE_MAX_CONCURRENCY = 8
+BEDROCK_STATE_FILENAME = "bedrock_smoke_state.json"
+CHECK_PRIMARY_TOUCHED = "primary_smoke_prefix_touched"
+JSON_INDENT = 2
+
+
+@dataclass(frozen=True)
+class BedrockSmokeJob:
+    """Rows, usage, and converse counts from one Bedrock smoke engine."""
+
+    rows: list[dict[str, Any]]
+    request_usages: list[RequestUsage]
+    last_usage: dict[str, int]
+    converse_calls: int
+    stamped_at: str
+
+
+class CountingBedrockClient:
+    """Bedrock Runtime wrapper that counts ``converse`` calls and stores per-call usage."""
+
+    def __init__(self, client: BedrockRuntimeClient) -> None:
+        self._client = client
+        self._lock = threading.Lock()
+        self.calls: Counter[str] = Counter()
+        self.usages: list[tuple[str, int, int]] = []
+
+    def converse(self, **kwargs: Any) -> dict[str, Any]:
+        response = self._client.converse(**kwargs)
+        user_text = kwargs["messages"][0]["content"][0]["text"]
+        usage = response.get("usage") or {}
+        with self._lock:
+            self.calls[CONVERSE_CALL] += 1
+            self.usages.append(
+                (
+                    str(user_text),
+                    int(usage.get("inputTokens", 0)),
+                    int(usage.get("outputTokens", 0)),
+                )
+            )
+        return response
+
+
+def build_reddit_smoke_paths(
+    campaign_id: str, dataset_id: str, feature: str, smoke_prefix: str | None
+) -> SmokePaths:
+    """Return primary Reddit feature paths, or paths under ``smoke_prefix`` when it is given.
+
+    Raises
+    ------
+    ValueError
+        When ``smoke_prefix`` is not an ``s3://`` URI, or when it overlaps the
+        primary feature prefix.
+    """
+    primary = FeaturePaths.for_campaign(
+        campaign_id,
+        feature,
+        platform=REDDIT_PLATFORM,
+        dataset_id=dataset_id,
+    )
+    if smoke_prefix is None:
+        return SmokePaths(
+            paths=primary,
+            canonical=primary,
+            smoke_prefix_uri=primary.uri(primary.smoke_prefix),
+        )
+    paths = FeaturePaths.from_root_uri(smoke_prefix, feature)
+    same_bucket = paths.bucket == primary.bucket
+    overlaps = paths.prefix.startswith(primary.prefix) or primary.prefix.startswith(
+        paths.prefix
+    )
+    if same_bucket and overlaps:
+        raise ValueError(
+            f"smoke prefix {smoke_prefix!r} overlaps the primary feature prefix "
+            f"{primary.uri(primary.prefix)}"
+        )
+    return SmokePaths(paths=paths, canonical=primary, smoke_prefix_uri=smoke_prefix)
+
+
+def _bedrock_request_ids(ordered_ids: list[str]) -> dict[str, str]:
+    return {
+        source_record_id: f"{BEDROCK_REQUEST_ID_PREFIX}{index:0{BEDROCK_REQUEST_ID_WIDTH}d}"
+        for index, source_record_id in enumerate(ordered_ids)
+    }
+
+
+def _usages_for_tasks(
+    client: CountingBedrockClient, tasks: list[LabelTask]
+) -> list[RequestUsage]:
+    last_by_text: dict[str, tuple[int, int]] = {}
+    for text, input_tokens, output_tokens in client.usages:
+        last_by_text[text] = (input_tokens, output_tokens)
+    usages: list[RequestUsage] = []
+    request_ids = _bedrock_request_ids([task.uri for task in tasks])
+    for task in tasks:
+        tokens = last_by_text.get(task.text)
+        if tokens is None:
+            raise RuntimeError(f"no Bedrock usage captured for {task.uri}")
+        input_tokens, output_tokens = tokens
+        usages.append(
+            RequestUsage(
+                source_record_id=task.uri,
+                request_id=request_ids[task.uri],
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+        )
+    return usages
+
+
+def _write_bedrock_state(path: Path, job: BedrockSmokeJob) -> None:
+    document = {
+        "rows": job.rows,
+        "request_usages": [asdict(usage) for usage in job.request_usages],
+        "last_usage": job.last_usage,
+        "converse_calls": job.converse_calls,
+        "stamped_at": job.stamped_at,
+    }
+    path.write_text(f"{json.dumps(document, indent=JSON_INDENT)}\n", encoding="utf-8")
+
+
+def _read_bedrock_state(path: Path) -> BedrockSmokeJob:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    return BedrockSmokeJob(
+        rows=document["rows"],
+        request_usages=[RequestUsage(**payload) for payload in document["request_usages"]],
+        last_usage=document["last_usage"],
+        converse_calls=int(document["converse_calls"]),
+        stamped_at=document["stamped_at"],
+    )
+
+
+def submit_bedrock_and_interrupt(
+    client: CountingBedrockClient,
+    spec: FeatureSpec,
+    posts: pd.DataFrame,
+    *,
+    run_id: str,
+    state_path: Path,
+) -> BedrockSmokeJob:
+    """Label the ten comments through Converse, save rows locally, and stop before S3 writes."""
+    tasks = _tasks(posts)
+    engine = BedrockConverseEngine(
+        spec,
+        FeatureRunConfig(
+            batch_size=len(tasks),
+            max_concurrency=BEDROCK_SMOKE_MAX_CONCURRENCY,
+        ),
+        client,
+        DEFAULT_BEDROCK_NOVA_MICRO,
+    )
+    labels = engine.batch_label_records(tasks)
+    if engine.last_usage is None:
+        raise RuntimeError("Bedrock engine reported no usage after labeling")
+    ordered_ids = [task.uri for task in tasks]
+    rows = attach_row_metadata(
+        labels,
+        run_id=run_id,
+        batch_id=BEDROCK_SMOKE_BATCH_ID,
+        request_ids=_bedrock_request_ids(ordered_ids),
+        attempt_count=BEDROCK_SMOKE_ATTEMPT_COUNT,
+    )
+    job = BedrockSmokeJob(
+        rows=rows,
+        request_usages=_usages_for_tasks(client, tasks),
+        last_usage={
+            "input_tokens": engine.last_usage.input_tokens,
+            "output_tokens": engine.last_usage.output_tokens,
+            "total_tokens": engine.last_usage.total_tokens,
+        },
+        converse_calls=int(client.calls[CONVERSE_CALL]),
+        stamped_at=get_current_timestamp(),
+    )
+    _write_bedrock_state(state_path, job)
+    logger.info(
+        "Deliberate smoke interruption after Bedrock Converse",
+        extra={"feature_name": spec.name, "converse_calls": job.converse_calls},
+    )
+    return job
+
+
+def resume_bedrock_from_state(state_path: Path, client: CountingBedrockClient) -> BedrockSmokeJob:
+    """Return the saved Bedrock rows without making another Converse call."""
+    if int(client.calls[CONVERSE_CALL]) != 0:
+        raise RuntimeError("resume Bedrock client already made a converse call")
+    return _read_bedrock_state(state_path)
+
+
+def build_bedrock_resume_evidence(
+    *,
+    feature: str,
+    run_id: str,
+    interrupted: BedrockSmokeJob,
+    resumed: BedrockSmokeJob,
+    resume_converse_calls: int,
+) -> dict[str, Any]:
+    """Return the interrupt-and-resume proof for a Bedrock smoke run."""
+    same_rows = len(resumed.rows) == SMOKE_POST_COUNT
+    no_new_jobs = resume_converse_calls == 0
+    return {
+        "feature": feature,
+        "run_id": run_id,
+        "batch_id": BEDROCK_SMOKE_BATCH_ID,
+        "input_file_id": None,
+        "interrupted_at": interrupted.stamped_at,
+        "resumed_at": get_current_timestamp(),
+        "submit_calls_before_interrupt": {CONVERSE_CALL: interrupted.converse_calls},
+        "submit_calls_after_resume": {CONVERSE_CALL: resume_converse_calls},
+        "reattached_same_batch_id": True,
+        "rows_written": len(resumed.rows),
+        "provider_batch_ids_in_output": sorted(
+            {str(row["batch_id"]) for row in resumed.rows}
+        ),
+        "resume_ok": no_new_jobs and same_rows,
+    }
+
+
+def _label_openai_with_interrupt(
+    spec: FeatureSpec,
+    posts: pd.DataFrame,
+    *,
+    run_id: str,
+    run_dir: Path,
+    client_factory: Callable[[], OpenAIBatchClient],
+) -> tuple[InterruptedJob, ResumedJob]:
+    interrupted = submit_and_interrupt(
+        CountingOpenAIClient(client_factory()), spec, posts, run_dir=run_dir
+    )
+    resumed = resume_and_collect_rows(
+        CountingOpenAIClient(client_factory()), spec, posts, run_dir=run_dir, run_id=run_id
+    )
+    return interrupted, resumed
+
+
+def _openai_cost_and_evidence(
+    *,
+    campaign_id: str,
+    dataset_id: str,
+    preprocessed_run: str,
+    feature: str,
+    run_id: str,
+    smoke_uri: str,
+    interrupted: InterruptedJob,
+    resumed: ResumedJob,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    cost_report = build_feature_cost_report(
+        campaign_id=campaign_id,
+        dataset_id=dataset_id,
+        preprocessed_run=preprocessed_run,
+        feature=feature,
+        model=DEFAULT_OPENAI_BATCH_ENGINE_CONFIG.model,
+        engine_type=OPENAI_ENGINE_TYPE,
+        smoke_uri=smoke_uri,
+        batch_id=interrupted.state["batch_id"],
+        batch_usage=resumed.last_batch.usage,
+        request_usages=resumed.request_usages,
+        pricing=pricing_for_engine_type(OPENAI_ENGINE_TYPE),
+        full_run_row_count=FULL_RUN_ROW_COUNT,
+    )
+    resume_evidence = build_resume_evidence(
+        feature=feature, run_id=run_id, interrupted=interrupted, resumed=resumed
+    )
+    return cost_report, resume_evidence
+
+
+def _label_bedrock_with_interrupt(
+    spec: FeatureSpec,
+    posts: pd.DataFrame,
+    *,
+    run_id: str,
+    run_dir: Path,
+    client_factory: Callable[[], BedrockRuntimeClient],
+) -> tuple[BedrockSmokeJob, BedrockSmokeJob, int]:
+    state_path = run_dir / BEDROCK_STATE_FILENAME
+    interrupted = submit_bedrock_and_interrupt(
+        CountingBedrockClient(client_factory()),
+        spec,
+        posts,
+        run_id=run_id,
+        state_path=state_path,
+    )
+    resume_client = CountingBedrockClient(client_factory())
+    resumed = resume_bedrock_from_state(state_path, resume_client)
+    return interrupted, resumed, int(resume_client.calls[CONVERSE_CALL])
+
+
+def _bedrock_cost_and_evidence(
+    *,
+    campaign_id: str,
+    dataset_id: str,
+    preprocessed_run: str,
+    feature: str,
+    run_id: str,
+    smoke_uri: str,
+    interrupted: BedrockSmokeJob,
+    resumed: BedrockSmokeJob,
+    resume_converse_calls: int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    cost_report = build_feature_cost_report(
+        campaign_id=campaign_id,
+        dataset_id=dataset_id,
+        preprocessed_run=preprocessed_run,
+        feature=feature,
+        model=DEFAULT_BEDROCK_NOVA_MICRO,
+        engine_type=BEDROCK_ENGINE_TYPE,
+        smoke_uri=smoke_uri,
+        batch_id=BEDROCK_SMOKE_BATCH_ID,
+        batch_usage=None,
+        request_usages=resumed.request_usages,
+        pricing=pricing_for_engine_type(BEDROCK_ENGINE_TYPE),
+        full_run_row_count=FULL_RUN_ROW_COUNT,
+    )
+    cost_report["batch_usage"] = resumed.last_usage
+    resume_evidence = build_bedrock_resume_evidence(
+        feature=feature,
+        run_id=run_id,
+        interrupted=interrupted,
+        resumed=resumed,
+        resume_converse_calls=resume_converse_calls,
+    )
+    return cost_report, resume_evidence
+
+
+def run_campaign_smoke(
+    *,
+    campaign_id: str,
+    dataset_id: str,
+    preprocessed_run: str,
+    feature: str,
+    smoke_prefix: str | None,
+    output_dir: Path,
+    openai_client_factory: Callable[[], OpenAIBatchClient] | None = None,
+    bedrock_client_factory: Callable[[], BedrockRuntimeClient] | None = None,
+) -> SmokeResult:
+    """Label the ten smoke comments for ``feature`` with one deliberate interruption and resume.
+
+    Raises
+    ------
+    ValueError
+        When ``feature`` is missing from the registry or the campaign map, or
+        ``smoke_prefix`` overlaps the primary feature prefix.
+    RuntimeError
+        When the resumed job leaves any of the ten comments without a valid row.
+    """
+    spec = FEATURE_REGISTRY.get(feature)
+    if spec is None:
+        raise ValueError(f"unknown feature {feature!r}")
+    engine_type = campaign_engine_type(campaign_id, feature)
+    smoke_paths = build_reddit_smoke_paths(campaign_id, dataset_id, feature, smoke_prefix)
+    store = CampaignObjectStore(smoke_paths.paths.bucket)
+    primary_smoke_keys_before = store.list_keys(smoke_paths.canonical.smoke_prefix)
+    posts = load_deterministic_ten_posts_for_spec(REDDIT_SPEC, dataset_id, preprocessed_run)
+    run_id = run_id_for_feature(campaign_id, feature)
+    with tempfile.TemporaryDirectory(prefix="smoke_reddit_campaign_") as run_dir_name:
+        run_dir = Path(run_dir_name)
+        if engine_type == OPENAI_ENGINE_TYPE:
+            interrupted_openai, resumed_openai = _label_openai_with_interrupt(
+                spec,
+                posts,
+                run_id=run_id,
+                run_dir=run_dir,
+                client_factory=openai_client_factory or create_openai_client,
+            )
+            rows = resumed_openai.rows
+            cost_report, resume_evidence = _openai_cost_and_evidence(
+                campaign_id=campaign_id,
+                dataset_id=dataset_id,
+                preprocessed_run=preprocessed_run,
+                feature=feature,
+                run_id=run_id,
+                smoke_uri=smoke_paths.paths.uri(smoke_paths.paths.smoke_prefix),
+                interrupted=interrupted_openai,
+                resumed=resumed_openai,
+            )
+        elif engine_type == BEDROCK_ENGINE_TYPE:
+            interrupted_bedrock, resumed_bedrock, resume_calls = _label_bedrock_with_interrupt(
+                spec,
+                posts,
+                run_id=run_id,
+                run_dir=run_dir,
+                client_factory=bedrock_client_factory or create_bedrock_runtime_client,
+            )
+            rows = resumed_bedrock.rows
+            cost_report, resume_evidence = _bedrock_cost_and_evidence(
+                campaign_id=campaign_id,
+                dataset_id=dataset_id,
+                preprocessed_run=preprocessed_run,
+                feature=feature,
+                run_id=run_id,
+                smoke_uri=smoke_paths.paths.uri(smoke_paths.paths.smoke_prefix),
+                interrupted=interrupted_bedrock,
+                resumed=resumed_bedrock,
+                resume_converse_calls=resume_calls,
+            )
+        else:
+            raise ValueError(f"unsupported engine_type {engine_type!r}")
+    write_smoke_objects(
+        store,
+        smoke_paths.paths,
+        posts=posts,
+        rows=rows,
+        spec=spec,
+        run_id=run_id,
+        cost_report=cost_report,
+        resume_evidence=resume_evidence,
+    )
+    checks, check_lines = run_s3_checks(
+        store,
+        smoke_paths,
+        spec=spec,
+        canonical_smoke_keys_before=primary_smoke_keys_before,
+    )
+    cost_report_path = write_git_copies(
+        output_dir,
+        feature,
+        cost_report=cost_report,
+        resume_evidence=resume_evidence,
+        check_lines=check_lines,
+    )
+    return SmokeResult(
+        smoke_prefix_uri=smoke_paths.smoke_prefix_uri,
+        cost_report=cost_report,
+        resume_evidence=resume_evidence,
+        checks=checks,
+        cost_report_path=cost_report_path,
+    )
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def summary_lines(result: SmokeResult) -> list[str]:
+    """Return the stdout lines of one Reddit smoke run, in the order the step spec fixes."""
+    report = result.cost_report
+    checks = result.checks
+    return [
+        f"smoke_prefix={result.smoke_prefix_uri}",
+        f"engine_type={report['engine_type']}",
+        f"smoke_rows={result.resume_evidence['rows_written']}",
+        f"avg_input_tokens={report['avg_input_tokens_per_request']}",
+        f"max_input_tokens={report['max_input_tokens_per_request']}",
+        f"avg_output_tokens={report['avg_output_tokens_per_request']}",
+        f"max_output_tokens={report['max_output_tokens_per_request']}",
+        f"estimated_full_run_usd_avg={report['estimated_full_run_usd_avg']}",
+        f"estimated_full_run_usd_max={report['estimated_full_run_usd_max']}",
+        f"full_run_row_count={report['full_run_row_count']}",
+        f"{CHECK_SMOKE_OUTPUT_OK}={str(checks[CHECK_SMOKE_OUTPUT_OK]).lower()}",
+        f"{CHECK_RESUME_EVIDENCE_OK}={str(checks[CHECK_RESUME_EVIDENCE_OK]).lower()}",
+        f"{CHECK_NO_BATCHES}={str(checks[CHECK_NO_BATCHES]).lower()}",
+        f"{CHECK_PRIMARY_TOUCHED}={str(checks[CHECK_CANONICAL_TOUCHED]).lower()}",
+        f"cost_report={_display_path(result.cost_report_path)}",
+    ]
+
+
+def main(
+    campaign_id: str = typer.Option(..., "--campaign-id"),
+    dataset_id: str = typer.Option(..., "--dataset-id"),
+    preprocessed_run: str = typer.Option(..., "--preprocessed-run"),
+    feature: str = typer.Option(..., "--feature"),
+    smoke_prefix: str | None = typer.Option(None, "--smoke-prefix"),
+    output_dir: Path | None = typer.Option(None, "--output-dir"),
+) -> None:
+    """Run the ten-comment smoke for one Reddit feature, print the summary, and exit 1 when an S3 check fails."""
+    result = run_campaign_smoke(
+        campaign_id=campaign_id,
+        dataset_id=dataset_id,
+        preprocessed_run=preprocessed_run,
+        feature=feature,
+        smoke_prefix=smoke_prefix,
+        output_dir=output_dir or DEFAULT_SMOKE_REPORTS_DIR / feature,
+    )
+    for line in summary_lines(result):
+        print(line)
+    if not checks_passed(result.checks):
+        raise typer.Exit(code=1)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/deterministic_ten_comment_ids.json
+++ b/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/deterministic_ten_comment_ids.json
@@ -1,0 +1,17 @@
+{
+  "dataset_id": "reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079",
+  "preprocessed_run": "2026_09_03-23:39:28",
+  "selection_rule": "Keep rows with non-empty text, sort by ascending source_record_id, take the first ten.",
+  "source_record_ids": [
+    "t1_mpxmfe6",
+    "t1_mpxmfoa",
+    "t1_mpxmfr2",
+    "t1_mpxmgbj",
+    "t1_mpxmgxp",
+    "t1_mpxmho3",
+    "t1_mpxmjkx",
+    "t1_mpxmk1u",
+    "t1_mpxmkdo",
+    "t1_mpxmlk4"
+  ]
+}

--- a/docs/plans/2026-09-07_reddit_campaign_smoke_cost_watcher_39bb77/plan.md
+++ b/docs/plans/2026-09-07_reddit_campaign_smoke_cost_watcher_39bb77/plan.md
@@ -1,0 +1,81 @@
+# Add Reddit campaign smoke, mixed-engine cost aggregate, and watcher platform flags
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, frequent commits
+- Use only the approved offline checks and one live disposable-prefix proof. Do not add or run automated tests.
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Seven later feature issues need one mixed-engine cost number before anyone labels 400,000 Reddit comments. This package adds a Reddit smoke command that labels the same ten comments for every feature, records OpenAI Batch and Bedrock on-demand prices at 400,000-row scale, sums those reports into one parent file, and lets the progress watcher resolve Reddit S3 prefixes when the operator passes platform and dataset id.
+
+The package is one independently mergeable pull request for child issue [221](https://github.com/METResearchGroup/mirrorView-task/issues/221). The pull request is part of parent issue [218](https://github.com/METResearchGroup/mirrorView-task/issues/218). The parent issue stays open. Sibling issues stay out of the pull request. The pull request is tooling only. It does not label 400,000 comments, and it does not run all seven live smokes.
+
+The authoritative spec is `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/steps/step3.md` on `origin/cursor/reddit-llm-features-plan-d983`. Read it with `git show`. Do not check out that docs-only branch. Do not copy the rest of that epic plan package into this branch.
+
+## Happy flow
+
+An operator runs the Reddit smoke command for one feature under a disposable S3 prefix. The command loads the pinned preprocessed comments, keeps rows with text, sorts by source record id, and takes the first ten. It labels those ten comments with the engine from the campaign map. After the provider work is submitted and before smoke objects are written, it stops once on purpose, then resumes without a second provider job. It writes four untagged smoke objects under the disposable prefix, writes local copies of the cost report, resume proof, and S3 checks, and prints token averages, token maximums, engine type, and the estimated cost of 400,000 comments.
+
+A later operator, after all seven reports exist, runs the aggregate command with a 400,000-row scale flag. The command prints seven features, four OpenAI features, three Bedrock features, and both full-run totals.
+
+```mermaid
+flowchart TD
+    A[Reddit smoke command for one feature] --> B[Load pinned preprocessed comments]
+    B --> C[Keep rows with text, sort by source record id, take ten]
+    C --> D[Campaign engine map picks OpenAI or Bedrock]
+    D --> E[Submit provider work and save local state]
+    E --> F[Deliberate stop]
+    F --> G[Resume without a second provider job]
+    G --> H[Write four untagged smoke objects under the prefix in use]
+    H --> I[Write local cost, resume, and S3 check copies]
+    I --> J[Later: aggregate seven reports at 400000 rows]
+```
+
+## Approach
+
+Reuse the Bluesky smoke helpers instead of building a third smoke framework. Parameterize the ten-row selector with a platform spec so the Bluesky helpers keep working. Import the campaign engine map. Do not change registry engine defaults. Do not change the Bedrock campaign writer. Do not change the Reddit migrate scripts.
+
+Cost math for this campaign always uses 400,000 rows. The Bluesky default of 200,000 stays when the new row-count flag is omitted. Mixed-engine totals come from the campaign map for the campaign id on the command line.
+
+The live proof in this pull request labels `is_political` only, under the disposable prefix `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step3_campaign_smoke/`. Primary campaign smoke and batches prefixes stay empty. Temporary local copies under `reports/smoke/{feature}/` are deleted before the last commit. The ten comment ids JSON stays.
+
+## Decisions
+
+- Campaign id `reddit_2026_09_03_233928_llm_features_v1` is the only mixed-engine campaign.
+- OpenAI features: `is_news_or_opinion`, `is_political`, `political_stance`, `llm_toxicity_tiered`. Batch rates 0.10 and 0.625 USD per million tokens.
+- Bedrock features: `is_likely_spam`, `is_self_contained`, `is_structurally_complete`. On-demand rates 0.035 and 0.14 USD per million tokens, matching `smoke_bedrock_engine.py`.
+- The ten comment rule does not take a feature name, so every feature gets the same ids.
+- Watcher `--platform` and `--dataset-id` keep Bluesky defaults when omitted. Passing `reddit` plus the pinned dataset id must put the Reddit dataset prefix in the path.
+- The watcher never posts to GitHub.
+- Cost reports record `engine_type`, max token fields, `full_run_post_count`, and `full_run_row_count` with the same integer. Parquet rows still have no `engine_type` column.
+- Interrupt-and-resume lives only in `smoke_reddit_campaign.py`. OpenAI reuses the Bluesky submit-then-reattach helpers. Bedrock saves labeled rows to a local file after Converse returns and before S3 writes, then resumes from that file with zero extra Converse calls.
+- `s3_feature_campaign.py` is unchanged unless a missing helper blocks smoke paths. Smoke object keys already exist.
+- Phase 4 and Phase 6 are the offline commands and the one live disposable-prefix proof. Do not add or run files under `tests/`.
+- Changelog is updated after the pull request exists.
+
+## Steps
+
+### Step 1: Extend the ten-comment selector and the mixed-engine cost report
+
+Parameterize the sample loader with a platform spec, keep the Bluesky helpers as wrappers, and commit the ten Reddit comment ids. Add `--full-run-row-count` to the cost report command, keep the Bluesky default of 200,000, and make `--aggregate` emit OpenAI and Bedrock subtotals from the campaign map. See [steps/step1.md](steps/step1.md).
+
+### Step 2: Add watcher platform flags and the Reddit smoke caller
+
+Pass `--platform` and `--dataset-id` through `FeaturePaths.for_campaign`. Add `smoke_reddit_campaign.py` that reuses Bluesky smoke helpers, labels ten comments with the mapped engine, proves interrupt-and-resume, and writes untagged smoke objects. See [steps/step2.md](steps/step2.md).
+
+### Step 3: Run offline checks, one live proof, and cleanup
+
+Run the deterministic sample check, the watcher path check, the aggregate command shape check with synthetic reports, and one live `is_political` smoke under the disposable prefix. Delete the disposable prefix and the temporary Git copies under `reports/smoke/{feature}/`. Keep `deterministic_ten_comment_ids.json`. See [steps/step3.md](steps/step3.md).
+
+## What "done" looks like
+
+1. `load_deterministic_ten_post_ids_for_spec` with the Reddit spec, the pinned dataset id, and run `2026_09_03-23:39:28` returns ten sorted ids. Those ids are committed in `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/deterministic_ten_comment_ids.json`.
+2. `smoke_reddit_campaign.py` labels those ten comments for one feature, performs one deliberate interrupt after provider submit, resumes without a second provider job, and prints `engine_type`, `smoke_rows=10`, `full_run_row_count=400000`, and the S3 check lines from the spec.
+3. The four smoke objects exist untagged under the prefix in use. `output.parquet` holds exactly ten rows with the label metadata columns. No object exists under that prefix's `batches/`.
+4. Per-feature cost reports record pricing, `engine_type`, average and maximum tokens, and both 400,000-row estimates. The parent aggregate for this campaign id prints `features_included=7`, `openai_features=4`, `bedrock_features=3`, and `full_run_row_count=400000`. Omitting `--full-run-row-count` still uses 200,000.
+5. `feature_progress_watcher.py --help` shows `--platform` and `--dataset-id`. `resolve_feature_paths` with platform `reddit` and the pinned dataset id includes `/reddit/reddit_3d8a2c41` in the prefix. The module still does not post to GitHub.
+6. The live proof wrote only under the disposable prefix. That prefix is empty before merge. Primary `is_political/smoke/` and `is_political/batches/` stay empty.
+7. Temporary `reports/smoke/{feature}/` Git copies are gone. No files under `tests/` were added or run. The 400,000-row production job did not run.

--- a/docs/plans/2026-09-07_reddit_campaign_smoke_cost_watcher_39bb77/steps/step1.md
+++ b/docs/plans/2026-09-07_reddit_campaign_smoke_cost_watcher_39bb77/steps/step1.md
@@ -1,0 +1,223 @@
+# Step 1: Extend the ten-comment selector and the mixed-engine cost report
+
+## Scope
+
+- **Caller:** `data_platform/generate_features/deterministic_smoke_sample.py` `load_deterministic_ten_post_ids_for_spec`, and `data_platform/generate_features/campaign_cost_report.py` `main` with `--aggregate` and `--full-run-row-count`.
+- **Task:** Accept a `FeaturePlatformSpec` on the ten-row selector, keep Bluesky helpers working, write the committed Reddit ten-id JSON, add mixed-engine parent aggregate fields from the campaign map, and add `--full-run-row-count` with Bluesky default 200000.
+- **Out of scope:** Reddit smoke caller, watcher flags, live provider jobs, pytest, registry engine defaults, campaign engine map edits.
+
+Phase 4 for this package is the offline `python -c` and `--help` checks, not pytest. Do not add files under `tests/`. Run unattended. Skip Phase 3 approval.
+
+## Files to inspect
+
+- `data_platform/generate_features/deterministic_smoke_sample.py`
+- `data_platform/generate_features/campaign_cost_report.py`
+- `data_platform/generate_features/campaign_engine_map.py` (import only)
+- `data_platform/generate_features/generate_reddit_features.py` (`REDDIT_SPEC`)
+- `data_platform/generate_features/generate_bluesky_features.py` (`BLUESKY_SPEC`)
+- `data_platform/generate_features/platform_cli.py` (`FeaturePlatformSpec`, `load_pinned_preprocessed_records`)
+- `data_platform/generate_features/smoke_bedrock_engine.py` (`ON_DEMAND_INPUT_USD_PER_MILLION = 0.035`, `ON_DEMAND_OUTPUT_USD_PER_MILLION = 0.14`)
+- `data_platform/generate_features/smoke_bluesky_campaign.py` (how it calls `load_deterministic_ten_posts` and `build_feature_cost_report`)
+- `data_platform/generate_features/feature_progress_watcher.py` (`estimated_cost_to_date` still reads `full_run_post_count`)
+
+## Files allowed to change
+
+- `data_platform/generate_features/deterministic_smoke_sample.py`
+- `data_platform/generate_features/campaign_cost_report.py`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/deterministic_ten_comment_ids.json` (new)
+
+## Files forbidden to change
+
+- `data_platform/generate_features/campaign_engine_map.py`
+- `data_platform/generate_features/registry.py`
+- `data_platform/generate_features/s3_feature_campaign.py`
+- `data_platform/generate_features/feature_progress_watcher.py` (Step 2)
+- `data_platform/generate_features/smoke_bluesky_campaign.py`
+- `data_platform/generate_features/engines/**`
+- `data_platform/scripts/migrate_reddit_preprocessed_to_s3.py` and any other migrate script
+- Any file under `tests/`
+- `data_platform/data/**`
+- Feature prompt modules
+- `CHANGELOG.md`
+
+Stage files by explicit path only. Never run `git add -A` or `git add .`.
+
+## Locked identities
+
+| Field | Value |
+| ----- | ----- |
+| Platform | `reddit` |
+| Dataset id | `reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079` |
+| Preprocessed run | `2026_09_03-23:39:28` |
+| Campaign id | `reddit_2026_09_03_233928_llm_features_v1` |
+| Full-run row count for this campaign | `400000` |
+| Bluesky default full-run row count | `200000` (`FULL_RUN_POST_COUNT`) |
+| Smoke sample size | `10` |
+
+If Git LFS has not materialized the pinned comments parquet, run this before sample selection:
+
+```bash
+git lfs pull --include "data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet"
+```
+
+## Contracts
+
+### `deterministic_smoke_sample.py`
+
+Keep `SMOKE_POST_COUNT = 10`, `SELECTION_RULE`, and `select_deterministic_sample` unchanged.
+
+Add:
+
+```python
+def load_deterministic_ten_posts_for_spec(
+    spec: FeaturePlatformSpec, dataset_id: str, preprocessed_run: str
+) -> pd.DataFrame:
+    ...
+
+def load_deterministic_ten_post_ids_for_spec(
+    spec: FeaturePlatformSpec, dataset_id: str, preprocessed_run: str
+) -> list[str]:
+    ...
+
+def write_deterministic_ten_post_ids_for_spec(
+    spec: FeaturePlatformSpec, dataset_id: str, preprocessed_run: str, output: Path
+) -> Path:
+    ...
+```
+
+`load_deterministic_ten_posts` and `load_deterministic_ten_post_ids` stay as Bluesky wrappers that call the `_for_spec` functions with `BLUESKY_SPEC`. `write_deterministic_ten_post_ids` stays a Bluesky wrapper too.
+
+The JSON writer writes:
+
+```json
+{
+  "dataset_id": "...",
+  "preprocessed_run": "...",
+  "selection_rule": "Keep rows with non-empty text, sort by ascending source_record_id, take the first ten.",
+  "source_record_ids": ["...", "..."]
+}
+```
+
+Extend `main` with `--platform`. Default `bluesky` keeps the current Bluesky output path behavior. When `--platform reddit`, load `REDDIT_SPEC` and write through `write_deterministic_ten_post_ids_for_spec`. Do not add a second Typer app.
+
+Commit the Reddit ids file at:
+
+`docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/deterministic_ten_comment_ids.json`
+
+### `campaign_cost_report.py`
+
+Keep `FULL_RUN_POST_COUNT = 200_000` and `CAMPAIGN_LLM_FEATURES` (OpenAI names from `FEATURE_REGISTRY`). Do not mutate `FEATURE_REGISTRY`.
+
+Import from `campaign_engine_map.py` only: `campaign_engine_type`, `REDDIT_LLM_FEATURES_CAMPAIGN_ID`, `REDDIT_CAMPAIGN_ENGINE_BY_FEATURE`, `OPENAI_ENGINE_TYPE`, `BEDROCK_ENGINE_TYPE`.
+
+Add Bedrock on-demand constants matching `smoke_bedrock_engine.py`:
+
+- `DEFAULT_BEDROCK_INPUT_USD_PER_MILLION_TOKENS = 0.035`
+- `DEFAULT_BEDROCK_OUTPUT_USD_PER_MILLION_TOKENS = 0.14`
+- `BEDROCK_PRICING_SOURCE_URL = "https://aws.amazon.com/bedrock/pricing/"`
+
+`BatchPricing` stays the price holder for both engines. OpenAI reports keep `PRICING_SOURCE_URL`. Bedrock reports use `BEDROCK_PRICING_SOURCE_URL`.
+
+`build_feature_cost_report` gains:
+
+- `engine_type: str` written on the report
+- `full_run_row_count: int | None = None`. When omitted, use `full_run_post_count`. Write both `full_run_post_count` and `full_run_row_count` with that integer so the watcher can still divide by `full_run_post_count`.
+- Keep max token fields `max_input_tokens_per_request` and `max_output_tokens_per_request`.
+
+`aggregate_cost_reports` signature becomes:
+
+```python
+def aggregate_cost_reports(
+    campaign_id: str,
+    smoke_reports_dir: Path,
+    features: tuple[str, ...] | None = None,
+    full_run_row_count: int = FULL_RUN_POST_COUNT,
+) -> dict[str, Any]:
+```
+
+Feature list:
+
+- When `features` is passed, use it.
+- When `campaign_id == REDDIT_LLM_FEATURES_CAMPAIGN_ID`, use `tuple(REDDIT_CAMPAIGN_ENGINE_BY_FEATURE)`.
+- Otherwise use `CAMPAIGN_LLM_FEATURES`.
+
+Each feature entry includes `engine_type` from `campaign_engine_type(campaign_id, feature)`, not from registry defaults.
+
+Parent document fields:
+
+- `campaign_id`
+- `generated_at`
+- `features_included` (length of entries)
+- `openai_features` (count of map entries equal to `openai`)
+- `bedrock_features` (count of map entries equal to `bedrock`)
+- `full_run_row_count` (the CLI value)
+- `features` (one object per feature, including `engine_type` and both estimate fields)
+- `total_smoke_cost_usd`
+- `total_estimated_full_run_usd_avg`
+- `total_estimated_full_run_usd_max`
+- `openai_estimated_full_run_usd_avg`
+- `openai_estimated_full_run_usd_max`
+- `bedrock_estimated_full_run_usd_avg`
+- `bedrock_estimated_full_run_usd_max`
+
+`main` adds `--full-run-row-count` with default `FULL_RUN_POST_COUNT` (200000). `--help` must show both `--aggregate` and `--full-run-row-count`.
+
+Stdout for aggregate:
+
+```text
+features_included=<n>
+openai_features=<n>
+bedrock_features=<n>
+total_estimated_full_run_usd_avg=<number>
+total_estimated_full_run_usd_max=<number>
+full_run_row_count=<n>
+parent_cost_aggregate.json written
+```
+
+The last line still uses `output.name`, so a different output filename still prints `<name> written`. When the output file is `parent_cost_aggregate.json`, the line matches the spec.
+
+Existing Bluesky aggregate without `--full-run-row-count` must still run, with `openai_features=7`, `bedrock_features=0`, `full_run_row_count=200000`, once seven Bluesky reports exist. This step proves that with synthetic temp reports, not live smokes.
+
+## Scenarios (given, when, then)
+
+No pytest. These are the checks Step 3 runs.
+
+1. Given the pinned Reddit comments parquet, when `load_deterministic_ten_post_ids_for_spec(REDDIT_SPEC, pinned dataset, pinned run)` runs, then it returns ten ids and `ids == sorted(ids)`.
+2. Given the same run loaded twice, when the selector runs without a feature name, then both calls return the same ids.
+3. Given `load_deterministic_ten_post_ids` with Bluesky arguments, when it runs, then it still loads through `BLUESKY_SPEC`.
+4. Given seven synthetic cost reports for the Reddit campaign (four `openai`, three `bedrock`) and `--full-run-row-count 400000`, when `--aggregate` runs, then stdout includes `features_included=7`, `openai_features=4`, `bedrock_features=3`, `full_run_row_count=400000`.
+5. Given seven synthetic OpenAI reports for the Bluesky campaign and no row-count flag, when `--aggregate` runs, then `full_run_row_count=200000`, `openai_features=7`, `bedrock_features=0`.
+6. Given `campaign_cost_report.py --help`, when it prints, then the text includes `--aggregate` and `--full-run-row-count`.
+
+## What must pass
+
+- Offline sample command in `steps/step3.md` of this plan prints `deterministic_ten_comment_ids OK` and `first_id=<id>`.
+- The committed JSON has ten sorted `source_record_ids` matching that command.
+- `PYTHONPATH=. uv run python data_platform/generate_features/campaign_cost_report.py --help` includes `--aggregate` and `--full-run-row-count`.
+- Synthetic mixed-engine aggregate for the Reddit campaign id prints the four/three split and 400000.
+
+## What must fail / stop
+
+- Sample ids that differ across calls or that are not sorted.
+- Cost math that uses 200000 for the Reddit campaign when `--full-run-row-count 400000` is passed.
+- Aggregate that counts engines from `FEATURE_REGISTRY` instead of `campaign_engine_type`.
+- Any edit of `registry.py` engine defaults.
+- Any file under `tests/`.
+
+## Commits
+
+Frequent commits, no squash. Suggested sequence:
+
+1. Scaffold: add `_for_spec` function signatures as stubs, add `--full-run-row-count` option that is unused, add `engine_type` parameter stub on the cost builder.
+2. Contracts: signatures and report/aggregate field names match this file. Bodies still stubbed where new.
+3. Test design: this file's scenarios are the spec. No pytest commit. If a commit is required for Phase 4, commit only a comment in the plan, not product code. Prefer to skip a product commit for Phase 4.
+4. Flesh `load_deterministic_ten_posts_for_spec` and wrappers.
+5. Write and commit `deterministic_ten_comment_ids.json`.
+6. Flesh `build_feature_cost_report` engine type and `full_run_row_count`.
+7. Flesh `aggregate_cost_reports` mixed-engine parent document and CLI stdout.
+
+## Implementation notes
+
+- `PYTHONPATH=.` on every command.
+- Vocabulary: confirm, not freeze. Standardized, not canonical, for new wording. Existing `canonical` aliases may stay. Run, not invoke. Upload and download for S3.
+- Numpy docstrings on new public functions.

--- a/docs/plans/2026-09-07_reddit_campaign_smoke_cost_watcher_39bb77/steps/step2.md
+++ b/docs/plans/2026-09-07_reddit_campaign_smoke_cost_watcher_39bb77/steps/step2.md
@@ -1,0 +1,222 @@
+# Step 2: Add watcher platform flags and the Reddit smoke caller
+
+## Scope
+
+- **Caller:** `data_platform/generate_features/smoke_reddit_campaign.py` `main`, and `data_platform/generate_features/feature_progress_watcher.py` `main` / `resolve_feature_paths`.
+- **Task:** Resolve watcher paths through `FeaturePaths.for_campaign` with `--platform` and `--dataset-id`. Add the Reddit smoke command that labels the shared ten comments, proves interrupt-and-resume, writes four untagged smoke objects, and writes local cost, resume, and S3 check copies.
+- **Out of scope:** Editing migrate scripts, Bedrock campaign writer product behavior, registry engine defaults, pytest, all seven live smokes, 400000-row production.
+
+Phase 4 is the watcher `--help` / path check and the live `is_political` command in Step 3, not pytest. Do not add files under `tests/`. Run unattended. Skip Phase 3 approval.
+
+## Files to inspect
+
+- `data_platform/generate_features/smoke_bluesky_campaign.py`
+- `data_platform/generate_features/feature_progress_watcher.py`
+- `data_platform/generate_features/s3_feature_campaign.py` (`FeaturePaths.for_campaign`, smoke keys, `from_root_uri`)
+- `data_platform/generate_features/campaign_engine_map.py` (import only)
+- `data_platform/generate_features/campaign_cost_report.py` (Step 1 result)
+- `data_platform/generate_features/deterministic_smoke_sample.py` (Step 1 result)
+- `data_platform/generate_features/engines/openai_engine.py` (`submit_active_batch`, `OpenAIBatchEngine.label_chunk`)
+- `data_platform/generate_features/engines/bedrock_engine.py` (`BedrockConverseEngine.batch_label_records`, `last_usage`, `create_bedrock_runtime_client`, `DEFAULT` model via `lib.constants`)
+- `data_platform/generate_features/s3_feature_batches.py` (`attach_provenance`, `validate_q44_rows`)
+- `lib/constants.py` (`DEFAULT_LLM_MODEL`, `DEFAULT_BEDROCK_NOVA_MICRO`)
+
+## Files allowed to change
+
+- `data_platform/generate_features/smoke_reddit_campaign.py` (new)
+- `data_platform/generate_features/feature_progress_watcher.py`
+- `data_platform/generate_features/s3_feature_campaign.py` only if a tiny smoke-path helper is strictly required. Prefer no edit.
+
+## Files forbidden to change
+
+- `data_platform/generate_features/campaign_engine_map.py`
+- `data_platform/generate_features/registry.py`
+- `data_platform/generate_features/engines/bedrock_campaign.py`
+- `data_platform/generate_features/smoke_bluesky_campaign.py` except that the Reddit module may import its helpers
+- `data_platform/utils/storage.py`
+- `data_platform/scripts/migrate_reddit_preprocessed_to_s3.py`
+- Any file under `tests/`
+- Feature prompt modules
+- `webapp/**`, `experiments/**`
+- Any GitHub posting code
+- `CHANGELOG.md`
+
+Do not add `APPROVED.txt`. Do not drop Reddit Git LFS tracking.
+
+## Watcher contracts
+
+`resolve_feature_paths` becomes:
+
+```python
+def resolve_feature_paths(
+    campaign_id: str,
+    feature: str,
+    smoke_prefix: str | None,
+    *,
+    platform: str = DEFAULT_CAMPAIGN_PLATFORM,
+    dataset_id: str = DEFAULT_CAMPAIGN_DATASET_ID,
+) -> FeaturePaths:
+```
+
+When `smoke_prefix` is None, call `FeaturePaths.for_campaign(campaign_id, feature, platform=platform, dataset_id=dataset_id)`. When `smoke_prefix` is set, keep `FeaturePaths.from_root_uri(smoke_prefix, feature)`.
+
+`main` adds:
+
+- `--platform` default `DEFAULT_CAMPAIGN_PLATFORM` (`bluesky`)
+- `--dataset-id` default `DEFAULT_CAMPAIGN_DATASET_ID`
+
+`--help` must show both flags.
+
+When `--platform reddit --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079` is passed, `paths.prefix` contains `/reddit/reddit_3d8a2c41`.
+
+The module still prints `github_write_skipped=true` and never posts to GitHub. Grep of the module must show no `gh`, no `PyGithub`, and no HTTP post to `api.github.com`.
+
+## Reddit smoke caller contracts
+
+New module `data_platform/generate_features/smoke_reddit_campaign.py`.
+
+CLI:
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_reddit_campaign.py \
+  --campaign-id reddit_2026_09_03_233928_llm_features_v1 \
+  --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079 \
+  --preprocessed-run 2026_09_03-23:39:28 \
+  --feature <feature> \
+  --smoke-prefix <optional-disposable-s3-prefix> \
+  --output-dir <git-report-dir>
+```
+
+Locked full-run row count inside this caller is `400000`. Do not default this caller to 200000.
+
+Default `--output-dir` is:
+
+`docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/{feature}`
+
+### Reuse
+
+Import these from `smoke_bluesky_campaign.py` rather than copying them:
+
+- `SmokePaths`, `SmokeResult`, `InterruptedJob`, `ResumedJob`
+- `CountingOpenAIClient`
+- `build_smoke_paths` (it already calls `FeaturePaths.for_campaign` with the given `dataset_id`; pass `platform="reddit"` by wrapping if the Bluesky helper hardcodes Bluesky platform)
+- `submit_and_interrupt`, `resume_and_collect_rows`, `build_resume_evidence`
+- `write_smoke_objects`, `run_s3_checks`, `write_git_copies`, `checks_passed`
+
+If `build_smoke_paths` hardcodes `DEFAULT_CAMPAIGN_PLATFORM` (`bluesky`), do not edit `smoke_bluesky_campaign.py`. In the Reddit module, build paths with `FeaturePaths.for_campaign(..., platform="reddit", dataset_id=dataset_id)` and `FeaturePaths.from_root_uri` using the same overlap rule as Bluesky (`ValueError` when the disposable prefix overlaps the primary feature prefix). That local helper is allowed. Do not change `s3_feature_campaign.py` for this.
+
+Primary-prefix check name in Reddit stdout is `primary_smoke_prefix_touched`, mapped from the Bluesky check `canonical_smoke_prefix_touched` if `run_s3_checks` is reused.
+
+### Engine routing
+
+`engine = campaign_engine_type(campaign_id, feature)`.
+
+OpenAI features use `gpt-5.4-nano` Batch (`DEFAULT_OPENAI_BATCH_ENGINE_CONFIG` / `DEFAULT_LLM_MODEL`). Token usage from `engine.last_batch.usage` plus per-request usage from the batch output file, same as Bluesky.
+
+Bedrock features use Nova Micro (`DEFAULT_BEDROCK_NOVA_MICRO`) through `BedrockConverseEngine`. Token usage from `engine.last_usage` plus per-request usage captured by wrapping `client.converse` so each response's `usage.inputTokens` / `usage.outputTokens` can be paired to a `source_record_id` by matching the user text to the task text. Do not edit `bedrock_engine.py`.
+
+Refuse features that are not in the campaign map for this campaign id.
+
+### Interrupt and resume (inside this module only)
+
+OpenAI: call `submit_and_interrupt`, discard that client, then `resume_and_collect_rows` on a new counting client. Resume must make zero `files.create` and zero `batches.create` calls.
+
+Bedrock: wrap the runtime client and count `converse` calls. First engine labels the ten comments and writes rows plus per-request usage to a local state file, then stops before any S3 write. Second engine reads that file and returns the same rows with zero additional `converse` calls. `resume_ok` is true when resume converse count is 0 and ten rows exist.
+
+Write `resume_evidence.json` to S3 and a Git copy `{feature}_resume_evidence.json`.
+
+### S3 objects
+
+Four untagged objects under `{prefix}{feature}/smoke/` when `--smoke-prefix` is a root URI (Bluesky `from_root_uri` layout), or under the primary `{feature}/smoke/` when `--smoke-prefix` is omitted:
+
+- `input.parquet`
+- `output.parquet`
+- `cost_report.json`
+- `resume_evidence.json`
+
+Smoke never writes `batches/part-*.parquet`. Step 3 live proof must pass `--smoke-prefix` with:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step3_campaign_smoke/`
+
+so the primary prefix is not written.
+
+### Cost report
+
+Call `build_feature_cost_report` with `full_run_row_count=400000` and `engine_type` from the campaign map.
+
+OpenAI pricing: 0.10 / 0.625 and `PRICING_SOURCE_URL`.
+
+Bedrock pricing: 0.035 / 0.14 and `BEDROCK_PRICING_SOURCE_URL`.
+
+### Stdout (order)
+
+```text
+smoke_prefix=<uri>
+engine_type=<openai|bedrock>
+smoke_rows=10
+avg_input_tokens=<number>
+max_input_tokens=<number>
+avg_output_tokens=<number>
+max_output_tokens=<number>
+estimated_full_run_usd_avg=<number>
+estimated_full_run_usd_max=<number>
+full_run_row_count=400000
+s3_smoke_output_ok=true
+s3_smoke_resume_evidence_ok=true
+no_batches_prefix_objects=true
+primary_smoke_prefix_touched=false
+cost_report=<path>
+```
+
+Exit 1 when `checks_passed` is false. For a disposable-prefix run, `primary_smoke_prefix_touched` must be false. Do not treat that flag as a pass bit inside `checks_passed` (same as Bluesky).
+
+Local copies under `--output-dir` (temporary during review, deleted in Step 3):
+
+- `{feature}_cost_report.json`
+- `{feature}_resume_evidence.json`
+- `{feature}_s3_checks.txt`
+
+## Scenarios
+
+1. Given watcher `--help`, when it prints, then the text includes `--platform` and `--dataset-id`.
+2. Given `resolve_feature_paths` with the Reddit campaign, `is_political`, `platform='reddit'`, and the pinned dataset id, when it returns, then `'/reddit/reddit_3d8a2c41' in paths.prefix`.
+3. Given the watcher module source, when searched for GitHub posting, then it still only records an optional comment id and prints `github_write_skipped=true`.
+4. Given OpenAI credentials and the disposable prefix, when the smoke runs for `is_political`, then stdout matches the lines above, `engine_type=openai`, and no primary smoke or batches objects are written.
+5. Given a Bedrock feature, when the smoke path runs (later issues, not this PR's live proof), then it uses Bedrock rates, `engine_type=bedrock`, and resume converse count is zero.
+
+## What must pass
+
+- Watcher path check from this plan's Step 3.
+- Live `is_political` proof from this plan's Step 3.
+- Bluesky smoke module still imports and `load_deterministic_ten_posts` still exists.
+
+## What must fail / stop
+
+- Watcher still resolving Bluesky paths when `--platform reddit` is passed without a dataset override that would keep Bluesky.
+- Smoke writing under the primary campaign feature prefix during the disposable proof.
+- Smoke writing `batches/part-*.parquet`.
+- A second OpenAI Batch job on resume.
+- Editing `campaign_engine_map.py` or registry engine defaults.
+- Any file under `tests/`.
+
+## Commits
+
+1. Scaffold `smoke_reddit_campaign.py` with Typer flags and stub `run_campaign_smoke`. Add watcher flag signatures that still call the old path until fleshed.
+2. Contracts: watcher `resolve_feature_paths` signature, smoke result and summary line names.
+3. Flesh watcher `resolve_feature_paths` and CLI flags.
+4. Flesh Reddit OpenAI smoke path (sample load, interrupt, resume, S3, summary), enough for the live `is_political` proof.
+5. Flesh Reddit Bedrock smoke path (counting converse wrapper, local state resume, Bedrock pricing).
+
+## S3 rules for this step
+
+- Product code may write smoke objects. The only live write allowed in this PR is under `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step3_campaign_smoke/`.
+- Do not write primary `{feature}/smoke/` or any `batches/` object.
+- Deletes of that disposable prefix wait for Step 3.
+
+## Implementation notes
+
+- Always `PYTHONPATH=.`.
+- Export `AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"` and `AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"` before any AWS call. Do not echo secrets. No AWS profile.
+- `OPENAI_API_KEY` is already set.
+- Numpy docstrings on new public functions.
+- Do not run all seven live smokes in this PR.

--- a/docs/plans/2026-09-07_reddit_campaign_smoke_cost_watcher_39bb77/steps/step3.md
+++ b/docs/plans/2026-09-07_reddit_campaign_smoke_cost_watcher_39bb77/steps/step3.md
@@ -1,0 +1,217 @@
+# Step 3: Run offline checks, one live proof, and cleanup
+
+## Scope
+
+- **Caller:** the commands in this file, run from `/workspace` with `PYTHONPATH=.`.
+- **Task:** Prove the sample selector, watcher paths, mixed-engine aggregate shape, and one live `is_political` smoke under the disposable prefix. Then delete the disposable S3 prefix and temporary Git copies under `reports/smoke/{feature}/`. Keep `deterministic_ten_comment_ids.json`.
+- **Out of scope:** Product behavior changes except deleting those temporary report files. No pytest. No 400000-row production. No issues 222 through 229.
+
+## Files to inspect
+
+- `data_platform/generate_features/smoke_reddit_campaign.py`
+- `data_platform/generate_features/feature_progress_watcher.py`
+- `data_platform/generate_features/campaign_cost_report.py`
+- `data_platform/generate_features/deterministic_smoke_sample.py`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/deterministic_ten_comment_ids.json`
+
+## Files allowed to change
+
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/{feature}/` may exist during the live proof and must be deleted before the last commit.
+- No other product files unless a check reveals a correctness bug from Step 1 or Step 2. If a bug is found, fix it in the owning file from those steps and re-run the failing check.
+
+## Files forbidden to change
+
+- `tests/**`
+- `registry.py` engine defaults
+- `campaign_engine_map.py`
+- migrate scripts
+- `CHANGELOG.md` (updated only after the pull request exists)
+- Primary S3 campaign prefixes
+
+## Environment
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+export GH_TOKEN="$METRESEARCHGROUP_GITHUB_PAT_TOKEN"
+export GH_PROMPT_DISABLED=1
+```
+
+Never echo those values.
+
+If the comments parquet is an LFS pointer, pull it before check 1:
+
+```bash
+git lfs pull --include "data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/preprocessed/2026_09_03-23:39:28/comments.parquet"
+```
+
+## Check 1: Offline deterministic sample
+
+```bash
+cd /workspace
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.generate_reddit_features import REDDIT_SPEC
+from data_platform.generate_features.deterministic_smoke_sample import load_deterministic_ten_post_ids_for_spec
+ids = load_deterministic_ten_post_ids_for_spec(
+    REDDIT_SPEC,
+    'reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079',
+    '2026_09_03-23:39:28',
+)
+assert len(ids) == 10
+assert ids == sorted(ids)
+print('deterministic_ten_comment_ids OK')
+print('first_id=' + ids[0])
+"
+```
+
+Expected stdout:
+
+```text
+deterministic_ten_comment_ids OK
+first_id=<reddit-source-record-id>
+```
+
+The committed JSON `source_record_ids` must equal that list.
+
+## Check 2: Watcher paths and no GitHub posting
+
+```bash
+PYTHONPATH=. uv run python -c "
+from data_platform.generate_features.feature_progress_watcher import resolve_feature_paths
+paths = resolve_feature_paths(
+    'reddit_2026_09_03_233928_llm_features_v1',
+    'is_political',
+    smoke_prefix=None,
+    platform='reddit',
+    dataset_id='reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079',
+)
+assert '/reddit/reddit_3d8a2c41' in paths.prefix
+print('watcher paths OK')
+"
+```
+
+Expected stdout:
+
+```text
+watcher paths OK
+```
+
+Also run:
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/feature_progress_watcher.py --help
+```
+
+Expected: help text includes `--platform` and `--dataset-id`.
+
+Confirm the module still does not post to GitHub (search for `api.github.com`, `PyGithub`, and `subprocess` `gh`). Printing `github_write_skipped=true` is required. Recording `--github-comment-id` in `watcher.json` is not posting.
+
+## Check 3: Aggregate command shape (synthetic reports, no seven live smokes)
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/campaign_cost_report.py --help
+```
+
+Expected: help text includes `--aggregate` and `--full-run-row-count`.
+
+Create seven synthetic per-feature reports in a temp directory (not under git). Four OpenAI features and three Bedrock features for campaign `reddit_2026_09_03_233928_llm_features_v1`. Each report needs `campaign_id`, `feature`, `model`, `request_count`, token averages and maxes, `smoke_cost_usd`, and both estimated full-run fields. Then:
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/campaign_cost_report.py \
+  --aggregate \
+  --campaign-id reddit_2026_09_03_233928_llm_features_v1 \
+  --smoke-reports-dir "$TMPDIR/reddit_step3_synth_reports" \
+  --output "$TMPDIR/reddit_step3_synth_reports/parent_cost_aggregate.json" \
+  --full-run-row-count 400000
+```
+
+Expected stdout includes:
+
+```text
+features_included=7
+openai_features=4
+bedrock_features=3
+full_run_row_count=400000
+```
+
+Repeat with seven OpenAI synthetic reports for `bluesky_2026_09_03_235130_llm_features_v1` and omit `--full-run-row-count`. Expected `full_run_row_count=200000`, `openai_features=7`, `bedrock_features=0`.
+
+Delete the temp directory. Do not commit synthetic reports.
+
+## Check 4: Live single-feature tooling proof
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+DISPOSABLE_PREFIX=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step3_campaign_smoke/
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_reddit_campaign.py \
+  --campaign-id reddit_2026_09_03_233928_llm_features_v1 \
+  --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079 \
+  --preprocessed-run 2026_09_03-23:39:28 \
+  --feature is_political \
+  --smoke-prefix "$DISPOSABLE_PREFIX" \
+  --output-dir docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_political
+```
+
+Expected stdout includes:
+
+```text
+engine_type=openai
+smoke_rows=10
+full_run_row_count=400000
+s3_smoke_output_ok=true
+s3_smoke_resume_evidence_ok=true
+no_batches_prefix_objects=true
+primary_smoke_prefix_touched=false
+```
+
+Do not run the other six features live in this PR.
+
+## Check 5: Cleanup before the last commit
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+aws s3 rm s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step3_campaign_smoke/ --recursive
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step3_campaign_smoke/ --recursive
+```
+
+Expected: `aws s3 ls` prints no lines.
+
+```bash
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_political/smoke/ 2>&1 || true
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_political/batches/ 2>&1 || true
+```
+
+Expected: empty listing or `NoSuchKey`.
+
+Delete every temporary Git copy under `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/{feature}/`. Keep `deterministic_ten_comment_ids.json`.
+
+## What must pass
+
+All five checks. Record `first_id` from check 1 in the pull request body.
+
+## What must fail / stop
+
+- Live proof writing primary smoke or batches objects.
+- Disposable prefix still listing objects after cleanup.
+- Temporary `{feature}/` report directories still in git at the last commit.
+- Running pytest or adding `tests/**`.
+- Closing keyword on issue 218.
+
+## After verification
+
+Do not use `gh pr create`. Stay on `cursor/epic-218-221-reddit-smoke-cost-watcher-flags-d983`. Push, then:
+
+```bash
+GH_TOKEN="$METRESEARCHGROUP_GITHUB_PAT_TOKEN" gh stack submit --open --auto --remote origin
+```
+
+Then `gh pr edit` so this layer includes `Fixes #221` and `Part of #218` and never a closing keyword on 218.
+
+Title: `Add Reddit campaign smoke, mixed-engine cost aggregate, and watcher platform flags`
+
+Body must state: tooling only, no full runs, disposable smoke prefix used for proof, primary smoke deferred, no GitHub posting from repo code.
+
+This PR's base must be `cursor/epic-218-219-campaign-engine-map-bedrock-path-d983`.


### PR DESCRIPTION
Fixes #221

Part of #218

## Summary

Adds Reddit campaign smoke tooling that labels the same ten comments for every LLM feature on campaign `reddit_2026_09_03_233928_llm_features_v1`. The smoke caller uses the Step 2 campaign engine map, records mixed OpenAI Batch and Bedrock on-demand cost at 400000 rows, and writes one interrupt-and-resume proof inside the smoke process.

This pull request is tooling only. It does not run the full 400000 comment job, and it does not run all seven live smokes. The live proof used only `s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step3_campaign_smoke/` for `is_political`. Primary `{feature}/smoke/` is deferred. Repository code does not post to GitHub.

## Purpose

Operators need one mixed-engine cost number before anyone labels 400000 Reddit comments across seven features. Bluesky smoke and cost math stay at 200000 posts and OpenAI Batch. Reddit smoke reuses those helpers, scales cost to 400000 comments, and lets the progress watcher resolve Reddit S3 prefixes when `--platform reddit` and `--dataset-id` are passed.

## Architecture

Components:

- `deterministic_smoke_sample.py` selects ten comments from a platform spec. Bluesky helpers still load `BLUESKY_SPEC`.
- `smoke_reddit_campaign.py` labels those ten comments, interrupts after provider submit, resumes without a second provider job, and writes four untagged smoke objects.
- `campaign_cost_report.py` aggregates seven per-feature reports with OpenAI and Bedrock subtotals from the campaign map, and accepts `--full-run-row-count`.
- `feature_progress_watcher.py` resolves paths through `FeaturePaths.for_campaign` with `--platform` and `--dataset-id`.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    S1[smoke_bluesky_campaign] --> B1[Bluesky only]
    W1[feature_progress_watcher] --> P1[Bluesky path defaults]
    C1[campaign_cost_report] --> O1[OpenAI Batch pricing only]
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    D[deterministic_smoke_sample] --> R[smoke_reddit_campaign]
    M[campaign_engine_map] --> R
    R --> S3[(S3 smoke objects)]
    C2[campaign_cost_report aggregate] --> P[parent_cost_aggregate.json]
    W2[feature_progress_watcher] --> F[FeaturePaths.for_campaign]
    F --> S3
  end
```

## Interfaces

### smoke_reddit_campaign.py CLI

```bash
PYTHONPATH=. uv run python data_platform/generate_features/smoke_reddit_campaign.py \
  --campaign-id reddit_2026_09_03_233928_llm_features_v1 \
  --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079 \
  --preprocessed-run 2026_09_03-23:39:28 \
  --feature is_political \
  --smoke-prefix s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step3_campaign_smoke/ \
  --output-dir docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_political
```

### Cost report fields

| Field | Notes |
| ----- | ----- |
| `engine_type` | `openai` or `bedrock` from the campaign map |
| `full_run_row_count` | `400000` for this campaign |
| `full_run_post_count` | same integer, so the watcher can still scale cost |
| `estimated_full_run_usd_avg` | scaled from ten-comment averages |
| `estimated_full_run_usd_max` | scaled from ten-comment maxima |

### Pricing

| Engine | Input USD per 1M tokens | Output USD per 1M tokens |
| ------ | ----------------------- | ------------------------ |
| OpenAI Batch | `0.10` | `0.625` |
| Bedrock on-demand | `0.035` | `0.14` |

### Watcher CLI

```bash
PYTHONPATH=. uv run python data_platform/generate_features/feature_progress_watcher.py \
  --campaign-id reddit_2026_09_03_233928_llm_features_v1 \
  --feature is_political \
  --platform reddit \
  --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079 \
  --once
```

## How to run

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
DISPOSABLE_PREFIX=s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/reddit_step3_campaign_smoke/
PYTHONPATH=. uv run python data_platform/generate_features/smoke_reddit_campaign.py \
  --campaign-id reddit_2026_09_03_233928_llm_features_v1 \
  --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079 \
  --preprocessed-run 2026_09_03-23:39:28 \
  --feature is_political \
  --smoke-prefix "$DISPOSABLE_PREFIX" \
  --output-dir docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_political
```

Expected: `engine_type=openai`, `smoke_rows=10`, `full_run_row_count=400000`, `no_batches_prefix_objects=true`, `primary_smoke_prefix_touched=false`. The disposable prefix used for this proof was emptied before review. Temporary `reports/smoke/{feature}/` Git copies were deleted. `deterministic_ten_comment_ids.json` stays. `first_id=t1_mpxmfe6`.

Plan: `docs/plans/2026-09-07_reddit_campaign_smoke_cost_watcher_39bb77/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added campaign cost reporting for OpenAI and Bedrock, including engine-specific totals and configurable row-count estimates.
  - Added Reddit support to deterministic smoke runs, with platform selection for Reddit and Bluesky.
  - Added a Reddit campaign smoke runner with interruption, resume, validation, and evidence reporting.
  - Added platform and dataset options to feature progress monitoring.
  - Added engine-specific usage and cost details to smoke-run outputs.

- **Documentation**
  - Added a deterministic report listing ten selected Reddit records and their selection details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->