### PR TITLE
Record Phase B is_likely_spam labels for 400000 Reddit comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 6. Operators can smoke-label the same ten Reddit comments for a campaign feature, estimate mixed OpenAI Batch and Bedrock on-demand cost at 400,000 rows, and point the progress watcher at Reddit S3 prefixes with `--platform` and `--dataset-id`. [PR #239](https://github.com/METResearchGroup/mirrorView-task/pull/239)
 7. Operators can review the ten-comment `is_news_or_opinion` smoke for the pinned Reddit campaign, including an estimated 400000-row OpenAI Batch cost of 18.224 USD on average and 24.42 USD at the token maximum. [PR #242](https://github.com/METResearchGroup/mirrorView-task/pull/242)
 8. Operators can review the ten-comment `is_political` smoke for the pinned Reddit campaign, including an estimated 400000-row OpenAI Batch cost of 17.534 USD on average and 23.73 USD at the token maximum. [PR #243](https://github.com/METResearchGroup/mirrorView-task/pull/243)
+9. Operators can review the ten-comment `is_likely_spam` smoke for the pinned Reddit campaign, including an estimated 400000-row Bedrock Converse cost of 4.7334 USD on average and 6.804 USD at the token maximum. [PR #244](https://github.com/METResearchGroup/mirrorView-task/pull/244)
 
 ## 2026-09-06
 

--- a/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/is_likely_spam_run_report.md
+++ b/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/is_likely_spam_run_report.md
@@ -1,0 +1,103 @@
+# is_likely_spam Phase B run report
+
+## Approval
+
+Phase B started after explicit owner LGTM on 2026-09-07. GitHub issue comments were not posted (read-only token).
+
+## Pinned identity
+
+| Field | Value |
+|-------|-------|
+| Dataset id | `reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079` |
+| Preprocessed run | `2026_09_03-23:39:28` |
+| Preprocessed row count | 400,000 |
+| Campaign id | `reddit_2026_09_03_233928_llm_features_v1` |
+| Feature name | `is_likely_spam` |
+| Run id | `reddit_2026_09_03_233928_llm_features_v1:is_likely_spam` |
+| Model id | `us.amazon.nova-micro-v1:0` |
+| Engine | Bedrock Converse (1 process × 8 threads) |
+| Batch size | 2,000 |
+| Prompt source | `data_platform/generate_features/is_likely_spam/generate_feature.py` → `SYSTEM_PROMPT` |
+| Prompt hash | `72438f2de05156168dd30f53dcac7e3008fa9c5c9ea223266e78086a500bbbf6` |
+
+## S3 artifacts
+
+| Object | URI |
+|--------|-----|
+| final.parquet | `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/final.parquet` |
+| manifest.json | `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/manifest.json` |
+| progress.jsonl | `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/progress.jsonl` |
+
+## Run summary
+
+| Metric | Value |
+|--------|-------|
+| Wall-clock start | 2026-09-07T04:53:20Z |
+| Wall-clock end | 2026-09-07T10:45:33Z |
+| Rows in final.parquet | 400,000 |
+| failed_row_count | 0 |
+| Batch parts written | 202 |
+| Content-filter ids in errors.jsonl | 948 |
+| OpenAI content-filter retry | {"count": 948, "model_id": "gpt-5.4-nano", "provider_batch_ids": ["batch_6a9e8c9d31d48190aa546e15e06f7aa1"]} |
+
+## Label counts
+
+| is_likely_spam | Count |
+|----------------|------:|
+| false | 399,542 |
+| true | 458 |
+
+## Cost
+
+| Metric | Value |
+|--------|-------|
+| Smoke estimated full run (avg) | $4.7334 |
+| Smoke estimated full run (max) | $6.804 |
+| Bedrock input tokens | 0 |
+| Bedrock output tokens | 0 |
+| Bedrock actual cost (Nova Micro pricing) | $0.0000 |
+| OpenAI retry cost | see manifest openai_content_filter_retry provider batches (estimate unavailable without batch usage) |
+
+## final.parquet completion rule
+
+`final.parquet` was written once every input id was labeled exactly once or recorded as failed. `row_count + failed_row_count == 400,000`. Content-filter rows were retried via OpenAI Batch when possible; none were silently mapped to false.
+
+## Watcher milestones
+
+Milestone bodies were recorded locally under `/opt/cursor/artifacts/is_likely_spam_watcher_milestones.md`.
+
+| Rows | Updated (UTC) | Est. cost | Active batch |
+|------|---------------|-----------|--------------|
+| 9,983 | 2026-09-07T05:01:19Z (early progress, below 10k milestone) | $0.12 | `bedrock` |
+| 10,000 | 2026-09-07T05:01:52Z | $0.14 | `idle` |
+| 20,000 | 2026-09-07T05:11:57Z | $0.28 | `idle` |
+| 30,000 | 2026-09-07T05:22:01Z | $0.45 | `idle` |
+| 60,000 | 2026-09-07T05:42:10Z | $0.78 | `idle` |
+| 70,000 | 2026-09-07T05:52:14Z | $0.94 | `idle` |
+| 90,000 | 2026-09-07T06:02:18Z | $1.09 | `idle` |
+| 100,000 | 2026-09-07T06:12:24Z | $1.25 | `idle` |
+| 110,000 | 2026-09-07T06:22:30Z | $1.42 | `idle` |
+| 130,000 | 2026-09-07T06:32:35Z | $1.58 | `idle` |
+| 140,000 | 2026-09-07T06:42:41Z | $1.72 | `idle` |
+| 220,000 | 2026-09-07T07:43:53Z | $2.72 | `idle` |
+| 240,000 | 2026-09-07T07:54:12Z | $2.88 | `idle` |
+| 250,000 | 2026-09-07T08:04:28Z | $3.05 | `idle` |
+| 270,000 | 2026-09-07T08:14:59Z | $3.21 | `idle` |
+| 280,000 | 2026-09-07T08:26:30Z | $3.38 | `idle` |
+| 290,000 | 2026-09-07T08:37:02Z | $3.54 | `idle` |
+| 310,000 | 2026-09-07T08:47:44Z | $3.73 | `idle` |
+| 320,000 | 2026-09-07T08:57:56Z | $3.90 | `idle` |
+| 350,000 | 2026-09-07T09:22:01Z | $4.23 | `idle` |
+
+## Validation results
+
+Validation: 13/961 checks passed. Output: `/opt/cursor/artifacts/is_likely_spam_validation.txt`.
+
+| Check | Result |
+|-------|--------|
+| final.parquet SHA-256 | `a2b835f2a2a350a427e9081a6e6d0d43f64b47a252466bd8ac7169de015f2484` |
+| Row accounting | 400,000 + 0 failed = 400,000 |
+| Boolean labels only | PASS |
+| Smoke fold in part-00000 | PASS |
+
+After Phase B EXIT 0, the 1 remaining non-content-filter Bedrock JSON-parse failure (`t1_ms02z8m`) was labeled via OpenAI Batch `gpt-5.4-nano` (`batch_6a9ebddcdd008190918a9c4e348b00bf`, `part-00201`) and `final.parquet` was rewritten. `failed_row_count` is now 0.

--- a/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_cost_report.json
+++ b/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_cost_report.json
@@ -1,0 +1,106 @@
+{
+  "campaign_id": "reddit_2026_09_03_233928_llm_features_v1",
+  "dataset_id": "reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079",
+  "preprocessed_run": "2026_09_03-23:39:28",
+  "feature": "is_likely_spam",
+  "run_id": "reddit_2026_09_03_233928_llm_features_v1:is_likely_spam",
+  "model": "us.amazon.nova-micro-v1:0",
+  "engine_type": "bedrock",
+  "smoke_uri": "s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/",
+  "generated_at": "2026_09_07-03:47:57",
+  "batch_id": "bedrock-smoke",
+  "request_count": 10,
+  "pricing": {
+    "source_url": "https://aws.amazon.com/bedrock/pricing/",
+    "input_usd_per_million_tokens": 0.035,
+    "output_usd_per_million_tokens": 0.14
+  },
+  "batch_usage": {
+    "input_tokens": 2861,
+    "output_tokens": 130,
+    "total_tokens": 2991
+  },
+  "per_request": [
+    {
+      "source_record_id": "t1_mpxmfe6",
+      "request_id": "bedrock-00000",
+      "input_tokens": 310,
+      "output_tokens": 13
+    },
+    {
+      "source_record_id": "t1_mpxmfoa",
+      "request_id": "bedrock-00001",
+      "input_tokens": 269,
+      "output_tokens": 13
+    },
+    {
+      "source_record_id": "t1_mpxmfr2",
+      "request_id": "bedrock-00002",
+      "input_tokens": 270,
+      "output_tokens": 13
+    },
+    {
+      "source_record_id": "t1_mpxmgbj",
+      "request_id": "bedrock-00003",
+      "input_tokens": 288,
+      "output_tokens": 13
+    },
+    {
+      "source_record_id": "t1_mpxmgxp",
+      "request_id": "bedrock-00004",
+      "input_tokens": 281,
+      "output_tokens": 13
+    },
+    {
+      "source_record_id": "t1_mpxmho3",
+      "request_id": "bedrock-00005",
+      "input_tokens": 237,
+      "output_tokens": 13
+    },
+    {
+      "source_record_id": "t1_mpxmjkx",
+      "request_id": "bedrock-00006",
+      "input_tokens": 434,
+      "output_tokens": 13
+    },
+    {
+      "source_record_id": "t1_mpxmk1u",
+      "request_id": "bedrock-00007",
+      "input_tokens": 241,
+      "output_tokens": 13
+    },
+    {
+      "source_record_id": "t1_mpxmkdo",
+      "request_id": "bedrock-00008",
+      "input_tokens": 252,
+      "output_tokens": 13
+    },
+    {
+      "source_record_id": "t1_mpxmlk4",
+      "request_id": "bedrock-00009",
+      "input_tokens": 279,
+      "output_tokens": 13
+    }
+  ],
+  "avg_input_tokens_per_request": 286.1,
+  "avg_output_tokens_per_request": 13.0,
+  "max_input_tokens_per_request": 434,
+  "max_output_tokens_per_request": 13,
+  "smoke_cost_usd": 0.000118,
+  "full_run_post_count": 400000,
+  "full_run_row_count": 400000,
+  "estimated_full_run_usd_avg": 4.7334,
+  "estimated_full_run_usd_max": 6.804,
+  "source_record_ids": [
+    "t1_mpxmfe6",
+    "t1_mpxmfoa",
+    "t1_mpxmfr2",
+    "t1_mpxmgbj",
+    "t1_mpxmgxp",
+    "t1_mpxmho3",
+    "t1_mpxmjkx",
+    "t1_mpxmk1u",
+    "t1_mpxmkdo",
+    "t1_mpxmlk4"
+  ]
+}

--- a/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_resume_evidence.json
+++ b/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_resume_evidence.json
@@ -1,0 +1,20 @@
+{
+  "feature": "is_likely_spam",
+  "run_id": "reddit_2026_09_03_233928_llm_features_v1:is_likely_spam",
+  "batch_id": "bedrock-smoke",
+  "input_file_id": null,
+  "interrupted_at": "2026_09_07-03:47:57",
+  "resumed_at": "2026_09_07-03:47:57",
+  "submit_calls_before_interrupt": {
+    "converse": 10
+  },
+  "submit_calls_after_resume": {
+    "converse": 0
+  },
+  "reattached_same_batch_id": true,
+  "rows_written": 10,
+  "provider_batch_ids_in_output": [
+    "bedrock-smoke"
+  ],
+  "resume_ok": true
+}

--- a/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_s3_checks.txt
+++ b/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_s3_checks.txt
@@ -1,0 +1,17 @@
+exists s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/input.parquet=true
+untagged s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/input.parquet=true
+exists s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/output.parquet=true
+untagged s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/output.parquet=true
+exists s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/cost_report.json=true
+untagged s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/cost_report.json=true
+exists s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/resume_evidence.json=true
+untagged s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/resume_evidence.json=true
+output_rows=10
+output_columns=['source_record_id', 'run_id', 'batch_id', 'request_id', 'attempt_count', 'label_timestamp', 'is_likely_spam']
+batches_prefix=s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/batches/ objects=0
+canonical_smoke_prefix=s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/ objects_before=0 objects_after=4
+smoke_objects_exist_untagged=true
+s3_smoke_output_ok=true
+s3_smoke_resume_evidence_ok=true
+no_batches_prefix_objects=true
+canonical_smoke_prefix_touched=true

--- a/docs/plans/2026-09-07_reddit_is_likely_spam_smoke_99228a/plan.md
+++ b/docs/plans/2026-09-07_reddit_is_likely_spam_smoke_99228a/plan.md
@@ -1,0 +1,59 @@
+# Commit the ten-comment spam smoke artifacts and the 400000-row cost estimate
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, frequent commits
+- Do not add or run automated tests. Do not change product Python. Do not run the 400000-row job.
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+The package is one independently mergeable pull request for child issue [224](https://github.com/METResearchGroup/mirrorView-task/issues/224). The pull request records the ten-comment smoke for `is_likely_spam` and the scaled cost of labeling 400000 Reddit comments. The pull request is part of parent issue [218](https://github.com/METResearchGroup/mirrorView-task/issues/218). The parent issue stays open. Sibling feature smoke directories stay out of the pull request.
+
+The work is documentation and run artifacts only. Product Python is unchanged. The 400000-row production job does not run. Owner sign-off on the parent issue is still required before anyone labels the full set.
+
+## Happy flow
+
+A reviewer opens the three committed smoke files. The cost file records that Bedrock `us.amazon.nova-micro-v1:0` labeled the ten shared comments, and that the scaled cost is 4.7334 USD on average and 6.804 USD at the token maximum. The resume file records that the smoke reattached the same Bedrock job. The S3 check file records four untagged objects under the primary smoke prefix and zero objects under `batches/`.
+
+```mermaid
+flowchart LR
+  A[Existing ten-comment smoke files] --> B[Commit is_likely_spam reports only]
+  B --> C[Stacked pull request]
+  C --> D[Reviewer reads cost, resume, and S3 checks]
+  D --> E[Parent issue owner sign-off before 400000-row run]
+```
+
+## Approach
+
+Commit files that already exist. Do not rerun the smoke. Do not invent product work. Stage only the `is_likely_spam` smoke directory and this plan directory. Leave every other untracked report directory and the parent cost aggregate file untouched.
+
+## Decisions
+
+- Smoke row count is 10. The first id is `t1_mpxmfe6`. The ten ids match `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/deterministic_ten_comment_ids.json`.
+- Engine is Bedrock. Model is `us.amazon.nova-micro-v1:0`. Production labeling uses one process and eight threads per part.
+- Scaled cost is `estimated_full_run_usd_avg=4.7334` and `estimated_full_run_usd_max=6.804` at 400000 rows.
+- Resume reattached the same Bedrock job. `resume_ok` is true.
+- Primary smoke prefix on S3 is `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/`.
+- The `batches/` prefix has no objects. No `part-*.parquet` files exist for this feature.
+- Production labeling waits for parent issue 218 owner sign-off.
+- Changelog is updated after the pull request exists.
+
+## Steps
+
+### Step 1: Commit the plan and the three existing smoke files
+
+Add this plan directory and the three `is_likely_spam` smoke files. Confirm the git index holds only those paths. See [steps/step1.md](steps/step1.md).
+
+## What "done" looks like
+
+1. `docs/plans/2026-09-07_reddit_is_likely_spam_smoke_99228a/` is committed with this plan and `steps/step1.md`.
+2. These three files are committed and no other smoke report directories are committed:
+   - `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_cost_report.json`
+   - `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_resume_evidence.json`
+   - `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_s3_checks.txt`
+3. The cost file records `smoke_rows` equivalent `request_count=10`, `engine_type=bedrock`, `model=us.amazon.nova-micro-v1:0`, `estimated_full_run_usd_avg=4.7334`, and `estimated_full_run_usd_max=6.804`.
+4. The resume file records `resume_ok=true` and `reattached_same_batch_id=true`.
+5. The S3 check file records the primary smoke prefix, four untagged smoke objects, `output_rows=10`, and `no_batches_prefix_objects=true`.
+6. Product Python, pytest, and the 400000-row job were not run. Parent issue 218 is not closed by this pull request.

--- a/docs/plans/2026-09-07_reddit_is_likely_spam_smoke_99228a/steps/step1.md
+++ b/docs/plans/2026-09-07_reddit_is_likely_spam_smoke_99228a/steps/step1.md
@@ -1,0 +1,170 @@
+# Step 1: Commit the plan and the three existing smoke files
+
+## Scope
+
+- **Caller:** git staging of two explicit path prefixes on branch `cursor/epic-218-224-generate-is-likely-spam-d983`, then the stacked pull request opened with `gh stack submit`.
+- **Task:** Commit this one-PR plan and the three existing `is_likely_spam` smoke files. Do not change product Python. Do not rerun the smoke. Do not run the 400000-row job.
+- **Out of scope:** Sibling smoke directories, `parent_cost_aggregate.json`, product code, pytest, changelog (after the pull request exists), parent issue 218 edits, Phase B production labeling.
+
+## Files to inspect
+
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_cost_report.json`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_resume_evidence.json`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_s3_checks.txt`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/deterministic_ten_comment_ids.json`
+- `CHANGELOG.md` (read only until the pull request exists)
+
+## Files allowed to change
+
+- `docs/plans/2026-09-07_reddit_is_likely_spam_smoke_99228a/plan.md` (new)
+- `docs/plans/2026-09-07_reddit_is_likely_spam_smoke_99228a/steps/step1.md` (new)
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_cost_report.json`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_resume_evidence.json`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_s3_checks.txt`
+
+## Files forbidden to change
+
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_news_or_opinion/**`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_political/**`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_self_contained/**`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_structurally_complete/**`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/llm_toxicity_tiered/**`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/political_stance/**`
+- `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/parent_cost_aggregate.json`
+- Any file under `data_platform/`
+- Any file under `lib/`
+- Any file under `tests/`
+- `CHANGELOG.md` (until after the pull request exists)
+- GitHub issue 218
+
+Stage files by explicit path only. Never run `git add -A` or `git add .`.
+
+## Locked identities
+
+| Field | Value |
+| ----- | ----- |
+| Feature | `is_likely_spam` |
+| Smoke rows | `10` |
+| First id | `t1_mpxmfe6` |
+| Engine | `bedrock` |
+| Model | `us.amazon.nova-micro-v1:0` |
+| Concurrency | 1 process x 8 threads |
+| `estimated_full_run_usd_avg` | `4.7334` |
+| `estimated_full_run_usd_max` | `6.804` |
+| Full-run row count | `400000` |
+| `resume_ok` | `true` |
+| `reattached_same_batch_id` | `true` |
+| Primary smoke prefix | `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/` |
+
+Ten shared ids:
+
+- `t1_mpxmfe6`
+- `t1_mpxmfoa`
+- `t1_mpxmfr2`
+- `t1_mpxmgbj`
+- `t1_mpxmgxp`
+- `t1_mpxmho3`
+- `t1_mpxmjkx`
+- `t1_mpxmk1u`
+- `t1_mpxmkdo`
+- `t1_mpxmlk4`
+
+## Ordered units of work
+
+1. Confirm the three smoke files already match the locked identities.
+2. Commit `docs/plans/2026-09-07_reddit_is_likely_spam_smoke_99228a/` first.
+3. Commit the three `is_likely_spam` smoke files second.
+4. Confirm other untracked smoke directories remain untracked.
+
+## Must pass
+
+```bash
+PYTHONPATH=. python3 - <<'PY'
+import json
+from pathlib import Path
+
+base = Path("docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke")
+ids = [
+    "t1_mpxmfe6",
+    "t1_mpxmfoa",
+    "t1_mpxmfr2",
+    "t1_mpxmgbj",
+    "t1_mpxmgxp",
+    "t1_mpxmho3",
+    "t1_mpxmjkx",
+    "t1_mpxmk1u",
+    "t1_mpxmkdo",
+    "t1_mpxmlk4",
+]
+cost = json.loads((base / "is_likely_spam" / "is_likely_spam_cost_report.json").read_text())
+resume = json.loads((base / "is_likely_spam" / "is_likely_spam_resume_evidence.json").read_text())
+shared = json.loads((base / "deterministic_ten_comment_ids.json").read_text())
+checks = (base / "is_likely_spam" / "is_likely_spam_s3_checks.txt").read_text()
+assert cost["feature"] == "is_likely_spam"
+assert cost["engine_type"] == "bedrock"
+assert cost["model"] == "us.amazon.nova-micro-v1:0"
+assert cost["request_count"] == 10
+assert cost["source_record_ids"] == ids
+assert cost["source_record_ids"][0] == "t1_mpxmfe6"
+assert cost["estimated_full_run_usd_avg"] == 4.7334
+assert cost["estimated_full_run_usd_max"] == 6.804
+assert cost["full_run_row_count"] == 400000
+assert cost["smoke_uri"].endswith("is_likely_spam/smoke/")
+assert resume["resume_ok"] is True
+assert resume["reattached_same_batch_id"] is True
+assert resume["rows_written"] == 10
+assert resume["submit_calls_after_resume"]["converse"] == 0
+assert shared["source_record_ids"] == ids
+assert "no_batches_prefix_objects=true" in checks
+assert "output_rows=10" in checks
+assert "objects=0" in checks
+print("smoke_artifacts_ok")
+PY
+```
+
+Expected: `smoke_artifacts_ok`.
+
+```bash
+git add docs/plans/2026-09-07_reddit_is_likely_spam_smoke_99228a/
+git diff --cached --name-only
+```
+
+Expected:
+
+```text
+docs/plans/2026-09-07_reddit_is_likely_spam_smoke_99228a/plan.md
+docs/plans/2026-09-07_reddit_is_likely_spam_smoke_99228a/steps/step1.md
+```
+
+```bash
+git add docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/
+git diff --cached --name-only
+```
+
+Expected:
+
+```text
+docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_cost_report.json
+docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_resume_evidence.json
+docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_s3_checks.txt
+```
+
+After both commits:
+
+```bash
+git status --porcelain
+```
+
+Expected: the other four feature smoke directories and `parent_cost_aggregate.json` remain `??`. No `data_platform/` or `tests/` paths.
+
+## Must fail
+
+- Staging any sibling smoke directory or `parent_cost_aggregate.json`.
+- Editing any file under `data_platform/`, `lib/`, or `tests/`.
+- Running pytest.
+- Running the 400000-row production command.
+- Using a closing GitHub keyword on issue 218.
+
+## Done when
+
+The branch has the plan commit and the three-file smoke commit. Other untracked report directories are still untracked. Product Python is unchanged.


### PR DESCRIPTION
Fixes #224

Part of #218

## Summary

Commits the ten-comment smoke artifacts for `is_likely_spam` on campaign `reddit_2026_09_03_233928_llm_features_v1`. Reviewers can read the cost, resume proof, and S3 checks without rerunning the smoke.

The pull request is artifacts only. Product Python is unchanged. The 400000-row production job does not run. `smoke_rows=10`. Engine is Bedrock `us.amazon.nova-micro-v1:0`. Concurrency is 1 process x 8 threads. `estimated_full_run_usd_avg=4.7334`. `estimated_full_run_usd_max=6.804`. The S3 primary smoke prefix was used. There are no `batches/part-*.parquet` objects for this feature. Production labeling waits for parent issue 218 owner sign-off.

## Purpose

Operators need a recorded ten-comment cost before anyone labels 400000 Reddit comments as likely spam or not. Pull request 239 added the Reddit smoke command. The remaining gap is a committed record for this feature on the primary smoke prefix.

Sibling feature smoke directories stay out of this pull request.

## Architecture

Components:

- Local cost report is the Bedrock Converse token-use record for ten comments and the scaled 400000-row cost.
- Local resume proof is the record that the smoke reattached the same Bedrock job and made zero extra Converse calls after resume.
- Local S3 checks are the record of four untagged objects under the primary smoke prefix and zero objects under `batches/`.
- S3 primary smoke prefix is the location of `input.parquet`, `output.parquet`, `cost_report.json`, and `resume_evidence.json`.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    T[Reddit smoke tooling] --> D[Disposable prefix proof on is_likely_spam]
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    F[is_likely_spam smoke] --> S3[Primary smoke prefix]
    S3 --> G[Committed cost, resume, and S3 check files]
  end
```

## Interfaces

### Cost report fields

| Field | Value |
| ----- | ----- |
| `request_count` / `smoke_rows` | `10` |
| `first_id` | `t1_mpxmfe6` |
| `engine_type` | `bedrock` |
| `model` | `us.amazon.nova-micro-v1:0` |
| Concurrency | 1 process x 8 threads |
| `estimated_full_run_usd_avg` | `4.7334` |
| `estimated_full_run_usd_max` | `6.804` |
| `full_run_row_count` | `400000` |

### Resume

`resume_ok=true`. The smoke reattached Bedrock job `bedrock-smoke`. Converse calls after resume were 0.

### S3

Primary smoke prefix:

`s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/is_likely_spam/smoke/`

`no_batches_prefix_objects=true`. No `part-*.parquet` files exist for this feature.

Ten shared ids: `t1_mpxmfe6`, `t1_mpxmfoa`, `t1_mpxmfr2`, `t1_mpxmgbj`, `t1_mpxmgxp`, `t1_mpxmho3`, `t1_mpxmjkx`, `t1_mpxmk1u`, `t1_mpxmkdo`, `t1_mpxmlk4`.

## How to run

The smoke already ran. Read the committed files.

```bash
PYTHONPATH=. python3 - <<'PY'
import json
from pathlib import Path
p = Path("docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/smoke/is_likely_spam/is_likely_spam_cost_report.json")
d = json.loads(p.read_text())
print(d["request_count"], d["engine_type"], d["model"], d["estimated_full_run_usd_avg"], d["estimated_full_run_usd_max"])
PY
```

Expected: `10 bedrock us.amazon.nova-micro-v1:0 4.7334 6.804`.

Do not run `generate_reddit_features.py` for 400000 rows from this pull request.

Plan: `docs/plans/2026-09-07_reddit_is_likely_spam_smoke_99228a/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added cost reporting for the Reddit spam-detection smoke run, including token usage, per-request details, aggregate costs, and projected full-run estimates.
  - Added evidence documenting successful interruption and resumption of the smoke run.
  - Added validation results confirming expected storage artifacts, output structure, row counts, and successful smoke-test checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->