### PR TITLE
Join seven Twitter LLM features and write the MirrorView export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 2026-09-07
 
-1. Operators now have seven OpenAI Batch labels for all 6,374 pinned Twitter posts, with four batch objects and a run report per feature. [PR #240](https://github.com/METResearchGroup/mirrorView-task/pull/240)
-2. The pinned Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_06_192847_llm_features_v1`, run a ten-post disposable smoke, scale cost math to 6,374 rows, and print watcher status without writing to GitHub. [PR #238](https://github.com/METResearchGroup/mirrorView-task/pull/238)
+1. Operators now have a Twitter table of 6,374 labeled posts with 21 columns, plus a MirrorView curated export that records political stance by toxicity tier. [PR #249](https://github.com/METResearchGroup/mirrorView-task/pull/249)
+2. Operators now have seven OpenAI Batch labels for all 6,374 pinned Twitter posts, with four batch objects and a run report per feature. [PR #240](https://github.com/METResearchGroup/mirrorView-task/pull/240)
+3. The pinned Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_06_192847_llm_features_v1`, run a ten-post disposable smoke, scale cost math to 6,374 rows, and print watcher status without writing to GitHub. [PR #238](https://github.com/METResearchGroup/mirrorView-task/pull/238)
 
 ## 2026-09-06
 

--- a/data_platform/curate/consolidate_twitter_llm_campaign.py
+++ b/data_platform/curate/consolidate_twitter_llm_campaign.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from typing import Any
 
 import boto3
+import duckdb
 import pandas as pd
 
 from data_platform.curate.consolidate import (
@@ -350,12 +351,87 @@ def download_campaign_inputs(
     return preprocessed, features
 
 
+def _sql_path(path: Path) -> str:
+    return path.resolve().as_posix().replace("'", "''")
+
+
+def _posts_cte_sql(posts_file: Path) -> str:
+    id_column = STANDARDIZED_SOURCE_RECORD_ID_COLUMN
+    selected = ", ".join(
+        f"CAST({column} AS VARCHAR) AS {column}" if column == id_column else column
+        for column in TWITTER_PREPROCESSED_WIDE_COLUMNS
+    )
+    csv_path = _sql_path(posts_file)
+    return f"posts AS (SELECT {selected} FROM read_csv('{csv_path}', union_by_name = true))"
+
+
+def _feature_cte_sql(feature_name: str, parquet_path: Path) -> str:
+    column_pairs = FEATURE_WIDE_COLUMNS[feature_name]
+    inner_cols = ", ".join(
+        f"{source} AS {alias}" if source != alias else source for source, alias in column_pairs
+    )
+    outer_cols = ", ".join(alias for _, alias in column_pairs)
+    id_column = STANDARDIZED_SOURCE_RECORD_ID_COLUMN
+    parquet = _sql_path(parquet_path)
+    return f"""
+feat_{feature_name} AS (
+    SELECT {id_column}, {outer_cols}
+    FROM (
+        SELECT CAST({id_column} AS VARCHAR) AS {id_column}, {inner_cols},
+            ROW_NUMBER() OVER (
+                PARTITION BY CAST({id_column} AS VARCHAR)
+                ORDER BY label_timestamp DESC NULLS LAST, CAST({id_column} AS VARCHAR)
+            ) AS rn
+        FROM read_parquet('{parquet}')
+    )
+    WHERE rn = 1
+)"""
+
+
+def _twitter_join_sql(posts_file: Path, feature_files: dict[str, Path]) -> str:
+    id_column = STANDARDIZED_SOURCE_RECORD_ID_COLUMN
+    join_clauses = [
+        f"INNER JOIN feat_{feature_name} USING ({id_column})"
+        for feature_name in LLM_CAMPAIGN_FEATURE_NAMES
+    ]
+    label_cols = [
+        f"feat_{feature_name}.{alias}"
+        for feature_name in LLM_CAMPAIGN_FEATURE_NAMES
+        for _, alias in FEATURE_WIDE_COLUMNS[feature_name]
+    ]
+    posts_cols = [f"posts.{column}" for column in TWITTER_PREPROCESSED_WIDE_COLUMNS]
+    feature_ctes = [
+        _feature_cte_sql(feature_name, feature_files[feature_name])
+        for feature_name in LLM_CAMPAIGN_FEATURE_NAMES
+    ]
+    ctes = ",\n".join([_posts_cte_sql(posts_file), *feature_ctes])
+    return f"""
+WITH {ctes}
+SELECT {", ".join(posts_cols + label_cols)}
+FROM posts
+{" ".join(join_clauses)}
+ORDER BY posts.{id_column} ASC
+"""
+
+
+def _missing_feature_names(feature_files: dict[str, Path]) -> list[str]:
+    return [name for name in LLM_CAMPAIGN_FEATURE_NAMES if name not in feature_files]
+
+
 def build_twitter_llm_campaign_wide_table(
     posts_file: Path,
     feature_files: dict[str, Path],
 ) -> pd.DataFrame:
     """Inner-join pinned csv posts to seven campaign ``final.parquet`` files."""
-    raise NotImplementedError
+    missing = _missing_feature_names(feature_files)
+    if missing:
+        raise KeyError(f"missing campaign feature parquet paths: {missing}")
+    sql = _twitter_join_sql(posts_file, feature_files)
+    conn = duckdb.connect()
+    try:
+        return conn.execute(sql).fetchdf()
+    finally:
+        conn.close()
 
 
 def validate_wide_table(wide: pd.DataFrame) -> None:

--- a/data_platform/curate/consolidate_twitter_llm_campaign.py
+++ b/data_platform/curate/consolidate_twitter_llm_campaign.py
@@ -40,6 +40,7 @@ import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any
 
 import boto3
@@ -62,6 +63,7 @@ from data_platform.curate.runner import build_curate_metadata
 from data_platform.generate_features.s3_feature_campaign import (
     CampaignObjectStore,
     FeaturePaths,
+    parse_s3_uri,
     s3_uri,
 )
 from data_platform.utils.dataset import dataset_root, relative_run_path
@@ -619,6 +621,86 @@ def curate_mirrorview_dataset(
     )
 
 
+def _json_bytes(document: dict[str, Any]) -> bytes:
+    return json.dumps(document, indent=2).encode("utf-8")
+
+
+def _repo_relative(path: Path) -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(repo_root).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def _wide_prefix(output_key: str) -> str:
+    if not output_key.endswith(WIDE_PARQUET_FILENAME):
+        raise ValueError(
+            f"output-s3-uri must end with {WIDE_PARQUET_FILENAME}, got {output_key!r}"
+        )
+    return output_key[: -len(WIDE_PARQUET_FILENAME)]
+
+
+def _feature_manifest_block(
+    store: CampaignObjectStore, record: FeatureInputRecord
+) -> dict[str, Any]:
+    return {
+        "manifest_uri": s3_uri(store.bucket, record.manifest_key),
+        "manifest_sha256": record.manifest_sha256,
+        "final_parquet": {
+            "key": record.final_key,
+            "sha256": record.final_sha256,
+            "row_count": record.final_row_count,
+        },
+    }
+
+
+def _curated_manifest_block(
+    args: CampaignConsolidateArgs, curated: CuratedDatasetRecord
+) -> dict[str, Any]:
+    return {
+        "rules_config": _repo_relative(args.curate_config),
+        "rules_hash": curated.rules_hash,
+        "row_count": curated.row_count,
+        "parquet": {"key": curated.parquet_key, "sha256": curated.parquet_sha256},
+        "metadata": {"key": curated.metadata_key, "sha256": curated.metadata_sha256},
+        "crosstab_political_stance_by_llm_toxicity_tier": curated.stance_by_toxicity,
+    }
+
+
+def _wide_manifest_document(
+    store: CampaignObjectStore,
+    args: CampaignConsolidateArgs,
+    wide_key: str,
+    wide_sha: str,
+    preprocessed: PreprocessedInputRecord,
+    feature_inputs: tuple[FeatureInputRecord, ...],
+    curated: CuratedDatasetRecord | None,
+) -> dict[str, Any]:
+    document: dict[str, Any] = {
+        "dataset_id": args.dataset_id,
+        "preprocessed_run": args.preprocessed_run,
+        "campaign_id": args.campaign_id,
+        "row_count": TWITTER_EXPECTED_WIDE_ROW_COUNT,
+        "columns": list(twitter_llm_campaign_wide_columns()),
+        "sort_key": WIDE_SORT_KEY,
+        "wide_parquet": {
+            "key": wide_key,
+            "sha256": wide_sha,
+            "row_count": TWITTER_EXPECTED_WIDE_ROW_COUNT,
+        },
+        "preprocessed": {"key": preprocessed.key, "sha256": preprocessed.sha256},
+        "features": {
+            record.feature_name: _feature_manifest_block(store, record)
+            for record in feature_inputs
+        },
+    }
+    if curated is not None:
+        document["curated"] = _curated_manifest_block(args, curated)
+    return document
+
+
 def upload_wide_artifacts(
     store: CampaignObjectStore,
     wide: pd.DataFrame,
@@ -628,17 +710,69 @@ def upload_wide_artifacts(
     curated: CuratedDatasetRecord | None,
 ) -> tuple[str, str, str]:
     """Upload ``features.parquet`` and ``manifest.json``."""
-    raise NotImplementedError
+    bucket, wide_key = parse_s3_uri(args.output_s3_uri)
+    if bucket != store.bucket:
+        raise ValueError(f"output bucket {bucket} does not match campaign bucket {store.bucket}")
+    wide_sha = _upload_bytes(store, wide_key, wide.to_parquet(index=False))
+    manifest_key = f"{_wide_prefix(wide_key)}{WIDE_MANIFEST_FILENAME}"
+    manifest = _wide_manifest_document(
+        store, args, wide_key, wide_sha, preprocessed, feature_inputs, curated
+    )
+    _upload_bytes(store, manifest_key, _json_bytes(manifest))
+    return wide_sha, s3_uri(store.bucket, wide_key), s3_uri(store.bucket, manifest_key)
+
+
+def _campaign_store(args: CampaignConsolidateArgs) -> CampaignObjectStore:
+    paths = _twitter_feature_paths(
+        args.campaign_id, LLM_CAMPAIGN_FEATURE_NAMES[0], args.dataset_id
+    )
+    return CampaignObjectStore(paths.bucket)
 
 
 def run_campaign_consolidation(args: CampaignConsolidateArgs) -> WideConsolidateResult:
     """Download inputs, join, validate, upload wide artifacts, and curate."""
-    raise NotImplementedError
+    store = _campaign_store(args)
+    with TemporaryDirectory() as tmp:
+        preprocessed, features = download_campaign_inputs(store, args, Path(tmp))
+        wide = build_twitter_llm_campaign_wide_table(
+            preprocessed.local_csv,
+            {record.feature_name: record.local_parquet for record in features},
+        )
+        validate_wide_table(wide)
+        curated = curate_mirrorview_dataset(store, wide, args)
+        wide_sha, parquet_uri, manifest_uri = upload_wide_artifacts(
+            store, wide, args, preprocessed, features, curated
+        )
+    return WideConsolidateResult(
+        wide_rows=len(wide),
+        wide_columns=tuple(wide.columns),
+        wide_parquet_uri=parquet_uri,
+        wide_parquet_sha256=wide_sha,
+        manifest_uri=manifest_uri,
+        sort_key=WIDE_SORT_KEY,
+        feature_inputs=features,
+        preprocessed=preprocessed,
+        curated=curated,
+    )
+
+
+def _print_curated(result: WideConsolidateResult) -> None:
+    if result.curated is None:
+        return
+    bucket, _ = parse_s3_uri(result.wide_parquet_uri)
+    print(f"curated_rows={result.curated.row_count}")
+    print(f"curated={s3_uri(bucket, result.curated.parquet_key)}")
+    print("curated_crosstab_political_stance_by_llm_toxicity_tier=")
+    print(json.dumps(result.curated.stance_by_toxicity, indent=2))
 
 
 def print_result(result: WideConsolidateResult) -> None:
     """Print the stdout contract plus curated row count and crosstab."""
-    raise NotImplementedError
+    print(f"wide_rows={result.wide_rows}")
+    print(f"wide_columns={len(result.wide_columns)}")
+    print(f"manifest={result.manifest_uri}")
+    print(f"sort_key={result.sort_key}")
+    _print_curated(result)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/data_platform/curate/consolidate_twitter_llm_campaign.py
+++ b/data_platform/curate/consolidate_twitter_llm_campaign.py
@@ -35,11 +35,14 @@ Run from the repo root:
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import boto3
 import pandas as pd
 
 from data_platform.curate.consolidate import (
@@ -47,7 +50,12 @@ from data_platform.curate.consolidate import (
     LLM_CAMPAIGN_FEATURE_NAMES,
     WIDE_SORT_KEY,
 )
-from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from data_platform.generate_features.s3_feature_campaign import (
+    CampaignObjectStore,
+    FeaturePaths,
+    s3_uri,
+)
+from data_platform.utils.object_store import DEFAULT_S3_REGION, S3_KEY_PREFIX, sha256_hex
 from data_platform.utils.platform_specific_columns import STANDARDIZED_SOURCE_RECORD_ID_COLUMN
 from data_platform.utils.storage import TwitterStorageManager
 
@@ -186,6 +194,73 @@ def parse_args(argv: list[str] | None = None) -> CampaignConsolidateArgs:
     )
 
 
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(SHA256_READ_CHUNK_BYTES), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _s3_client() -> Any:
+    return boto3.client("s3", region_name=DEFAULT_S3_REGION)
+
+
+def _twitter_feature_paths(campaign_id: str, feature_name: str, dataset_id: str) -> FeaturePaths:
+    return FeaturePaths.for_campaign(
+        campaign_id,
+        feature_name,
+        platform=TWITTER_PLATFORM,
+        dataset_id=dataset_id,
+    )
+
+
+def _preprocessed_posts_key(dataset_id: str, preprocessed_run: str) -> str:
+    return (
+        f"{S3_KEY_PREFIX}/{TWITTER_PLATFORM}/{dataset_id}/"
+        f"preprocessed/{preprocessed_run}/posts.csv"
+    )
+
+
+def _inventory_path(dataset_id: str) -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / TWITTER_PLATFORM
+        / dataset_id
+        / INVENTORY_FILENAME
+    )
+
+
+def _expected_posts_sha256(dataset_id: str, posts_key: str) -> str:
+    inventory = json.loads(_inventory_path(dataset_id).read_text(encoding="utf-8"))
+    for obj in inventory["objects"]:
+        if obj.get("s3_key") == posts_key:
+            return str(obj["sha256"]).lower()
+    raise ValueError(f"inventory has no object for {posts_key}")
+
+
+def _require_sha256(label: str, actual: str, expected: str) -> None:
+    if actual != expected:
+        raise ValueError(f"{label} SHA-256 mismatch: expected {expected}, object {actual}")
+
+
+def _download_key(client: Any, bucket: str, key: str, dest: Path) -> str:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    client.download_file(bucket, key, str(dest))
+    return _sha256_file(dest)
+
+
+def _require_final_row_count(feature_name: str, manifest: dict[str, Any]) -> dict[str, Any]:
+    final = manifest.get("final_parquet") or {}
+    if final.get("row_count") != TWITTER_EXPECTED_WIDE_ROW_COUNT:
+        raise ValueError(
+            f"{feature_name} final.parquet row_count is {final.get('row_count')}, "
+            f"expected {TWITTER_EXPECTED_WIDE_ROW_COUNT}"
+        )
+    return final
+
+
 def verify_feature_manifest(
     store: CampaignObjectStore,
     feature_name: str,
@@ -193,7 +268,71 @@ def verify_feature_manifest(
     dataset_id: str,
 ) -> tuple[str, dict[str, Any]]:
     """Return manifest SHA-256 and parsed JSON after checking row count 6374."""
-    raise NotImplementedError
+    paths = _twitter_feature_paths(campaign_id, feature_name, dataset_id)
+    stored = store.get(paths.manifest_key)
+    if stored is None:
+        raise FileNotFoundError(f"missing feature manifest: {paths.uri(paths.manifest_key)}")
+    manifest = json.loads(stored.body)
+    _require_final_row_count(feature_name, manifest)
+    digest = sha256_hex(stored.body)
+    print(f"accepted {feature_name} manifest sha256={digest}")
+    return digest, manifest
+
+
+def _feature_record(
+    paths: FeaturePaths,
+    feature_name: str,
+    manifest_sha: str,
+    final: dict[str, Any],
+    digest: str,
+    local_path: Path,
+) -> FeatureInputRecord:
+    return FeatureInputRecord(
+        feature_name=feature_name,
+        final_key=paths.final_key,
+        final_sha256=digest,
+        final_row_count=int(final["row_count"]),
+        manifest_key=paths.manifest_key,
+        manifest_sha256=manifest_sha,
+        local_parquet=local_path,
+    )
+
+
+def _download_feature_final(
+    store: CampaignObjectStore,
+    client: Any,
+    args: CampaignConsolidateArgs,
+    work_dir: Path,
+    feature_name: str,
+) -> FeatureInputRecord:
+    paths = _twitter_feature_paths(args.campaign_id, feature_name, args.dataset_id)
+    manifest_sha, manifest = verify_feature_manifest(
+        store, feature_name, args.campaign_id, args.dataset_id
+    )
+    local_path = work_dir / feature_name / "final.parquet"
+    digest = _download_key(client, store.bucket, paths.final_key, local_path)
+    _require_sha256(
+        f"{feature_name} final.parquet",
+        digest,
+        str(manifest["final_parquet"]["sha256"]).lower(),
+    )
+    return _feature_record(
+        paths, feature_name, manifest_sha, manifest["final_parquet"], digest, local_path
+    )
+
+
+def _download_posts_csv(
+    client: Any,
+    store: CampaignObjectStore,
+    args: CampaignConsolidateArgs,
+    work_dir: Path,
+) -> PreprocessedInputRecord:
+    posts_key = _preprocessed_posts_key(args.dataset_id, args.preprocessed_run)
+    expected = _expected_posts_sha256(args.dataset_id, posts_key)
+    posts_path = work_dir / "posts.csv"
+    posts_sha = _download_key(client, store.bucket, posts_key, posts_path)
+    _require_sha256("posts.csv", posts_sha, expected)
+    return PreprocessedInputRecord(key=posts_key, sha256=posts_sha, local_csv=posts_path)
 
 
 def download_campaign_inputs(
@@ -202,7 +341,13 @@ def download_campaign_inputs(
     work_dir: Path,
 ) -> tuple[PreprocessedInputRecord, tuple[FeatureInputRecord, ...]]:
     """Download pinned posts.csv and seven verified ``final.parquet`` files."""
-    raise NotImplementedError
+    client = _s3_client()
+    preprocessed = _download_posts_csv(client, store, args, work_dir)
+    features = tuple(
+        _download_feature_final(store, client, args, work_dir, feature_name)
+        for feature_name in LLM_CAMPAIGN_FEATURE_NAMES
+    )
+    return preprocessed, features
 
 
 def build_twitter_llm_campaign_wide_table(

--- a/data_platform/curate/consolidate_twitter_llm_campaign.py
+++ b/data_platform/curate/consolidate_twitter_llm_campaign.py
@@ -434,9 +434,41 @@ def build_twitter_llm_campaign_wide_table(
         conn.close()
 
 
+def _validate_wide_rows(wide: pd.DataFrame) -> None:
+    id_column = STANDARDIZED_SOURCE_RECORD_ID_COLUMN
+    if len(wide) != TWITTER_EXPECTED_WIDE_ROW_COUNT:
+        raise ValueError(f"wide_rows={len(wide)}, expected {TWITTER_EXPECTED_WIDE_ROW_COUNT}")
+    unique_ids = wide[id_column].astype(str).nunique()
+    if unique_ids != TWITTER_EXPECTED_WIDE_ROW_COUNT:
+        raise ValueError(
+            f"distinct source_record_id={unique_ids}, expected {TWITTER_EXPECTED_WIDE_ROW_COUNT}"
+        )
+    if not wide[id_column].astype(str).is_monotonic_increasing:
+        raise ValueError("wide rows are not sorted by source_record_id ASC")
+
+
+def _validate_wide_labels(wide: pd.DataFrame, expected_columns: tuple[str, ...]) -> None:
+    label_columns = expected_columns[len(TWITTER_PREPROCESSED_WIDE_COLUMNS) :]
+    null_counts = {
+        column: int(wide[column].isna().sum())
+        for column in label_columns
+        if int(wide[column].isna().sum()) > 0
+    }
+    if null_counts:
+        raise ValueError(f"null feature values: {null_counts}")
+
+
 def validate_wide_table(wide: pd.DataFrame) -> None:
     """Raise ValueError when the wide table misses the Twitter campaign contract."""
-    raise NotImplementedError
+    expected = twitter_llm_campaign_wide_columns()
+    actual = tuple(wide.columns)
+    if actual != expected:
+        raise ValueError(f"wide columns {actual} do not match {expected}")
+    _validate_wide_rows(wide)
+    forbidden = FORBIDDEN_WIDE_COLUMNS.intersection(actual)
+    if forbidden:
+        raise ValueError(f"wide table contains forbidden columns: {sorted(forbidden)}")
+    _validate_wide_labels(wide, expected)
 
 
 def curate_mirrorview_dataset(

--- a/data_platform/curate/consolidate_twitter_llm_campaign.py
+++ b/data_platform/curate/consolidate_twitter_llm_campaign.py
@@ -46,19 +46,29 @@ import boto3
 import duckdb
 import pandas as pd
 
+from data_platform.curate.apply_rules import (
+    ApplyRulesResult,
+    CurateRulesConfig,
+    FilterStepResult,
+    apply_rules,
+    load_rules_config,
+)
 from data_platform.curate.consolidate import (
     FEATURE_WIDE_COLUMNS,
     LLM_CAMPAIGN_FEATURE_NAMES,
     WIDE_SORT_KEY,
 )
+from data_platform.curate.runner import build_curate_metadata
 from data_platform.generate_features.s3_feature_campaign import (
     CampaignObjectStore,
     FeaturePaths,
     s3_uri,
 )
+from data_platform.utils.dataset import dataset_root, relative_run_path
 from data_platform.utils.object_store import DEFAULT_S3_REGION, S3_KEY_PREFIX, sha256_hex
 from data_platform.utils.platform_specific_columns import STANDARDIZED_SOURCE_RECORD_ID_COLUMN
-from data_platform.utils.storage import TwitterStorageManager
+from data_platform.utils.storage import DATA_ROOT, TwitterStorageManager
+from lib.timestamp_utils import get_current_timestamp
 
 MIRRORVIEW_RULES_PATH = (
     Path(__file__).resolve().parent / "configs" / "twitter" / "mirrorview.yaml"
@@ -471,13 +481,142 @@ def validate_wide_table(wide: pd.DataFrame) -> None:
     _validate_wide_labels(wide, expected)
 
 
+def _upload_bytes(store: CampaignObjectStore, key: str, body: bytes) -> str:
+    stored = store.get(key)
+    if stored is None:
+        return store.put_new(key, body).sha256
+    return store.replace(key, body, etag=stored.etag).sha256
+
+
+def _full_data_key(path: Path) -> str:
+    return f"{S3_KEY_PREFIX}/{path.relative_to(DATA_ROOT).as_posix()}"
+
+
+def _curated_export_filename(stem: str) -> str:
+    return f"{stem}.{CURATED_EXPORT_SUFFIX}"
+
+
+def _filter_step_record(step: FilterStepResult) -> dict[str, Any]:
+    return {
+        **step.rule.model_dump(),
+        "records_before": step.records_before,
+        "records_passing": step.records_passing,
+    }
+
+
+def _stance_by_toxicity(filtered: pd.DataFrame) -> dict[str, dict[str, int]]:
+    counts: dict[str, dict[str, int]] = {
+        stance: {tier: 0 for tier in TOXICITY_CROSSTAB_COLUMNS} for stance in STANCE_CROSSTAB_ROWS
+    }
+    grouped = filtered.groupby(["political_stance", "llm_toxicity_tier"], dropna=False).size()
+    for (stance, tier), row_count in grouped.items():
+        stance_key = str(stance)
+        tier_key = str(tier)
+        counts.setdefault(stance_key, {})
+        counts[stance_key][tier_key] = int(row_count)
+    return counts
+
+
+def _write_curated_parquet(
+    store: CampaignObjectStore,
+    filtered: pd.DataFrame,
+    output_path: Path,
+) -> tuple[str, str]:
+    parquet_key = _full_data_key(output_path)
+    digest = _upload_bytes(store, parquet_key, filtered.to_parquet(index=False))
+    return parquet_key, digest
+
+
+def _curate_metadata_document(
+    args: CampaignConsolidateArgs,
+    rules: CurateRulesConfig,
+    rules_hash: str,
+    wide: pd.DataFrame,
+    filtered: pd.DataFrame,
+    applied: ApplyRulesResult,
+    export_filename: str,
+    stance_by_toxicity: dict[str, dict[str, int]],
+) -> dict[str, Any]:
+    dataset = dataset_root(TWITTER_PLATFORM, args.dataset_id)
+    preprocessed_dir = dataset / "preprocessed" / args.preprocessed_run
+    metadata = build_curate_metadata(
+        dataset_id=args.dataset_id,
+        rules_name=rules.name,
+        rules_hash=rules_hash,
+        source_preprocessed_runs=[relative_run_path(dataset, preprocessed_dir)],
+        wide_df=wide,
+        filtered_df=filtered,
+        rules_result=applied,
+        export_filename=export_filename,
+    )
+    metadata["crosstab_political_stance_by_llm_toxicity_tier"] = stance_by_toxicity
+    return metadata
+
+
+def _curated_record(
+    filtered: pd.DataFrame,
+    parquet_key: str,
+    parquet_sha: str,
+    metadata_key: str,
+    metadata_sha: str,
+    rules_hash: str,
+    applied: ApplyRulesResult,
+    stance_by_toxicity: dict[str, dict[str, int]],
+) -> CuratedDatasetRecord:
+    return CuratedDatasetRecord(
+        row_count=len(filtered),
+        parquet_key=parquet_key,
+        parquet_sha256=parquet_sha,
+        metadata_key=metadata_key,
+        metadata_sha256=metadata_sha,
+        rules_hash=rules_hash,
+        filter_steps=[_filter_step_record(step) for step in applied.steps],
+        stance_by_toxicity=stance_by_toxicity,
+    )
+
+
+def _object_sha256(store: CampaignObjectStore, key: str) -> str:
+    stored = store.get(key)
+    if stored is None:
+        raise FileNotFoundError(f"missing object after write: {s3_uri(store.bucket, key)}")
+    return sha256_hex(stored.body)
+
+
+def _apply_mirrorview_rules(
+    args: CampaignConsolidateArgs, wide: pd.DataFrame
+) -> tuple[CurateRulesConfig, str, ApplyRulesResult]:
+    rules = load_rules_config(args.curate_config)
+    rules_hash = hashlib.sha256(args.curate_config.read_bytes()).hexdigest()
+    return rules, rules_hash, apply_rules(wide, rules)
+
+
 def curate_mirrorview_dataset(
     store: CampaignObjectStore,
     wide: pd.DataFrame,
     args: CampaignConsolidateArgs,
 ) -> CuratedDatasetRecord:
     """Apply Twitter MirrorView YAML filters and upload ``mirrorview.parquet``."""
-    raise NotImplementedError
+    rules, rules_hash, applied = _apply_mirrorview_rules(args, wide)
+    filtered = applied.dataframe
+    curated_storage = TwitterStorageManager("curated", args.dataset_id)
+    run_dir = curated_storage.create_new_run_dir(get_current_timestamp())
+    export_filename = _curated_export_filename(rules.output.stem)
+    parquet_key, parquet_sha = _write_curated_parquet(store, filtered, run_dir / export_filename)
+    stance_by_toxicity = _stance_by_toxicity(filtered)
+    metadata = _curate_metadata_document(
+        args, rules, rules_hash, wide, filtered, applied, export_filename, stance_by_toxicity
+    )
+    metadata_key = _full_data_key(curated_storage.write_run_metadata(run_dir, metadata))
+    return _curated_record(
+        filtered,
+        parquet_key,
+        parquet_sha,
+        metadata_key,
+        _object_sha256(store, metadata_key),
+        rules_hash,
+        applied,
+        stance_by_toxicity,
+    )
 
 
 def upload_wide_artifacts(

--- a/data_platform/curate/consolidate_twitter_llm_campaign.py
+++ b/data_platform/curate/consolidate_twitter_llm_campaign.py
@@ -40,36 +40,127 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from data_platform.curate.consolidate import LLM_CAMPAIGN_FEATURE_NAMES
+import pandas as pd
+
+from data_platform.curate.consolidate import (
+    FEATURE_WIDE_COLUMNS,
+    LLM_CAMPAIGN_FEATURE_NAMES,
+    WIDE_SORT_KEY,
+)
 from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from data_platform.utils.platform_specific_columns import STANDARDIZED_SOURCE_RECORD_ID_COLUMN
 from data_platform.utils.storage import TwitterStorageManager
 
-MIRRORVIEW_RULES_PATH = Path(__file__).resolve().parent / "configs" / "twitter" / "mirrorview.yaml"
+MIRRORVIEW_RULES_PATH = (
+    Path(__file__).resolve().parent / "configs" / "twitter" / "mirrorview.yaml"
+)
+TWITTER_PLATFORM = "twitter"
+TWITTER_EXPECTED_WIDE_ROW_COUNT = 6374
+WIDE_MANIFEST_FILENAME = "manifest.json"
+WIDE_PARQUET_FILENAME = "features.parquet"
+CURATED_EXPORT_SUFFIX = "parquet"
+SHA256_READ_CHUNK_BYTES = 1024 * 1024
+STANCE_CROSSTAB_ROWS = ("left", "right")
+TOXICITY_CROSSTAB_COLUMNS = ("low", "medium", "high")
+INVENTORY_FILENAME = "s3_preprocessed_inventory.json"
+TWITTER_PREPROCESSED_WIDE_COLUMNS: tuple[str, ...] = (
+    "tweet_id",
+    "record_id",
+    "url",
+    "username",
+    "author_handle",
+    "text",
+    "created_at",
+    "like_count",
+    "retweet_count",
+    "reply_count",
+    "quote_count",
+    "keyword",
+    "sync_timestamp",
+    STANDARDIZED_SOURCE_RECORD_ID_COLUMN,
+)
+FORBIDDEN_WIDE_COLUMNS = frozenset(
+    {
+        "toxicity_prob",
+        "toxicity_tier",
+        "label_timestamp",
+        "run_id",
+        "is_toxic_tiered",
+        "author_id",
+    }
+)
 
 
 @dataclass(frozen=True)
 class CampaignConsolidateArgs:
     """CLI inputs for the Twitter LLM campaign wide join."""
 
+    dataset_id: str
+    preprocessed_run: str
+    campaign_id: str
+    output_s3_uri: str
+    curate_config: Path
+
 
 @dataclass(frozen=True)
 class FeatureInputRecord:
-    """Verified feature final.parquet and its parameter manifest."""
+    """Verified feature ``final.parquet`` and its parameter manifest."""
+
+    feature_name: str
+    final_key: str
+    final_sha256: str
+    final_row_count: int
+    manifest_key: str
+    manifest_sha256: str
+    local_parquet: Path
 
 
 @dataclass(frozen=True)
 class PreprocessedInputRecord:
     """Pinned preprocessed posts used as the wide-join left table."""
 
+    key: str
+    sha256: str
+    local_csv: Path
+
 
 @dataclass(frozen=True)
 class CuratedDatasetRecord:
     """MirrorView-filtered rows plus stance by toxicity counts."""
 
+    row_count: int
+    parquet_key: str
+    parquet_sha256: str
+    metadata_key: str
+    metadata_sha256: str
+    rules_hash: str
+    filter_steps: list[dict[str, Any]]
+    stance_by_toxicity: dict[str, dict[str, int]]
+
 
 @dataclass(frozen=True)
 class WideConsolidateResult:
     """Uploaded wide Parquet, manifest, and curated export."""
+
+    wide_rows: int
+    wide_columns: tuple[str, ...]
+    wide_parquet_uri: str
+    wide_parquet_sha256: str
+    manifest_uri: str
+    sort_key: str
+    feature_inputs: tuple[FeatureInputRecord, ...]
+    preprocessed: PreprocessedInputRecord
+    curated: CuratedDatasetRecord | None
+
+
+def twitter_llm_campaign_wide_columns() -> tuple[str, ...]:
+    """Return the 21 wide columns in campaign contract order."""
+    label_columns = tuple(
+        alias
+        for feature_name in LLM_CAMPAIGN_FEATURE_NAMES
+        for _, alias in FEATURE_WIDE_COLUMNS[feature_name]
+    )
+    return TWITTER_PREPROCESSED_WIDE_COLUMNS + label_columns
 
 
 def parse_args(argv: list[str] | None = None) -> CampaignConsolidateArgs:
@@ -85,8 +176,14 @@ def parse_args(argv: list[str] | None = None) -> CampaignConsolidateArgs:
         default=str(MIRRORVIEW_RULES_PATH),
         help="YAML rules applied to the wide table after the join.",
     )
-    parser.parse_args(argv)
-    raise NotImplementedError
+    parsed = parser.parse_args(argv)
+    return CampaignConsolidateArgs(
+        dataset_id=parsed.dataset_id,
+        preprocessed_run=parsed.preprocessed_run,
+        campaign_id=parsed.campaign_id,
+        output_s3_uri=parsed.output_s3_uri,
+        curate_config=Path(parsed.curate_config),
+    )
 
 
 def verify_feature_manifest(
@@ -95,6 +192,7 @@ def verify_feature_manifest(
     campaign_id: str,
     dataset_id: str,
 ) -> tuple[str, dict[str, Any]]:
+    """Return manifest SHA-256 and parsed JSON after checking row count 6374."""
     raise NotImplementedError
 
 
@@ -103,45 +201,51 @@ def download_campaign_inputs(
     args: CampaignConsolidateArgs,
     work_dir: Path,
 ) -> tuple[PreprocessedInputRecord, tuple[FeatureInputRecord, ...]]:
+    """Download pinned posts.csv and seven verified ``final.parquet`` files."""
     raise NotImplementedError
 
 
 def build_twitter_llm_campaign_wide_table(
     posts_file: Path,
     feature_files: dict[str, Path],
-) -> Any:
+) -> pd.DataFrame:
+    """Inner-join pinned csv posts to seven campaign ``final.parquet`` files."""
     raise NotImplementedError
 
 
-def validate_wide_table(wide: Any) -> None:
+def validate_wide_table(wide: pd.DataFrame) -> None:
+    """Raise ValueError when the wide table misses the Twitter campaign contract."""
     raise NotImplementedError
 
 
 def curate_mirrorview_dataset(
     store: CampaignObjectStore,
-    wide: Any,
+    wide: pd.DataFrame,
     args: CampaignConsolidateArgs,
-    curated_storage: TwitterStorageManager,
 ) -> CuratedDatasetRecord:
+    """Apply Twitter MirrorView YAML filters and upload ``mirrorview.parquet``."""
     raise NotImplementedError
 
 
 def upload_wide_artifacts(
     store: CampaignObjectStore,
-    wide: Any,
+    wide: pd.DataFrame,
     args: CampaignConsolidateArgs,
     preprocessed: PreprocessedInputRecord,
     feature_inputs: tuple[FeatureInputRecord, ...],
     curated: CuratedDatasetRecord | None,
 ) -> tuple[str, str, str]:
+    """Upload ``features.parquet`` and ``manifest.json``."""
     raise NotImplementedError
 
 
 def run_campaign_consolidation(args: CampaignConsolidateArgs) -> WideConsolidateResult:
+    """Download inputs, join, validate, upload wide artifacts, and curate."""
     raise NotImplementedError
 
 
 def print_result(result: WideConsolidateResult) -> None:
+    """Print the stdout contract plus curated row count and crosstab."""
     raise NotImplementedError
 
 
@@ -153,5 +257,4 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    _ = LLM_CAMPAIGN_FEATURE_NAMES
     sys.exit(main())

--- a/data_platform/curate/consolidate_twitter_llm_campaign.py
+++ b/data_platform/curate/consolidate_twitter_llm_campaign.py
@@ -185,6 +185,13 @@ def twitter_llm_campaign_wide_columns() -> tuple[str, ...]:
 
 
 def parse_args(argv: list[str] | None = None) -> CampaignConsolidateArgs:
+    """Parse dataset id, preprocessed run, campaign id, and output S3 URI.
+
+    Returns
+    -------
+    CampaignConsolidateArgs
+        Frozen CLI inputs, with curate YAML defaulting to Twitter MirrorView.
+    """
     parser = argparse.ArgumentParser(
         description="Join seven Twitter LLM campaign features into one wide Parquet object."
     )
@@ -280,7 +287,15 @@ def verify_feature_manifest(
     campaign_id: str,
     dataset_id: str,
 ) -> tuple[str, dict[str, Any]]:
-    """Return manifest SHA-256 and parsed JSON after checking row count 6374."""
+    """Return manifest SHA-256 and parsed JSON after checking row count 6374.
+
+    Raises
+    ------
+    FileNotFoundError
+        When the feature manifest object is missing.
+    ValueError
+        When ``final_parquet.row_count`` is not 6374.
+    """
     paths = _twitter_feature_paths(campaign_id, feature_name, dataset_id)
     stored = store.get(paths.manifest_key)
     if stored is None:
@@ -353,7 +368,14 @@ def download_campaign_inputs(
     args: CampaignConsolidateArgs,
     work_dir: Path,
 ) -> tuple[PreprocessedInputRecord, tuple[FeatureInputRecord, ...]]:
-    """Download pinned posts.csv and seven verified ``final.parquet`` files."""
+    """Download pinned posts.csv and seven verified ``final.parquet`` files.
+
+    Raises
+    ------
+    ValueError
+        When posts.csv does not match the inventory SHA-256, or a feature
+        ``final.parquet`` SHA-256 does not match its manifest.
+    """
     client = _s3_client()
     preprocessed = _download_posts_csv(client, store, args, work_dir)
     features = tuple(
@@ -434,7 +456,16 @@ def build_twitter_llm_campaign_wide_table(
     posts_file: Path,
     feature_files: dict[str, Path],
 ) -> pd.DataFrame:
-    """Inner-join pinned csv posts to seven campaign ``final.parquet`` files."""
+    """Inner-join pinned csv posts to seven campaign ``final.parquet`` files.
+
+    Rows are sorted by ``source_record_id`` ascending. Duplicate feature ids keep
+    the latest ``label_timestamp``. The left table is read with DuckDB ``read_csv``.
+
+    Raises
+    ------
+    KeyError
+        When a campaign feature path is missing from ``feature_files``.
+    """
     missing = _missing_feature_names(feature_files)
     if missing:
         raise KeyError(f"missing campaign feature parquet paths: {missing}")
@@ -709,7 +740,13 @@ def upload_wide_artifacts(
     feature_inputs: tuple[FeatureInputRecord, ...],
     curated: CuratedDatasetRecord | None,
 ) -> tuple[str, str, str]:
-    """Upload ``features.parquet`` and ``manifest.json``."""
+    """Upload untagged ``features.parquet`` and ``manifest.json``.
+
+    Returns
+    -------
+    tuple[str, str, str]
+        Wide parquet SHA-256, wide parquet URI, and wide manifest URI.
+    """
     bucket, wide_key = parse_s3_uri(args.output_s3_uri)
     if bucket != store.bucket:
         raise ValueError(f"output bucket {bucket} does not match campaign bucket {store.bucket}")

--- a/data_platform/curate/consolidate_twitter_llm_campaign.py
+++ b/data_platform/curate/consolidate_twitter_llm_campaign.py
@@ -1,0 +1,157 @@
+"""Join pinned Twitter posts with seven campaign LLM feature files into one wide Parquet object.
+
+Runtime validation (automated tests are forbidden by issue 235):
+
+given seven feature manifests whose final.parquet SHA-256 and row_count are 6374,
+     and posts.csv whose SHA-256 matches the inventory
+when the CLI joins pinned posts on source_record_id
+then stdout includes each accepted manifest digest, wide_rows=6374, wide_columns=21,
+     sort_key=source_record_id ASC, and the wide manifest URI
+
+given a missing or SHA-mismatched feature final.parquet, or a posts.csv SHA-256
+     that does not match the inventory
+when the CLI verifies inputs
+then it raises before writing wide/features.parquet
+
+given the uploaded wide parquet
+when the columns and row count are checked
+then column names match the 21-name contract, n=6374, and no llm_toxicity_tier is null
+
+given the same wide table and data_platform/curate/configs/twitter/mirrorview.yaml
+when apply_rules runs
+then curated row count and political_stance x llm_toxicity_tier counts are written
+     under the dataset curated/ stage, in a timestamped run directory,
+     as mirrorview.parquet plus metadata.json
+
+Run from the repo root:
+
+    PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \\
+        --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \\
+        --preprocessed-run 2026_09_06-19:28:47 \\
+        --campaign-id twitter_2026_09_06_192847_llm_features_v1 \\
+        --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/features.parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from data_platform.curate.consolidate import LLM_CAMPAIGN_FEATURE_NAMES
+from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from data_platform.utils.storage import TwitterStorageManager
+
+MIRRORVIEW_RULES_PATH = Path(__file__).resolve().parent / "configs" / "twitter" / "mirrorview.yaml"
+
+
+@dataclass(frozen=True)
+class CampaignConsolidateArgs:
+    """CLI inputs for the Twitter LLM campaign wide join."""
+
+
+@dataclass(frozen=True)
+class FeatureInputRecord:
+    """Verified feature final.parquet and its parameter manifest."""
+
+
+@dataclass(frozen=True)
+class PreprocessedInputRecord:
+    """Pinned preprocessed posts used as the wide-join left table."""
+
+
+@dataclass(frozen=True)
+class CuratedDatasetRecord:
+    """MirrorView-filtered rows plus stance by toxicity counts."""
+
+
+@dataclass(frozen=True)
+class WideConsolidateResult:
+    """Uploaded wide Parquet, manifest, and curated export."""
+
+
+def parse_args(argv: list[str] | None = None) -> CampaignConsolidateArgs:
+    parser = argparse.ArgumentParser(
+        description="Join seven Twitter LLM campaign features into one wide Parquet object."
+    )
+    parser.add_argument("--dataset-id", required=True)
+    parser.add_argument("--preprocessed-run", required=True)
+    parser.add_argument("--campaign-id", required=True)
+    parser.add_argument("--output-s3-uri", required=True)
+    parser.add_argument(
+        "--curate-config",
+        default=str(MIRRORVIEW_RULES_PATH),
+        help="YAML rules applied to the wide table after the join.",
+    )
+    parser.parse_args(argv)
+    raise NotImplementedError
+
+
+def verify_feature_manifest(
+    store: CampaignObjectStore,
+    feature_name: str,
+    campaign_id: str,
+    dataset_id: str,
+) -> tuple[str, dict[str, Any]]:
+    raise NotImplementedError
+
+
+def download_campaign_inputs(
+    store: CampaignObjectStore,
+    args: CampaignConsolidateArgs,
+    work_dir: Path,
+) -> tuple[PreprocessedInputRecord, tuple[FeatureInputRecord, ...]]:
+    raise NotImplementedError
+
+
+def build_twitter_llm_campaign_wide_table(
+    posts_file: Path,
+    feature_files: dict[str, Path],
+) -> Any:
+    raise NotImplementedError
+
+
+def validate_wide_table(wide: Any) -> None:
+    raise NotImplementedError
+
+
+def curate_mirrorview_dataset(
+    store: CampaignObjectStore,
+    wide: Any,
+    args: CampaignConsolidateArgs,
+    curated_storage: TwitterStorageManager,
+) -> CuratedDatasetRecord:
+    raise NotImplementedError
+
+
+def upload_wide_artifacts(
+    store: CampaignObjectStore,
+    wide: Any,
+    args: CampaignConsolidateArgs,
+    preprocessed: PreprocessedInputRecord,
+    feature_inputs: tuple[FeatureInputRecord, ...],
+    curated: CuratedDatasetRecord | None,
+) -> tuple[str, str, str]:
+    raise NotImplementedError
+
+
+def run_campaign_consolidation(args: CampaignConsolidateArgs) -> WideConsolidateResult:
+    raise NotImplementedError
+
+
+def print_result(result: WideConsolidateResult) -> None:
+    raise NotImplementedError
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = run_campaign_consolidation(args)
+    print_result(result)
+    return 0
+
+
+if __name__ == "__main__":
+    _ = LLM_CAMPAIGN_FEATURE_NAMES
+    sys.exit(main())

--- a/docs/plans/2026-09-07_consolidate_twitter_llm_wide_export_8b2f86/plan.md
+++ b/docs/plans/2026-09-07_consolidate_twitter_llm_wide_export_8b2f86/plan.md
@@ -1,0 +1,64 @@
+# Join seven Twitter LLM features and write the MirrorView export
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, frequent commits
+- Use only the approved live runtime checks. Do not add or run automated tests.
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Operators need one Twitter table with 21 columns and a MirrorView curated export. The pull request adds one consolidator script that joins seven verified feature files to the pinned preprocessed csv, uploads the wide table, applies the existing Twitter MirrorView filters, and records the curated row count plus the stance by toxicity table.
+
+## Happy flow
+
+An operator runs the consolidator with the pinned dataset id, preprocessed run, and campaign id. The script checks hashes, writes the wide table, writes a timestamped MirrorView export, and prints the curated counts.
+
+```mermaid
+flowchart TD
+    A[Download pinned posts csv] --> B[Check csv SHA-256 against inventory]
+    B --> C[Check seven feature manifests]
+    C --> D[Inner join on source_record_id]
+    D --> E[Upload wide parquet and manifest]
+    E --> F[Apply Twitter MirrorView filters]
+    F --> G[Write curated parquet and metadata]
+    G --> H[Write wide run report with crosstab]
+```
+
+## Approach
+
+Keep Twitter csv loading and Twitter column order inside the new consolidator. Do not call the Bluesky wide-table builder, because that reader expects parquet posts and the Bluesky 200000-row contract. Leave Bluesky constants unchanged. Leave Twitter MirrorView filter semantics unchanged. Do not add pytest.
+
+## Decisions
+
+- Pinned identities live in `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/campaign_contract.md`.
+- Path helper calls use platform `twitter` and the pinned dataset id. Do not call the missing Bluesky path helper on `FeaturePaths`.
+- The left table is S3 csv `posts.csv`. Verify SHA-256 against `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/s3_preprocessed_inventory.json`.
+- Join on `CAST(source_record_id AS VARCHAR)`. Sort `source_record_id ASC`. Expected wide rows are 6374.
+- Wide columns are the 21 names in the campaign contract, in that order. Forbidden extra columns include `author_id`, `toxicity_prob`, `toxicity_tier`, any `is_toxic_tiered` field, `label_timestamp`, and `run_id`.
+- Feature label aliases stay as in the contract: `is_news_or_opinion.category` becomes `news_or_opinion_category`, and `llm_toxicity_tiered.toxicity_tier` becomes `llm_toxicity_tier`.
+- The Twitter dataset file still says format csv, so the Twitter storage manager would write `mirrorview.csv`. Issue 235 requires `mirrorview.parquet`. Use `TwitterStorageManager("curated", dataset_id)` to create the run directory and write `metadata.json`. Upload parquet bytes to `curated/<timestamp>/mirrorview.parquet`. Do not change `dataset.json`.
+- Curated files live under the dataset `curated/` stage, not under `wide/curated/`. Do not use the Bluesky storage manager.
+- The report must include curated row count and a `political_stance` by `llm_toxicity_tier` table for rows that survive the filters. Stance rows are `left` and `right`. Toxicity columns are `low`, `medium`, and `high`.
+- Do not edit `consolidate.py`. Copy the DuckDB feature-join pattern into the new module with Twitter columns and `read_csv` for posts.
+- Implement-from-spec Phase 4 is the live runtime checks in the step files. Do not add files under `tests/`.
+
+## Steps
+
+### Step 1: Add the Twitter consolidator
+
+Add `/workspace/data_platform/curate/consolidate_twitter_llm_campaign.py` with csv left-table load, manifest checks, 21-column join, wide upload, and MirrorView curation. See [steps/step1.md](steps/step1.md).
+
+### Step 2: Run the live checks and write the report
+
+Run the consolidator and the parquet column check. Write `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md` with curated row count and the stance by toxicity table. See [steps/step2.md](steps/step2.md).
+
+## What "done" looks like
+
+1. Wide `features.parquet` has 6374 rows and 21 columns in contract order, with no nulls in the seven label columns.
+2. Wide `manifest.json` links all seven feature manifests and the preprocessed csv SHA-256.
+3. MirrorView curation writes `curated/<timestamp>/mirrorview.parquet` and `metadata.json` through the Twitter curated-stage manager.
+4. The wide run report is committed with curated row count and the stance by toxicity table for valid curated rows.
+5. Filter YAML semantics are unchanged.
+6. No pytest file was added or run. Bluesky wide-row and column constants are unchanged.

--- a/docs/plans/2026-09-07_consolidate_twitter_llm_wide_export_8b2f86/steps/step1.md
+++ b/docs/plans/2026-09-07_consolidate_twitter_llm_wide_export_8b2f86/steps/step1.md
@@ -1,0 +1,184 @@
+# Step 1: Add the Twitter consolidator
+
+## Scope
+
+- **Caller:** `data_platform/curate/consolidate_twitter_llm_campaign.py` `main`
+- **Task:** Download pinned `posts.csv`, verify its SHA-256 against the inventory, verify seven feature manifests at row_count 6374, inner-join on `source_record_id` to the 21-column contract, upload untagged `wide/features.parquet` and `wide/manifest.json`, apply `twitter/mirrorview.yaml`, and write a curated run under the dataset `curated/` stage.
+- **Out of scope:** pytest, GitHub posting, relabeling features, converting the dated dataset to parquet, editing Bluesky consolidator code, editing `twitter/mirrorview.yaml`, editing `consolidate.py`, editing `generate_features/**`.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py` | Campaign join, manifest checks, stdout, curated write, crosstab |
+| `/workspace/data_platform/curate/consolidate.py` | `LLM_CAMPAIGN_FEATURE_NAMES`, `FEATURE_WIDE_COLUMNS` aliases, DuckDB feature CTE pattern. Do not call `build_llm_campaign_wide_table`. |
+| `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml` | Filter set. Stem is `mirrorview`. |
+| `/workspace/data_platform/utils/storage.py` | `TwitterStorageManager` |
+| `/workspace/data_platform/generate_features/s3_feature_campaign.py` | `FeaturePaths.for_campaign`, `CampaignObjectStore` |
+| `/workspace/data_platform/curate/apply_rules.py` | `apply_rules`, `load_rules_config` |
+| `/workspace/data_platform/curate/runner.py` | `build_curate_metadata` |
+| `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/s3_preprocessed_inventory.json` | Expected csv SHA-256 |
+| `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/campaign_contract.md` | 21-column contract |
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/wide_run_report.md` | Report shape |
+
+## Files allowed to change
+
+- `/workspace/data_platform/curate/consolidate_twitter_llm_campaign.py` (new)
+
+## Files forbidden to change
+
+- `/workspace/data_platform/curate/consolidate.py`
+- `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py`
+- `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/tests/**`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/dataset.json`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/plan.md`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step1.md`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step2.md`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step3.md`
+- Any file outside the allowed list
+
+## Locked identities
+
+| Field | Value |
+|-------|-------|
+| Dataset id | `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` |
+| Preprocessed run | `2026_09_06-19:28:47` |
+| Campaign id | `twitter_2026_09_06_192847_llm_features_v1` |
+| Left table | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/preprocessed/2026_09_06-19:28:47/posts.csv` |
+| Inventory SHA-256 | `7233223b21210d0937372d9d906abfd914962784402d6b167805952a7415fa4a` |
+| Wide rows | `6374` |
+| Wide columns | `21` |
+| Sort | `source_record_id ASC` |
+| Platform argument | `twitter` |
+| Rules | `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml` |
+
+Wide output URI:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/features.parquet`
+
+Wide columns in this exact order:
+
+`tweet_id`, `record_id`, `url`, `username`, `author_handle`, `text`, `created_at`, `like_count`, `retweet_count`, `reply_count`, `quote_count`, `keyword`, `sync_timestamp`, `source_record_id`, `news_or_opinion_category`, `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tier`
+
+## Main caller
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/features.parquet
+```
+
+## Work
+
+Follow `/implement-from-spec`. Full auto. Do not add pytest. Phase 4 is the given/when/then live checks below, written in the module docstring.
+
+### Path helper
+
+Call `FeaturePaths.for_campaign(campaign_id, feature_name, platform="twitter", dataset_id=dataset_id)`. Do not call `FeaturePaths.canonical`.
+
+### Posts csv
+
+Download the pinned S3 object as csv. Hash full object bytes with SHA-256. Compare to the inventory object for that key. Raise before joining if the hash does not match. Do not load `posts.parquet`. Do not convert the csv to a parquet left table.
+
+### Feature manifests
+
+For each name in `LLM_CAMPAIGN_FEATURE_NAMES`, load `manifest.json`, require `final_parquet.row_count == 6374`, download `final.parquet`, and require its SHA-256 to match the manifest. Print `accepted {feature} manifest sha256={digest}` for each accepted manifest.
+
+### Join
+
+Twitter-local DuckDB: `read_csv` for posts, `read_parquet` for features. Inner join on `CAST(source_record_id AS VARCHAR)`. Select only the 21 contract columns, in contract order. Sort `source_record_id ASC`. Duplicate feature ids keep the latest `label_timestamp`. Reuse `FEATURE_WIDE_COLUMNS` aliases. Do not import or call `build_llm_campaign_wide_table`. Do not use Bluesky `PREPROCESSED_WIDE_COLUMNS` or `EXPECTED_WIDE_ROW_COUNT`.
+
+Posts.csv also has `author_id`. Do not put `author_id` on the wide table.
+
+### Validate
+
+Raise if column names or order differ, if row count is not 6374, if distinct `source_record_id` is not 6374, if sort is not ascending, if any of the seven label columns has nulls, or if a forbidden column is present.
+
+### Wide upload
+
+Upload untagged `wide/features.parquet` and `wide/manifest.json`. The manifest must include dataset id, campaign id, preprocessed run, 6374, the 21 column names, sort key, wide parquet SHA-256, preprocessed csv key and SHA-256, and all seven feature manifest URIs with final parquet SHA-256 and row count.
+
+### Curation
+
+Call `apply_rules` with `twitter/mirrorview.yaml`. Do not change filter semantics.
+
+`TwitterStorageManager("curated", dataset_id)` creates `curated/<timestamp>/` and writes `metadata.json`. The Twitter dataset format is csv, so `filename_for` would return `mirrorview.csv` and `write_dataframe` would write csv bytes. This issue requires `mirrorview.parquet`. Upload parquet bytes to `curated/<timestamp>/mirrorview.parquet` using the campaign object store. Stem `mirrorview` still comes from the YAML. Do not write under `wide/curated/`. Do not use `BlueskyStorageManager`.
+
+Add the stance by toxicity table to curated metadata. Stance rows `left` and `right`. Toxicity columns `low`, `medium`, `high`. Count rows that survive the filters.
+
+### Stdout
+
+Print each accepted manifest digest, then:
+
+- `wide_rows=6374`
+- `wide_columns=21`
+- `sort_key=source_record_id ASC`
+- `manifest=` plus the wide manifest URI
+- `curated_rows=` plus the filtered count
+- `curated=` plus the curated parquet URI
+- `curated_crosstab_political_stance_by_llm_toxicity_tier=` plus the JSON table
+
+## Implement-from-spec phases
+
+Phase 1 is this scope block.
+
+Phase 2: scaffold the module with argparse, dataclasses, and stub bodies (`raise NotImplementedError`). Imports must resolve. Commit.
+
+Phase 3: contracts only. Signatures and frozen dataclasses matching the Bluesky consolidator shape, with Twitter names (`local_csv` for posts, Twitter column tuple, expected row count 6374). Bodies stay stubs. Full auto, so do not wait. Commit.
+
+Phase 4: write the given/when/then live checks in the module docstring. Do not add `tests/`. The CLI must still raise `NotImplementedError` if run. Commit.
+
+Phase 5 units of work, in this order, one commit each:
+
+1. Download and verify posts csv plus seven feature manifests.
+2. Twitter DuckDB wide join.
+3. Validate the wide table.
+4. Curate with MirrorView rules, write parquet and metadata, build the crosstab.
+5. Upload wide artifacts, wire `run_campaign_consolidation`, `print_result`, and `main`.
+
+Phase 6: checklist. The live commands in Step 2 are the designed checks. Do not run pytest.
+
+## Given / when / then (Phase 4)
+
+given seven feature manifests whose final.parquet SHA-256 and row_count are 6374, and posts.csv whose SHA-256 matches the inventory
+when the CLI joins pinned posts on source_record_id
+then stdout includes each accepted manifest digest, wide_rows=6374, wide_columns=21, sort_key=source_record_id ASC, and the wide manifest URI
+
+given a missing or SHA-mismatched feature final.parquet, or a posts.csv SHA-256 that does not match the inventory
+when the CLI verifies inputs
+then it raises before writing wide/features.parquet
+
+given the uploaded wide parquet
+when the columns and row count are checked
+then column names match the 21-name contract, n=6374, and no llm_toxicity_tier is null
+
+given the same wide table and data_platform/curate/configs/twitter/mirrorview.yaml
+when apply_rules runs
+then curated row count and political_stance x llm_toxicity_tier counts are written under the dataset curated/ stage, in a timestamped run directory, as mirrorview.parquet plus metadata.json
+
+## Pass
+
+- The module exists and the main caller parses the four required flags.
+- Path building uses `FeaturePaths.for_campaign` with platform `twitter`.
+- Posts load from csv. Inventory SHA-256 is checked.
+- Join produces 21 columns in contract order.
+- Curation uses `TwitterStorageManager` and writes `mirrorview.parquet`.
+- No pytest files. No edits to forbidden files.
+
+## Fail
+
+- Left table loaded from parquet.
+- `build_llm_campaign_wide_table` is called.
+- `FeaturePaths.canonical` is called.
+- Bluesky `EXPECTED_WIDE_ROW_COUNT` is changed.
+- Curated files land under `wide/curated/` or through `BlueskyStorageManager`.
+- Curated export is `mirrorview.csv`.
+- A mismatched feature hash is accepted.
+- Any file under `tests/` is added or edited.

--- a/docs/plans/2026-09-07_consolidate_twitter_llm_wide_export_8b2f86/steps/step2.md
+++ b/docs/plans/2026-09-07_consolidate_twitter_llm_wide_export_8b2f86/steps/step2.md
@@ -1,0 +1,100 @@
+# Step 2: Run the live checks and write the report
+
+## Scope
+
+- **Caller:** the same consolidator `main` from Step 1, then the parquet assertion snippet below.
+- **Task:** Run the live consolidation against the pinned campaign, confirm stdout and the downloaded wide parquet, copy logs to `/opt/cursor/artifacts/`, and write the wide run report with curated row count and the stance by toxicity table.
+- **Out of scope:** pytest, editing the consolidator after a green run except for docstring fixes required by `write-docstring`, editing forbidden product files.
+
+## Files to inspect (read-only)
+
+- `/workspace/data_platform/curate/consolidate_twitter_llm_campaign.py`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/wide_run_report.md`
+
+## Files allowed to change
+
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md` (new)
+
+## Files forbidden to change
+
+- `/workspace/data_platform/curate/consolidate.py`
+- `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py`
+- `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/tests/**`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/dataset.json`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/plan.md`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step1.md`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step2.md`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/steps/step3.md`
+
+## Live commands
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/features.parquet
+```
+
+Expected stdout includes each accepted manifest digest, `wide_rows=6374`, `wide_columns=21`, `sort_key=source_record_id ASC`, the wide manifest URI, `curated_rows=`, the curated parquet URI, and the stance by toxicity JSON table.
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/features.parquet /tmp/twitter_wide.parquet
+PYTHONPATH=. uv run python - <<'PY'
+import pyarrow.parquet as pq
+t = pq.read_table("/tmp/twitter_wide.parquet")
+want = [
+    "tweet_id","record_id","url","username","author_handle","text","created_at",
+    "like_count","retweet_count","reply_count","quote_count","keyword","sync_timestamp",
+    "source_record_id","news_or_opinion_category","is_political","is_likely_spam",
+    "is_self_contained","is_structurally_complete","political_stance","llm_toxicity_tier",
+]
+assert t.column_names == want, t.column_names
+assert t.num_rows == 6374
+print("wide ok", t.num_rows, len(t.column_names))
+PY
+```
+
+Expected: `wide ok 6374 21`.
+
+Also list the curated prefix:
+
+```bash
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/curated/
+```
+
+Copy consolidator stdout, wide validation, curated S3 listing, and the crosstab to `/opt/cursor/artifacts/`.
+
+## Report
+
+Write `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md` in the same shape as the Bluesky wide report. It must include:
+
+- Pinned dataset id, preprocessed run, campaign id, 6374, 21 columns
+- Preprocessed csv SHA-256
+- Seven feature manifest and final.parquet SHA-256 values
+- Wide parquet and wide manifest URIs and SHA-256 values
+- Curated row count
+- Curated parquet and metadata URIs and SHA-256 values
+- Filter pass counts from YAML order
+- Crosstab of valid curated rows: `political_stance` rows `left` and `right` by `llm_toxicity_tier` columns `low`, `medium`, `high`, plus totals
+
+The crosstab is required. Do not omit it.
+
+## Pass
+
+- Live consolidator stdout matches the contract.
+- Downloaded wide parquet has 6374 rows and 21 named columns in order.
+- Report is committed with curated row count and the full stance by toxicity table.
+- Artifact logs exist under `/opt/cursor/artifacts/`.
+
+## Fail
+
+- Wide column order differs from the contract.
+- Report omits the crosstab or the curated row count.
+- Curated objects are missing from S3.
+- pytest is added or run.

--- a/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md
+++ b/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md
@@ -1,0 +1,112 @@
+# Wide consolidation and MirrorView curation report
+
+## Approval
+
+Phase B labeling finished on all seven features on pull request 240. This step did not call OpenAI. Inputs are the seven `final.parquet` objects for campaign `twitter_2026_09_06_192847_llm_features_v1`.
+
+## Pinned identity
+
+| Field | Value |
+|-------|-------|
+| Dataset id | `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` |
+| Preprocessed run | `2026_09_06-19:28:47` |
+| Preprocessed row count | 6374 |
+| Preprocessed file | `posts.csv` |
+| Campaign id | `twitter_2026_09_06_192847_llm_features_v1` |
+| Join key | `source_record_id` |
+| Sort | `source_record_id ASC` |
+| Wide columns | 21 |
+
+## Inputs
+
+Preprocessed posts SHA-256: `7233223b21210d0937372d9d906abfd914962784402d6b167805952a7415fa4a`
+
+The SHA-256 matches `data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/s3_preprocessed_inventory.json`.
+
+| Feature | Manifest SHA-256 | `final.parquet` SHA-256 | Rows |
+|---------|------------------|-------------------------|------|
+| `is_news_or_opinion` | `bcf3ea67da954b6053543db1371c1f4044bb8d81e46fe4cc01df1554967fb349` | `f999ad42141a10ba82194979f3cf3f5673655db7e50d4696bf8100a2fed5fbaa` | 6374 |
+| `is_political` | `69308ac0de12090e6d51dfc4ebb96e1226113f9ba801fa13213344847b1d5284` | `58b6dc78a222fe98dff13084176011b90fb4e650fd6d9a669c3d880af84c77e4` | 6374 |
+| `is_likely_spam` | `1e0d47675d2af41b4f57fb1c4d347f646ddf687c62f41eb2ca0eb28a464c77d2` | `a96dd1446e9204adcbd1716629fde077e95d3ff49e4f46182fb56368f739e689` | 6374 |
+| `is_self_contained` | `b6ce3062da1202019d0f5d0df9c0f19ba897607c163e7ebc0cd4fd2626026b4d` | `69d922ef1933ea3c236d5ea2ddced5e72cc940cfab31346afc6ccb23477f7da5` | 6374 |
+| `is_structurally_complete` | `4aec69422431046445e1f29603c5506141a523c34fad54cfa8f47f85d64d19b6` | `76a8a0c83ffff41eb5842cb3581d4014e629baa5afd4f4ae2e073fc928d1939c` | 6374 |
+| `political_stance` | `4f5dd74b01394bcfc5a7890ba9da2a5095e157cd6dbd3367734539e4229533e2` | `de7a67c77ffe98ccf439dca6f6ededb347a4658303424b9955d9a0e7d63d9c2e` | 6374 |
+| `llm_toxicity_tiered` | `bdf80f10b6e3a7c6b1ab234536f4cf74d991e1c52f846da05a3137968ffd4e94` | `2e8a8fbcb742e219929a92598e0d3b8f9be5957ac6c43c8598f2c4f2e4668ea8` | 6374 |
+
+Each feature `final.parquet` SHA-256 matched its parameter manifest before the join.
+
+## Wide outputs
+
+| Object | URI | SHA-256 |
+|--------|-----|---------|
+| Wide parquet | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/features.parquet` | `e5aa2d5313e7f69ae9f22230f0478bba54533f16cf4f19e891bc96d7b5b7751f` |
+| Wide manifest | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/manifest.json` | `92b083df880639e48ae8d66a977330b6dec08813ec1c1a1492ec6b4977659e9d` |
+
+Wide objects are untagged. The join is an inner join on `CAST(source_record_id AS VARCHAR)`. Duplicate feature rows keep the latest `label_timestamp`. The left table is csv `posts.csv`. `author_id` is absent.
+
+Column order:
+
+`tweet_id`, `record_id`, `url`, `username`, `author_handle`, `text`, `created_at`, `like_count`, `retweet_count`, `reply_count`, `quote_count`, `keyword`, `sync_timestamp`, `source_record_id`, `news_or_opinion_category`, `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tier`
+
+## Validation
+
+All checks passed on 2026-09-07 after download to `/tmp/twitter_wide.parquet`.
+
+| Check | Result |
+|-------|--------|
+| Twenty-one columns in contract order | PASS |
+| `wide_rows=6374` and 6374 distinct `source_record_id` | PASS |
+| File order matches `source_record_id ASC` | PASS |
+| Nulls on seven label columns | 0 |
+| Missing preprocessed posts after join | 0 |
+| Forbidden columns (`toxicity_prob`, `toxicity_tier`, `label_timestamp`, `run_id`, `is_toxic_tiered`, `author_id`) | absent |
+| Wide parquet SHA-256 matches manifest | PASS |
+| All seven feature manifests linked by SHA-256 | PASS |
+| Preprocessed csv SHA-256 matches inventory | PASS |
+
+## MirrorView curated dataset
+
+The export uses the dataset-stage layout: `curated/<timestamp>/mirrorview.parquet` plus `metadata.json` under `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/`. It is not stored under the campaign `wide/` prefix. `TwitterStorageManager("curated", dataset_id)` created the run directory and wrote `metadata.json`.
+
+Rules file: `data_platform/curate/configs/twitter/mirrorview.yaml` (SHA-256 `62a0ee4f4b8528b7e75382b0ddab3f21857b9f23101f5ebdc5d0926c99aa53ff`). Filters are AND, in YAML order. No extra toxicity filter.
+
+| Filter | Records before | Records passing |
+|--------|----------------|-----------------|
+| `news_or_opinion_category` eq `opinion` | 6374 | 3493 |
+| `is_political` eq true | 3493 | 2984 |
+| `is_likely_spam` eq false | 2984 | 2974 |
+| `political_stance` in `left`, `right` | 2974 | 2103 |
+| `is_self_contained` eq true | 2103 | 1484 |
+| `is_structurally_complete` eq true | 1484 | 1457 |
+
+Curated row count: 1457
+
+| Object | URI | SHA-256 |
+|--------|-----|---------|
+| Curated parquet | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/curated/2026_09_07-06:58:09/mirrorview.parquet` | `7639e54554869371fdb6397a1c2a497b32711679290322b999fb68ee173f39c9` |
+| Curated metadata | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/curated/2026_09_07-06:58:09/metadata.json` | `ce8f5f1300065c117d00c8155d4649559bf449f487f5c83ba0079cf50d234b31` |
+
+### Row count by political stance × LLM toxicity tier
+
+Valid curated rows only. Stance rows are `left` and `right`. Toxicity columns are `low`, `medium`, and `high`.
+
+| political_stance | low | medium | high | total |
+|------------------|-----|--------|------|-------|
+| left | 563 | 142 | 12 | 717 |
+| right | 392 | 279 | 69 | 740 |
+| total | 955 | 421 | 81 | 1457 |
+
+## Command
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \
+  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
+  --preprocessed-run 2026_09_06-19:28:47 \
+  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/features.parquet
+```
+
+Stdout included seven accepted manifest digests, `wide_rows=6374`, `wide_columns=21`, `sort_key=source_record_id ASC`, `curated_rows=1457`, and the stance × toxicity table above.


### PR DESCRIPTION
# Join seven Twitter LLM features and write the MirrorView export

Fixes #235

Part of #232

## Summary

Adds `consolidate_twitter_llm_campaign.py` to join seven verified `final.parquet` files to pinned preprocessed Twitter csv, upload `wide/features.parquet` with a SHA-256 manifest, and write a MirrorView curated export for dataset `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547`.

The CLI checks inventory and feature hashes, writes a 21-column table of 6374 rows, applies `twitter/mirrorview.yaml`, and prints curated row count plus the stance by toxicity table.

## Purpose

Step 2 leaves seven isolated feature prefixes. MirrorView needs one 21-column table and the existing Twitter filter YAML. The Bluesky wide-table builder reads posts as parquet and uses the Bluesky 200000-row contract, so this campaign keeps csv loading and Twitter columns in a Twitter consolidator.

Pytest, relabeling, and filter YAML edits are out of scope.

## Architecture

Components:

- `consolidate_twitter_llm_campaign.py` — downloads csv posts and seven feature files, inner-joins on `source_record_id`, validates the 21-column contract, uploads wide artifacts, and curates.
- `FeaturePaths.for_campaign` — Twitter campaign object keys (`platform=twitter`).
- `TwitterStorageManager` — curated run directory and `metadata.json`.
- S3 — untagged `wide/features.parquet`, `wide/manifest.json`, and `curated/<timestamp>/mirrorview.parquet`.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    C1[Operator] --> F1[Seven isolated final.parquet files]
  end
```

New flow:

```mermaid
flowchart TD
  subgraph after [After]
    C2[Operator] --> CLI[consolidate_twitter_llm_campaign.py]
    CLI --> CSV[Pinned posts.csv]
    CLI --> FEAT[Seven feature manifests]
    CLI --> WIDE[wide/features.parquet]
    CLI --> CUR[curated timestamped mirrorview.parquet]
  end
```

## Interfaces

### Locked identities

| Field | Value |
| --- | --- |
| Dataset id | `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` |
| Preprocessed run | `2026_09_06-19:28:47` |
| Campaign id | `twitter_2026_09_06_192847_llm_features_v1` |
| Wide rows | 6374 |
| Wide columns | 21 |
| Join key | `source_record_id` |

### Wide column order

`tweet_id`, `record_id`, `url`, `username`, `author_handle`, `text`, `created_at`, `like_count`, `retweet_count`, `reply_count`, `quote_count`, `keyword`, `sync_timestamp`, `source_record_id`, `news_or_opinion_category`, `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tier`

### Live result

- `wide_rows=6374`, `wide_columns=21`, `sort_key=source_record_id ASC`
- Curated rows: 1457 at `curated/2026_09_07-06:58:09/mirrorview.parquet`
- Stance by toxicity (valid curated rows): left 563/142/12, right 392/279/69 (low/medium/high)

## How to run

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"

PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \
  --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \
  --preprocessed-run 2026_09_06-19:28:47 \
  --campaign-id twitter_2026_09_06_192847_llm_features_v1 \
  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/features.parquet
```

Expected: `wide_rows=6374`, `wide_columns=21`, `sort_key=source_record_id ASC`, plus a timestamped `mirrorview.parquet` under the dataset `curated/` stage.

Plan: `docs/plans/2026-09-07_consolidate_twitter_llm_wide_export_8b2f86/plan.md`

Live report: `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line workflow for consolidating Twitter campaign data into a unified dataset.
  - Downloads campaign posts and feature data, removes duplicate records, and combines matching results.
  - Applies MirrorView curation rules and produces curated dataset artifacts and metadata.
  - Publishes wide and curated Parquet outputs with associated manifests.
  - Reports stance and toxicity counts alongside consolidation results.
  - Performs comprehensive input, schema, row-count, ordering, and storage validation before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->