### PR TITLE
Add plan for a new dated Twitter sync, LLM campaign, and MirrorView export

### DIFF
--- a/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/campaign_contract.md
+++ b/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/campaign_contract.md
@@ -1,0 +1,301 @@
+# New dated Twitter LLM campaign contract
+
+A wrong dataset id, bucket path, or row count forces a full rerun. Step files repeat only the values their pull request needs. This file holds the rest.
+
+## Pinned identities
+
+| Field | Value |
+|-------|-------|
+| Bucket | `mirrorview-experimental-artifacts` |
+| Region | `us-east-2` |
+| Platform | `twitter` |
+| Dataset id | `twitter_5901767a-e609-46fc-9a17-742516b548f2` |
+| Dataset name | `mirrorview_2026-09-07` |
+| Ingest config | `data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml` |
+| Copy source ingest YAML | `data_platform/ingestion/configs/twitter/mirrorview_2026-09-05.yaml` |
+| Preprocessed file | `posts.csv` |
+| Dataset format | `csv` (do not change `dataset.json`) |
+| Batch size | `2000` |
+| Engine | OpenAI Batch |
+| Model id | `gpt-5.4-nano` |
+
+Do not regenerate the dataset id. It must not equal any of:
+
+- `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547`
+- `twitter_f47ac10b-58cc-4372-a567-0e02b2c3d479`
+- `twitter_a8f3c22d-6b14-4e9a-9d2f-1c7e5a9b3d48`
+- `twitter_3b46b8f9-7e73-4e44-8f6a-3d0e67cfe921`
+- `twitter_00000000-0000-4000-8000-000000000099`
+
+## Values filled after Step 2
+
+Record these in the Step 2 pull request and copy them into the Step 3 campaign YAML. Do not invent them during Step 1.
+
+| Field | Source |
+|-------|--------|
+| Preprocessed run | `metadata.json` `preprocess_timestamp` under the new dataset, e.g. `2026_09_07-HH:MM:SS` |
+| Preprocessed row count | `metadata.json` `row_counts.output` |
+| Campaign id | `twitter_` + preprocessed run with `-` → `_` and `:` removed + `_llm_features_v1` |
+| Expected rows per feature | same as preprocessed row count |
+| Full-run cost scale | `--full-run-row-count` equal to that row count |
+| Last batch part size | `row_count % 2000` when that remainder is not 0; otherwise the last part is a full 2000-row part |
+
+Example: preprocessed run `2026_09_07-15:02:11` becomes campaign id `twitter_2026_09_07_150211_llm_features_v1`.
+
+Do not reuse campaign id `twitter_2026_09_06_192847_llm_features_v1`.
+
+## Prior campaign that must keep working
+
+| Field | Value |
+|-------|-------|
+| Dataset id | `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` |
+| Ingest config | `data_platform/ingestion/configs/twitter/mirrorview_2026-09-05.yaml` |
+| Preprocessed run | `2026_09_06-19:28:47` |
+| Row count | `6374` |
+| Campaign id | `twitter_2026_09_06_192847_llm_features_v1` |
+| Campaign YAML | `data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml` |
+
+## Ingest YAML
+
+Checked-in file after Step 1:
+
+`data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml`
+
+Byte-for-byte copy of `mirrorview_2026-09-05.yaml` except:
+
+```text
+dataset_id: twitter_5901767a-e609-46fc-9a17-742516b548f2
+name: mirrorview_2026-09-07
+description: Mirrorview topic keyword collection across Twitter (dated run 2026-09-07)
+date: "2026-09-07"
+```
+
+Keep `max_posts: 8000`, `limit_per_task: 110`, 73 keywords in the same order, `lang: en`, exclude `reply` / `retweet` / `quote`, `dedupe_policy: [prior_runs_same_dataset]`, and `record_types: [twitter.tweet]`.
+
+Do not add `output_format`, `query_batch_size`, top-level `fetch`, `current_run` in `dedupe_policy`, or a singular `keyword` key.
+
+Twitter has no `new-run` subcommand. One command starts or resumes. Resume with `--run-dir {timestamp}`. Do not pass `--run-dir` on the first start.
+
+## Campaign YAML
+
+Checked-in file after Step 3:
+
+`data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml`
+
+Required fields, with `{preprocessed_run}`, `{row_count}`, and `{campaign_id}` from Step 2:
+
+```yaml
+campaign_id: {campaign_id}
+platform: twitter
+dataset_id: twitter_5901767a-e609-46fc-9a17-742516b548f2
+preprocessed_run: "{preprocessed_run}"
+row_count: {row_count}
+batch_size: 2000
+engine_type: openai
+model_id: gpt-5.4-nano
+features:
+  - is_news_or_opinion
+  - is_political
+  - is_likely_spam
+  - is_self_contained
+  - is_structurally_complete
+  - political_stance
+  - llm_toxicity_tiered
+```
+
+Loader: scan `data_platform/generate_features/configs/twitter/*.yaml` for a mapping whose `campaign_id` equals the requested id. Return that mapping. If two files share an id, raise. If none match, raise `ValueError` naming the rejected id.
+
+Do not change `FEATURE_REGISTRY` defaults. Record `engine_type` on `manifest.json` and local `metadata.json`. Do not add an `engine_type` column to feature parquet output.
+
+Feature order above is the serial run order. Interrupt-and-resume proof runs on `is_news_or_opinion` only.
+
+## Copy to S3
+
+Upload only:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/posts.csv`
+
+Keep Git LFS for the local copy. Keep `dataset.json` in git with format `csv`. Do not upload raw `posts.csv`, `metadata.json`, or any Bluesky or Reddit path. Hash is SHA-256 of object bytes. Never use S3 ETag as a content hash. Abort if the local file still starts with Git LFS pointer text.
+
+Inventory path:
+
+`data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/s3_preprocessed_inventory.json`
+
+## S3 feature root and layout
+
+Feature root:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/{campaign_id}/`
+
+Per feature `{feature}` under that root:
+
+| Object | Path | Notes |
+|--------|------|-------|
+| Smoke input | `{feature}/smoke/input.parquet` | Ten-post sample input. Untagged. |
+| Smoke output | `{feature}/smoke/output.parquet` | Ten labeled rows with label metadata columns. Untagged. |
+| Smoke cost report | `{feature}/smoke/cost_report.json` | Token and pricing estimates. Untagged. |
+| Smoke resume evidence | `{feature}/smoke/resume_evidence.json` | Present for `is_news_or_opinion` only. Untagged. |
+| Active OpenAI state | `{feature}/active_openai_batch.json` | Mutable. Untagged. Conditional atomic replace. |
+| Batch parquet | `{feature}/batches/part-NNNNN.parquet` | Zero-based five-digit index. Immutable once written. Tagged `intermediate-artifact=true`. |
+| Final parquet | `{feature}/final.parquet` | One consolidated file per feature. Untagged. |
+| Manifest | `{feature}/manifest.json` | SHA-256 digests. Records `engine_type=openai`. Untagged. |
+| Progress | `{feature}/progress.jsonl` | One line per finished part. Untagged. |
+| Errors | `{feature}/errors.jsonl` | Same append semantics when needed. Untagged. |
+| Watcher state | `{feature}/watcher.json` | Untagged. `--once` only. Never posted to GitHub. |
+
+Wide outputs under the same feature root:
+
+| Object | Path |
+|--------|------|
+| Wide parquet | `wide/features.parquet` |
+| Wide manifest | `wide/manifest.json` |
+
+Forbidden layout elements:
+
+- No `campaigns/` prefix.
+- No `shards/` directory or `shard_*` object names.
+- No `final/` subdirectory.
+- No parquet copy of the dated preprocessed `posts.csv`.
+- No GitHub posting from repository code.
+
+## Smoke sample
+
+Shared by all seven features:
+
+1. Load the Step 2 preprocessed run.
+2. Keep rows with non-empty `text`.
+3. Sort by ascending `source_record_id`.
+4. Take the first ten rows.
+
+Smoke never writes `batches/part-00000.parquet` or any other production batch object.
+
+Temporary Git copies of smoke evidence live under `docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/smoke/{feature}/` during Step 4 Phase A and are deleted before merge. S3 smoke evidence under `{feature}/smoke/` remains.
+
+## Production batch schedule (after parent approval)
+
+Let `n` be campaign YAML `row_count`.
+
+| Part | Row composition |
+|------|-----------------|
+| `part-00000` | Ten unchanged smoke output rows (original smoke `batch_id` and `request_id` preserved) plus up to 1,990 new labeled rows |
+| later full parts | 2,000 new labeled rows each |
+| last part | `n % 2000` new labeled rows when that remainder is not 0; omit a trailing empty part |
+
+`part-00000` is 10 smoke rows plus the remaining rows of the first 2,000-row window. Do not assume last-part size 374.
+
+The existing campaign writer already folds `smoke/output.parquet` into `part-00000` through `_smoke_rows_by_id` in `generate_campaign_feature`.
+
+## Label row schema
+
+Every row in `smoke/output.parquet`, `batches/part-*.parquet`, and `final.parquet`:
+
+| Column | Meaning |
+|--------|---------|
+| `source_record_id` | Preprocessed tweet id |
+| `run_id` | `{campaign_id}:{feature}` |
+| `batch_id` | Provider batch id |
+| `request_id` | Provider request id |
+| `attempt_count` | 1–4 |
+| `label_timestamp` | UTC from `get_current_timestamp` |
+| `{label_field}` | Feature-specific column below |
+
+| Feature | Raw label column | Accepted values |
+|---------|------------------|-----------------|
+| `is_news_or_opinion` | `category` | `news`, `opinion`, `neither` |
+| `is_political` | `is_political` | boolean |
+| `is_likely_spam` | `is_likely_spam` | boolean |
+| `is_self_contained` | `is_self_contained` | boolean |
+| `is_structurally_complete` | `is_structurally_complete` | boolean |
+| `political_stance` | `political_stance` | `left`, `right`, `neutral`, `unclear` |
+| `llm_toxicity_tiered` | `toxicity_tier` | `low`, `medium`, `high` |
+
+## Wide table
+
+Wide output: exactly 21 columns in this order.
+
+Fourteen preprocessed columns:
+
+`tweet_id`, `record_id`, `url`, `username`, `author_handle`, `text`, `created_at`, `like_count`, `retweet_count`, `reply_count`, `quote_count`, `keyword`, `sync_timestamp`, `source_record_id`
+
+`username` is the public handle. `author_handle` on this corpus is a copy of `author_id` from Twitter preprocess.
+
+Seven aliased label columns:
+
+| Wide column | Source feature | Source column |
+|-------------|----------------|---------------|
+| `news_or_opinion_category` | `is_news_or_opinion` | `category` |
+| `is_political` | `is_political` | `is_political` |
+| `is_likely_spam` | `is_likely_spam` | `is_likely_spam` |
+| `is_self_contained` | `is_self_contained` | `is_self_contained` |
+| `is_structurally_complete` | `is_structurally_complete` | `is_structurally_complete` |
+| `political_stance` | `political_stance` | `political_stance` |
+| `llm_toxicity_tier` | `llm_toxicity_tiered` | `toxicity_tier` |
+
+Join on `CAST(source_record_id AS VARCHAR)`. Sort by `source_record_id` ascending. Left table is the new dataset's S3 `posts.csv`. Do not require a parquet copy of that file.
+
+Row count equals campaign YAML `row_count`, not 6374.
+
+Forbidden wide columns: `toxicity_tier`, `toxicity_prob`, `label_timestamp`, `run_id`, any Perspective column, `author_id` as an extra duplicate of `author_handle`.
+
+Do not change `FEATURE_REGISTRY`, Bluesky `EXPECTED_WIDE_ROW_COUNT = 200000` in `data_platform/curate/consolidate.py`, or Bluesky `PREPROCESSED_WIDE_COLUMNS`.
+
+## Curation
+
+Rules file: `data_platform/curate/configs/twitter/mirrorview.yaml`. Do not change filter semantics.
+
+| Filter | Value |
+|--------|-------|
+| `news_or_opinion_category` | `opinion` |
+| `is_political` | `true` |
+| `is_likely_spam` | `false` |
+| `political_stance` | `left` or `right` |
+| `is_self_contained` | `true` |
+| `is_structurally_complete` | `true` |
+
+Write the filtered frame with `TwitterStorageManager("curated", dataset_id)`. Export stem comes from the YAML (`mirrorview.parquet`).
+
+Resolve feature prefixes with `FeaturePaths.for_campaign(..., platform="twitter", dataset_id=...)`. Left table is csv, not parquet. Parquet bytes for campaign objects may need `CampaignObjectStore` because dataset format is csv.
+
+## Pricing (smoke cost math)
+
+| Engine | Input USD per 1M tokens | Output USD per 1M tokens |
+|--------|-------------------------|--------------------------|
+| OpenAI Batch | `0.10` | `0.625` |
+
+Scale ten-post averages to `--full-run-row-count` equal to the new preprocessed row count. Do not use `6374` or Bluesky `FULL_RUN_POST_COUNT = 200000` for this campaign.
+
+## Watcher
+
+CLI never posts to GitHub. `--once` is the only mode. Pass `--platform twitter` and `--dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2`. `github_write_skipped=true`. The 10,000-row milestone does not fire for a corpus this size. Still write `progress.jsonl` after each part.
+
+## Git tracking
+
+Keep the 2026-09-05 git ignore and Git LFS exceptions. Add the same shape for the new dataset:
+
+```text
+!data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/
+!data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/**
+!data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/**/*.csv
+```
+
+`.gitattributes`:
+
+```text
+data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/**/*.csv filter=lfs diff=lfs merge=lfs -text
+```
+
+## GitHub stack and issue dependencies
+
+Five children, one GitHub stack, parent tracking only.
+
+| Child | Depends on | GitHub `blocked-by` | Notes |
+|-------|------------|---------------------|-------|
+| Step 1 | none | none | Dated YAML, live sync, raw Git LFS commit. |
+| Step 2 | Step 1 | Step 1 | Preprocess and preprocessed Git LFS commit. |
+| Step 3 | Step 2 | Step 2 | Campaign YAML, directory loader, S3 csv copy. |
+| Step 4 | Step 3 | Step 3 | Docs and run artifacts only. Phase A then parent sign-off then Phase B on the same stack pull request. |
+| Step 5 | Step 4 | Step 4 | Wide join and curation. Expected row count from campaign YAML. |
+
+Parent-issue owner sign-off is not a GitHub `blocked-by`. Merged Step 3 is not permission to label the full preprocessed set.
+
+Reuse: `data_platform/ingestion/sync_twitter.py`, `data_platform/preprocessing/preprocess_twitter.py` (no Twitter preprocess YAML), `data_platform/generate_features/smoke_twitter_campaign.py`, `data_platform/generate_features/generate_twitter_features.py` campaign mode, `data_platform/curate/consolidate_twitter_llm_campaign.py`, watcher `--once`, `campaign_cost_report.py --full-run-row-count`.

--- a/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/plan.md
+++ b/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/plan.md
@@ -1,0 +1,85 @@
+# Sync, preprocess, generate, and curate a new dated Twitter LLM campaign
+
+Do not start the full OpenAI Batch labeling run until the repository owner signs off on the seven ten-post smoke costs in the parent GitHub issue. Merged campaign tooling is not permission.
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Collect a new dated Twitter Mirrorview corpus on 2026-09-07, preprocess it, label every surviving post with the same seven OpenAI Batch LLM features as the 2026-09-05 campaign, and write the MirrorView curated export. This is a new dataset and a new campaign. It is not a second run under the 2026-09-05 dataset, and it is not a relabel of those posts.
+
+Reuse the existing Twitter sync, preprocess, campaign smoke, campaign generate, cost aggregate, watcher, and consolidator entry points. Unlock the campaign loader so it reads whichever Twitter campaign YAML matches the campaign id. Keep the 2026-09-05 campaign working.
+
+## Happy flow
+
+An operator adds the dated ingest config, runs recent search, and commits the raw Git LFS csv. The next pull request preprocesses that run and commits the filtered csv. The third pull request adds the new campaign YAML, unlocks the loader, and copies only preprocessed `posts.csv` to S3. The fourth pull request runs seven ten-post smokes, posts cost on the parent issue, waits for owner sign-off, then labels the full preprocessed set. The fifth pull request joins the seven features and writes the MirrorView export.
+
+```mermaid
+flowchart TD
+  A[Step1 Dated ingest YAML live recent-search sync Git LFS raw csv]
+  B[Step2 Preprocess and commit Git LFS posts.csv]
+  C[Step3 Campaign YAML directory loader S3 csv copy]
+  D[Step4 Phase A seven ten-post smokes]
+  E[Parent issue owner sign off]
+  F[Step4 Phase B seven serial production runs]
+  G[Step5 Wide join and MirrorView export]
+  A --> B --> C --> D --> E --> F --> G
+```
+
+## Approach
+
+Give the new collection its own dataset id and dated ingest YAML. Copy ingest parameters from the 2026-09-05 Mirrorview config. A 7-day recent-search shortfall below 8,000 posts is documented success. Git LFS stores the new dataset's csv files. S3 receives only the preprocessed `posts.csv`.
+
+Campaign id is derived from the new preprocessed run timestamp after Step 2 exists. All seven features use OpenAI Batch `gpt-5.4-nano` and batch size 2,000. Interrupt-and-resume proof plus `resume_evidence.json` run only on `is_news_or_opinion`. Dataset format stays csv. Do not change MirrorView filter semantics. Do not add Perspective or Bedrock. The watcher never posts to GitHub.
+
+The owner records production approval on the parent GitHub issue only. There is no `APPROVED.txt`.
+
+See `campaign_contract.md` for identities, S3 layout, YAML shape, schemas, and the dependency graph.
+
+## Decisions
+
+- Identities, S3 layout, YAML shape, schemas, and the dependency graph live in `campaign_contract.md`.
+- Collection is a new `twitter_<uuid>` dataset with ingest YAML dated 2026-09-07. Do not append a run under the 2026-09-05 dataset.
+- Cost gate matches the prior Twitter LLM epic: seven ten-post smokes, per-feature and aggregate cost on the new parent, explicit owner comment, then full OpenAI Batch.
+- Live sync runs in Step 1 in this Cloud Agent environment. `X_BEARER_TOKEN` is expected. Ceiling is about $40 at $0.005 Posts Read.
+- Five children, one GitHub stack, serial `blocked-by`: 2 depends on 1, 3 on 2, 4 on 3, 5 on 4.
+- Campaign loader scans `data_platform/generate_features/configs/twitter/` for a YAML whose `campaign_id` matches. The 2026-09-05 YAML stays loadable. Unknown ids raise `ValueError` naming the bad id.
+- Consolidator expected row count comes from the campaign YAML, not the 6,374 constant from the prior campaign.
+- Migrate and verify take `--dataset-id` and `--preprocessed-run`. They must not pin the 2026-09-05 csv.
+- Step 1 may run the existing ingest YAML key tests. Steps 2 through 5 use live smoke and runtime checks only. Do not add automated tests in those steps.
+- Do not edit files under `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/`.
+
+## Steps
+
+### Step 1: Add dated Twitter ingest config and run recent-search sync for 2026-09-07
+
+Copy the 2026-09-05 ingest YAML to a 2026-09-07 file with the locked new dataset id. Add git ignore exceptions and a Git LFS csv rule. Record X usage, run recent search, and commit the raw run. See [steps/step1.md](steps/step1.md).
+
+### Step 2: Preprocess the new dated Twitter collection and store it in Git LFS
+
+Run the existing Twitter preprocess entry point on the new dataset. Commit preprocessed `posts.csv` through Git LFS and `metadata.json` as an ordinary git file. See [steps/step2.md](steps/step2.md).
+
+### Step 3: Add campaign YAML for the new collection, unlock the campaign loader, copy posts.csv to S3
+
+Add the new campaign YAML, change the loader to directory lookup, add migrate and verify CLI flags, and upload only the new preprocessed `posts.csv`. See [steps/step3.md](steps/step3.md).
+
+### Step 4: Smoke and generate seven LLM features for the new Twitter posts
+
+Run the seven ten-post smokes, post costs on the parent, wait for owner sign-off, then label the full preprocessed set on the same pull request. Docs and run artifacts only. See [steps/step4.md](steps/step4.md).
+
+### Step 5: Join seven Twitter LLM features and write the MirrorView curated export
+
+Read expected row count from the new campaign YAML, join the seven verified feature outputs to fourteen preprocessed columns, publish the wide artifact, and run the existing Twitter MirrorView rules. See [steps/step5.md](steps/step5.md).
+
+## What "done" looks like
+
+1. A new dated ingest YAML and a new Twitter dataset exist. Raw `posts.csv` is on the branch as Git LFS. `username` is empty on every raw row. A 7-day shortfall below 8,000 is documented if it happens.
+2. Preprocessed `posts.csv` for that dataset is on the branch as Git LFS, and `dataset.json` still says format `csv`.
+3. The new campaign YAML loads by campaign id. The 2026-09-05 campaign still loads. The new preprocessed csv is on S3 with a verified SHA-256. Git LFS still holds the local copy.
+4. Seven features each produce exactly the new preprocessed row count of unique, valid LLM labels, with smoke rows folded into `part-00000`, interrupt-and-resume proof only on `is_news_or_opinion`, and a permanent run report per feature.
+5. One wide parquet artifact contains the fourteen post columns and all seven LLM feature outputs. The MirrorView curation export is written from `data_platform/curate/configs/twitter/mirrorview.yaml`. The pull request records curated row count and the `political_stance` × `llm_toxicity_tier` crosstab.
+6. Intermediate batches expire after 30 days under the existing lifecycle rule. Final artifacts and run metadata remain in S3.

--- a/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step1.md
+++ b/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step1.md
@@ -1,0 +1,260 @@
+# Step 1: Add dated Twitter ingest config and run recent-search sync for 2026-09-07
+
+## Goal
+
+Add `data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml` as a copy of the 2026-09-05 Mirrorview ingest config, un-ignore the locked new dataset, mark its csv as Git LFS, run live recent search, and commit the raw run.
+
+## Dependencies
+
+None. Later steps use dataset id `twitter_5901767a-e609-46fc-9a17-742516b548f2`.
+
+Requires `X_BEARER_TOKEN` in the process environment. A repo-root `.env` file is not required when the variable is already set.
+
+## Caller / unit of work
+
+The main caller is `data_platform/ingestion/sync_twitter.py` `main`. It loads `--config` through `run_sync_cli` in `data_platform/ingestion/sync_checkpoint.py` and passes the path to `sync_records`.
+
+`sync_records` writes `dataset.json` and starts or resumes a raw run under `data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/{timestamp}/`. It prints `sync_records: wrote {n} rows to {output_dir} (status={sync_status})`.
+
+This pull request writes the dated config, git ignore exceptions, Git LFS csv rule, runbook exception, then runs that CLI and commits the raw files. Twitter has no `new-run` subcommand. One command starts or resumes.
+
+**Out of scope:** preprocess, features, curate, S3 upload, changing ingest Python, editing `mirrorview_2026-09-05.yaml` or `mirrorview.yaml`, un-ignoring other Twitter datasets, adding files under `docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/`, generating a new dataset id.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/plan.md` | Parent plan. |
+| `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/campaign_contract.md` | Locked dataset id and ingest fields. |
+| `/workspace/data_platform/ingestion/configs/twitter/mirrorview_2026-09-05.yaml` | Copy source. 73 keywords. `max_posts: 8000`. `limit_per_task: 110`. Dataset id `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547`. Do not edit. |
+| `/workspace/data_platform/ingestion/configs/twitter/mirrorview.yaml` | Undated config. Do not copy from this file. Do not edit. |
+| `/workspace/data_platform/ingestion/sync_twitter.py` | Print line and `--run-dir` resume. Do not edit. |
+| `/workspace/data_platform/ingestion/twitter_client.py` | No user expansions. `username` is empty. Do not edit. |
+| `/workspace/data_platform/utils/dataset.py` | `validate_dataset_id` requires `twitter_` plus a lowercase UUID with hyphens. |
+| `/workspace/tests/data_platform/ingestion/test_ingest_yaml_keys.py` | Globs every ingest YAML. The new file must pass. |
+| `/workspace/.gitignore` | Copy the 2026-09-05 Twitter exception shape. Keep those exceptions. |
+| `/workspace/.gitattributes` | Copy the 2026-09-05 csv LFS rule. Keep that rule. |
+| `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md` | Already allows `mirrorview_2026-09-05.yaml`. Add the 2026-09-07 dataset the same way. |
+
+## Files allowed to change
+
+- `/workspace/data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml`
+- `/workspace/.gitignore`
+- `/workspace/.gitattributes`
+- `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md`
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/dataset.json`
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/{timestamp}/posts.csv`
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/{timestamp}/metadata.json`
+- `/workspace/CHANGELOG.md`
+
+`{timestamp}` is the UTC run folder from `lib/timestamp_utils.get_current_timestamp`.
+
+Plan package files under `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/` may already be on a planning branch. Do not rewrite them during implementation.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/ingestion/configs/twitter/mirrorview_2026-09-05.yaml`
+- `/workspace/data_platform/ingestion/configs/twitter/mirrorview.yaml`
+- `/workspace/data_platform/ingestion/sync_twitter.py`
+- `/workspace/data_platform/ingestion/twitter_client.py`
+- `/workspace/data_platform/ingestion/sync_checkpoint.py`
+- `/workspace/data_platform/ingestion/sync_clients.py`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/**`
+- `/workspace/data_platform/preprocessing/**`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/**`
+- Any file outside the allowed list, except git commits of this work
+
+## Locked contracts
+
+Use dataset id `twitter_5901767a-e609-46fc-9a17-742516b548f2`. Do not call `uuid.uuid4()`.
+
+`/workspace/data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml` must be a copy of `mirrorview_2026-09-05.yaml` except these fields:
+
+```text
+dataset_id: twitter_5901767a-e609-46fc-9a17-742516b548f2
+name: mirrorview_2026-09-07
+description: Mirrorview topic keyword collection across Twitter (dated run 2026-09-07)
+date: "2026-09-07"
+```
+
+Keep `max_posts: 8000`, `limit_per_task: 110`, the same 73 keywords in the same order, `dedupe_policy: [prior_runs_same_dataset]`, `lang: en`, `exclude: [reply, retweet, quote]`, and `record_types: [twitter.tweet]`.
+
+Do not add unread keys that `tests/data_platform/ingestion/test_ingest_yaml_keys.py` forbids.
+
+Append these git ignore exceptions next to the 2026-09-05 Twitter exceptions. Do not remove the existing Bluesky, Reddit, or 2026-09-05 Twitter exceptions.
+
+```text
+!data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/
+!data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/**
+!data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/**/*.csv
+```
+
+Append this Git LFS rule. Do not change existing LFS lines.
+
+```text
+data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/**/*.csv filter=lfs diff=lfs merge=lfs -text
+```
+
+In `/workspace/docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md`, keep the rule that live API sync files are not committed by default. Extend the existing 2026-09-05 Twitter exception sentence so `mirrorview_2026-09-07.yaml` is also allowed and its `posts.csv` files are stored with Git LFS.
+
+Empty `username` is required. Cost ceiling is about $40 at $0.005 Posts Read for 8,000 posts. A documented 7-day recent-search shortfall below 8,000 is success.
+
+## Exact commands and expected output
+
+Confirm Git LFS matching before the sync writes files:
+
+```bash
+git check-attr filter -- data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/placeholder/posts.csv
+```
+
+Expected: `filter: lfs`.
+
+Record usage before the sync:
+
+```bash
+python - <<'PY'
+import json, os, urllib.request
+token = os.environ["X_BEARER_TOKEN"]
+req = urllib.request.Request(
+    "https://api.x.com/2/usage/tweets",
+    headers={"Authorization": f"Bearer {token}"},
+)
+with urllib.request.urlopen(req, timeout=30) as resp:
+    data = json.load(resp)["data"]
+print("http_status=200")
+print(f"project_id={data['project_id']}")
+print(f"project_cap={data['project_cap']}")
+print(f"project_usage={data['project_usage']}")
+print(f"cap_reset_day={data['cap_reset_day']}")
+PY
+```
+
+Expected: `http_status=200`, `project_id=2061451038012448768`, and a `project_usage` integer. Save that integer as the before value.
+
+Run the sync from the repo root. Do not pass `--run-dir` on the first start.
+
+```bash
+PYTHONPATH=. uv run python data_platform/ingestion/sync_twitter.py \
+  --config data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml
+```
+
+Stdout includes:
+
+```text
+sync_records: wrote 8000 rows to /workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/{timestamp} (status=completed)
+```
+
+A documented 7-day window shortfall may print a `wrote` count below 8000 with `status=completed`.
+
+If the process stops before `completed`, resume the same raw folder:
+
+```bash
+PYTHONPATH=. uv run python data_platform/ingestion/sync_twitter.py \
+  --config data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml \
+  --run-dir {timestamp}
+```
+
+Do not start a second dataset id.
+
+Check the raw run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import csv, json, yaml
+cfg = yaml.safe_load(Path("data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml").read_text())
+dataset_id = cfg["dataset_id"]
+assert dataset_id == "twitter_5901767a-e609-46fc-9a17-742516b548f2"
+raw_root = Path("data_platform/data/twitter") / dataset_id / "raw"
+run_dir = sorted(p for p in raw_root.iterdir() if p.is_dir())[-1]
+meta = json.loads((run_dir / "metadata.json").read_text())
+assert meta["sync_status"] == "completed", meta["sync_status"]
+row_count = int(meta["row_count"])
+assert row_count > 0
+with (run_dir / "posts.csv").open(newline="", encoding="utf-8") as handle:
+    rows = list(csv.DictReader(handle))
+assert len(rows) == row_count, (len(rows), row_count)
+nonempty = [row["tweet_id"] for row in rows if row.get("username")]
+assert nonempty == [], nonempty[:5]
+print(f"run_dir={run_dir}")
+print(f"row_count={row_count}")
+print("username_empty=yes")
+print("shortfall=yes" if row_count < 8000 else "shortfall=no")
+PY
+```
+
+Expected: `sync_status` completed, `username_empty=yes`, and either `row_count=8000` with `shortfall=no` or a lower count with `shortfall=yes`.
+
+Record usage after the sync with the same snippet. Subtract the before value. The increase should equal the row count, plus or minus a small number of extra Posts Read from pagination. Fail if the increase is about three times the row count (Posts Read plus User Read).
+
+Config identity checks:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import yaml
+src = yaml.safe_load(Path("data_platform/ingestion/configs/twitter/mirrorview_2026-09-05.yaml").read_text())
+new = yaml.safe_load(Path("data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml").read_text())
+assert new["name"] == "mirrorview_2026-09-07"
+assert new["date"] == "2026-09-07"
+assert new["dataset_id"] == "twitter_5901767a-e609-46fc-9a17-742516b548f2"
+assert new["ingestion_params"]["max_posts"] == 8000
+assert new["ingestion_params"]["limit_per_task"] == 110
+assert new["ingestion_params"]["keywords"] == src["ingestion_params"]["keywords"]
+assert new["ingestion_params"]["dedupe_policy"] == src["ingestion_params"]["dedupe_policy"]
+assert new["ingestion_params"]["lang"] == src["ingestion_params"]["lang"]
+assert new["ingestion_params"]["exclude"] == src["ingestion_params"]["exclude"]
+assert new["record_types"] == src["record_types"]
+print("step1 config checks passed")
+PY
+```
+
+Expected: `step1 config checks passed`.
+
+```bash
+PYTHONPATH=. uv run pytest tests/data_platform/ingestion/test_ingest_yaml_keys.py -q
+```
+
+Expected: exit 0. Do not add the new filename to any hardcoded allow-list. The glob already covers it. Do not add a live X test.
+
+```bash
+git add \
+  data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml \
+  .gitignore \
+  .gitattributes \
+  docs/runbooks/DATA_INGESTION_PIPELINE_ARCHITECTURE.md \
+  data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/dataset.json \
+  data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/{timestamp}/metadata.json \
+  data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/{timestamp}/posts.csv
+git status --short
+git lfs ls-files | grep twitter_5901767a-e609-46fc-9a17-742516b548f2
+git check-attr filter -- data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/{timestamp}/posts.csv
+```
+
+Expected: `git check-attr` prints `filter: lfs`. `git lfs ls-files` lists the new `posts.csv`. `dataset.json` and `metadata.json` are ordinary git files.
+
+The implementation pull request body must include: dataset id, raw run path, row_count, `username_empty=yes`, project_usage before, project_usage after, usage increase, shortfall yes or no and the reason if yes.
+
+## Pass / fail
+
+The step passes when the dated config exists with the locked id, keywords match the 2026-09-05 file, `test_ingest_yaml_keys.py` exits 0, the raw run is `completed`, every `username` is empty, usage increased by about the row count, `posts.csv` is Git LFS, and a shortfall below 8,000 is documented if it happens.
+
+The step fails when any item below is true.
+
+- the dataset id was regenerated or reused
+- `mirrorview_2026-09-05.yaml` or ingest Python changed
+- keywords, `max_posts`, or `limit_per_task` changed
+- other Twitter datasets were un-ignored
+- `posts.csv` is not Git LFS
+- `username` is non-empty
+- usage increased by about three times the row count
+- `sync_status` is not `completed`
+- preprocess, features, or S3 upload ran
+
+## PR artifact and commit rules
+
+- One independently mergeable PR for this step only.
+- Logical commits: dated YAML plus git tracking, live sync raw files, changelog if used.
+- PR title suggestion: `Add dated Twitter ingest config and run recent-search sync for 2026-09-07`.

--- a/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step2.md
+++ b/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step2.md
@@ -1,0 +1,167 @@
+# Step 2: Preprocess the new dated Twitter collection and store it in Git LFS
+
+## Goal
+
+Run the existing Twitter preprocess entry point on dataset `twitter_5901767a-e609-46fc-9a17-742516b548f2`, then commit preprocessed `posts.csv` through Git LFS and `metadata.json` as an ordinary git file.
+
+## Dependencies
+
+- **Step 1 merged** on the GitHub stack: dated ingest YAML, git ignore exceptions, Git LFS csv rule, completed raw run under the locked dataset id.
+
+## Caller / unit of work
+
+The main caller is `data_platform/preprocessing/preprocess_twitter.py` `main`, which calls `preprocess_records`. There is no Twitter preprocess YAML.
+
+Stdout includes:
+
+```text
+preprocess_records: kept {kept} of {input_count} (skipped {skipped} already in a prior preprocessed run, skipped {skipped_stimuli} already used as stimuli) -> {output_dir}
+```
+
+`{output_dir}` is `data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/`.
+
+This pull request runs that CLI once and commits the preprocessed files. Record `{preprocessed_run}` and `{row_count}` in the pull request body. Step 3 copies those values into the campaign YAML.
+
+**Out of scope:** changing preprocess Python, ingest, features, curate, S3 upload, converting csv to parquet, changing `dataset.json` format, labeling posts.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/campaign_contract.md` | How to derive campaign id after this step. |
+| `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step1.md` | Raw run that must already exist. |
+| `/workspace/data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml` | Confirms dataset id. |
+| `/workspace/data_platform/preprocessing/preprocess_twitter.py` | `--dataset-id` only. Do not edit. |
+| `/workspace/data_platform/preprocessing/runner.py` | Print line and `metadata.json` shape. |
+| `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/dataset.json` | Format must stay `csv`. |
+| `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/{timestamp}/` | Step 1 raw run. |
+| `/workspace/.gitignore` | Step 1 already un-ignores this dataset including csv. |
+| `/workspace/.gitattributes` | Step 1 already marks this dataset csv as Git LFS. |
+
+## Files allowed to change
+
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/dataset.json` only if preprocess rewrites it and format stays `csv`
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/posts.csv`
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/metadata.json`
+- `/workspace/CHANGELOG.md`
+
+`{preprocessed_run}` is created at runtime. Do not invent it.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/preprocessing/**`
+- `/workspace/data_platform/ingestion/**`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml`
+- `/workspace/.gitignore`
+- `/workspace/.gitattributes`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/**`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/**`
+- `/workspace/tests/**`
+- Any file outside the allowed list
+
+## Locked contracts
+
+```bash
+PYTHONPATH=. uv run python data_platform/preprocessing/preprocess_twitter.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2
+```
+
+Do not pass a preprocess YAML. Do not pass `--config`.
+
+`dataset.json` `format` stays `csv`. Preprocessed records filename is `posts.csv`.
+
+`metadata.json` must include `dataset_id`, `preprocess_timestamp`, and `row_counts.output`. `preprocess_timestamp` equals the run folder name.
+
+Campaign id for Step 3:
+
+```text
+twitter_{preprocess_timestamp with '-' -> '_' and ':' removed}_llm_features_v1
+```
+
+Row count is `row_counts.output`. It may be below the raw row count because validators, prior-preprocessed skips, and previously used stimuli drop rows. That lower count is the campaign size. Do not force 6374.
+
+Git LFS must store preprocessed `posts.csv`. `metadata.json` is an ordinary git file.
+
+## Exact commands and expected output
+
+Confirm the Step 1 raw run is present and `completed` before preprocess.
+
+Run preprocess from the repo root with `PYTHONPATH=.`.
+
+Expected stdout matches `preprocess_records: kept {kept} of {input_count} ... -> {output_dir}` and exit 0.
+
+Then:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import csv, json
+dataset_id = "twitter_5901767a-e609-46fc-9a17-742516b548f2"
+root = Path("data_platform/data/twitter") / dataset_id
+dataset = json.loads((root / "dataset.json").read_text())
+assert dataset.get("format") == "csv", dataset
+pre_root = root / "preprocessed"
+runs = sorted(p for p in pre_root.iterdir() if p.is_dir())
+assert runs, f"no preprocessed runs under {pre_root}"
+run_dir = runs[-1]
+meta = json.loads((run_dir / "metadata.json").read_text())
+assert meta["dataset_id"] == dataset_id
+assert meta["preprocess_timestamp"] == run_dir.name
+row_count = int(meta["row_counts"]["output"])
+assert row_count > 0
+posts = run_dir / "posts.csv"
+assert posts.is_file()
+with posts.open(newline="", encoding="utf-8") as handle:
+    rows = list(csv.DictReader(handle))
+assert len(rows) == row_count, (len(rows), row_count)
+assert all(row.get("text") for row in rows)
+campaign_id = (
+    "twitter_"
+    + run_dir.name.replace("-", "_").replace(":", "")
+    + "_llm_features_v1"
+)
+print(f"preprocessed_run={run_dir.name}")
+print(f"row_count={row_count}")
+print(f"campaign_id={campaign_id}")
+print("format=csv")
+PY
+```
+
+Expected: prints `preprocessed_run`, `row_count`, derived `campaign_id`, and `format=csv`.
+
+```bash
+git add \
+  data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/dataset.json \
+  data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/posts.csv \
+  data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/metadata.json
+git check-attr filter -- data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/posts.csv
+git lfs ls-files | grep twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed
+```
+
+Expected: `filter: lfs` for preprocessed `posts.csv`.
+
+The implementation pull request body must include `preprocessed_run`, `row_count`, derived `campaign_id`, and `format=csv`.
+
+Do not add pytest. Do not run the ingest YAML tests unless you touched ingest YAML (you must not).
+
+## Pass / fail
+
+The step passes when preprocess writes `posts.csv` and `metadata.json` under the new dataset, format stays `csv`, `posts.csv` is Git LFS, and the pull request records run timestamp, row count, and derived campaign id.
+
+The step fails when any item below is true.
+
+- preprocess Python changed
+- `dataset.json` format is not `csv`
+- files were written under the 2026-09-05 dataset
+- S3 upload ran
+- campaign YAML was added in this pull request
+- `posts.csv` is not Git LFS
+- a new pytest file was added
+
+## PR artifact and commit rules
+
+- One independently mergeable PR stacked on Step 1.
+- Logical commits: preprocessed csv and metadata, changelog if used.
+- PR title suggestion: `Preprocess the new dated Twitter collection and store it in Git LFS`.

--- a/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step3.md
+++ b/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step3.md
@@ -1,0 +1,211 @@
+# Step 3: Add campaign YAML for the new collection, unlock the campaign loader, copy posts.csv to S3
+
+## Goal
+
+Campaign workers need the new preprocessed csv on S3, a campaign YAML for the Step 2 identities, and a loader that finds that YAML by `campaign_id` without breaking the 2026-09-05 campaign. This pull request ships that product code. It does not label the full preprocessed set.
+
+## Dependencies
+
+- **Step 2 merged** on the GitHub stack: preprocessed run timestamp, row count, Git LFS `posts.csv`.
+
+Requires Git LFS, AWS credentials with `s3:PutObject`, `s3:GetObject`, and `s3:HeadObject` on `mirrorview-experimental-artifacts`, and `LAB_AWS_ACCESS_KEY_ID` / `LAB_AWS_ACCESS_KEY_SECRET` exported as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.
+
+## Caller / unit of work
+
+**Upload caller:** `data_platform/scripts/migrate_twitter_preprocessed_to_s3.py` `main`.
+
+**Verifier:** `data_platform/scripts/verify_twitter_preprocessed_s3.py` `main`.
+
+**Campaign caller after this PR merges** (replace `{preprocessed_run}` and `{campaign_id}` from Step 2):
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/generate_twitter_features.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run {preprocessed_run} \
+  --campaign-id {campaign_id} \
+  --features is_news_or_opinion \
+  --batch-size 2000
+```
+
+**Smoke caller after this PR merges:**
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_twitter_campaign.py \
+  --campaign-id {campaign_id} \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run {preprocessed_run} \
+  --feature is_news_or_opinion \
+  --smoke-prefix s3://mirrorview-experimental-artifacts/data_platform/data/_smoke/twitter_2026_09_07_step3_campaign_smoke/ \
+  --output-dir docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/smoke/_step3_disposable
+```
+
+**One implementation scope:** add `--dataset-id` and `--preprocessed-run` to migrate and verify so they no longer pin `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` / `2026_09_06-19:28:47`. Upload the new dataset's `posts.csv` only. Write inventory JSON under the new dataset. Add `mirrorview_2026-09-07_llm_features_v1.yaml`. Change `load_twitter_campaign_config` to scan `data_platform/generate_features/configs/twitter/*.yaml` for matching `campaign_id`. Keep the 2026-09-05 YAML loadable. Optional live proof uses only the disposable S3 prefix above.
+
+**Out of scope:** labeling the full preprocessed set, posting to GitHub, wide join, curation, lifecycle rules, converting csv to parquet, dropping Git LFS, changing `FEATURE_REGISTRY`, changing `twitter/mirrorview.yaml`, the official seven-feature smoke on the primary campaign prefix (Step 4), adding pytest.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/campaign_contract.md` | Identities and YAML shape. |
+| `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/metadata.json` | Run timestamp and row count. |
+| `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml` | Shape to copy. Do not edit. |
+| `/workspace/data_platform/generate_features/twitter_campaign_config.py` | Today accepts only `twitter_2026_09_06_192847_llm_features_v1`. |
+| `/workspace/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py` | Hardcoded old dataset id and run. |
+| `/workspace/data_platform/scripts/verify_twitter_preprocessed_s3.py` | Imports those constants. |
+| `/workspace/data_platform/generate_features/smoke_twitter_campaign.py` | Calls `load_twitter_campaign_config`. Interrupt-resume only for `is_news_or_opinion`. |
+| `/workspace/data_platform/generate_features/s3_feature_campaign.py` | `FeaturePaths.for_campaign`. |
+| `/workspace/AGENTS.md` | `PYTHONPATH=.` and AWS export. |
+
+## Files allowed to change
+
+- `/workspace/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py`
+- `/workspace/data_platform/scripts/verify_twitter_preprocessed_s3.py`
+- `/workspace/data_platform/generate_features/twitter_campaign_config.py`
+- `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml` (new)
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/s3_preprocessed_inventory.json` (new)
+- `/workspace/CHANGELOG.md`
+
+Temporary disposable smoke evidence under `docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/smoke/_step3_disposable/` may be committed during review and must be deleted before merge.
+
+Do not edit files under `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/`.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml`
+- `/workspace/data_platform/generate_features/registry.py`
+- `/workspace/data_platform/generate_features/smoke_twitter_campaign.py`
+- `/workspace/data_platform/generate_features/generate_twitter_features.py`
+- `/workspace/data_platform/generate_features/campaign_cost_report.py`
+- `/workspace/data_platform/generate_features/feature_progress_watcher.py`
+- `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml`
+- `/workspace/data_platform/curate/consolidate.py`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/**`
+- `/workspace/data_platform/data/bluesky/**`
+- `/workspace/data_platform/data/reddit/**`
+- `/workspace/.gitattributes`
+- `/workspace/.gitignore`
+- `/workspace/tests/**`
+- Any file outside the allowed list
+
+## Locked contracts
+
+Migrate and verify take required `--dataset-id` and `--preprocessed-run`. They must not default to the 2026-09-05 dataset. Inventory path is derived:
+
+`data_platform/data/twitter/{dataset_id}/s3_preprocessed_inventory.json`
+
+Scoped upload path:
+
+`data_platform/data/twitter/{dataset_id}/preprocessed/{preprocessed_run}/posts.csv`
+
+Expected object count remains 1. Hash is SHA-256 of bytes. Never use S3 ETag. If the scoped file begins with `version https://git-lfs.github.com/spec/v1`, abort after `git lfs pull`.
+
+Loader contract for `load_twitter_campaign_config(campaign_id)`:
+
+1. Iterate YAML files under `data_platform/generate_features/configs/twitter/`.
+2. Load each mapping. If `campaign_id` matches, return it.
+3. If two files match, raise `ValueError` naming the id.
+4. If none match, raise `ValueError` whose message includes `unsupported twitter campaign id: {campaign_id}`.
+
+Remove the single-file `ACCEPTED_CAMPAIGN_ID` / `CAMPAIGN_YAML_PATH` lock.
+
+After this change:
+
+- `load_twitter_campaign_config("twitter_2026_09_06_192847_llm_features_v1")` still returns the 2026-09-05 YAML (`row_count` 6374).
+- `load_twitter_campaign_config("{new_campaign_id}")` returns the 2026-09-07 YAML.
+- `load_twitter_campaign_config("bluesky_2026_09_03_235130_llm_features_v1")` still raises and names that id.
+
+New YAML fields: see `campaign_contract.md`. `row_count` and `preprocessed_run` come from Step 2, not 6374 / `2026_09_06-19:28:47`.
+
+`smoke_twitter_campaign.py` already writes `resume_evidence.json` only for `is_news_or_opinion`. Do not change that.
+
+## Ordered implementation work
+
+1. Add required `--dataset-id` and `--preprocessed-run` to migrate and verify. Derive inventory and csv paths from those flags. Upload one object. Write inventory under the new dataset.
+2. Add the 2026-09-07 campaign YAML using Step 2 identities.
+3. Change `load_twitter_campaign_config` to directory lookup.
+4. Run migrate and verify against the new dataset.
+5. Prove both campaign ids load. Prove an unknown id fails.
+6. Optional: one disposable `is_news_or_opinion` smoke under `_smoke/twitter_2026_09_07_step3_campaign_smoke/`. Delete that prefix and Git copies before merge. Do not write primary `batches/part-*.parquet`.
+
+## Exact commands and expected output
+
+From the repo root:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+aws sts get-caller-identity
+```
+
+Expected: JSON with `"Arn"` containing the lab IAM user and exit 0.
+
+```bash
+git lfs pull --include "data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/posts.csv"
+python3 -c "
+from pathlib import Path
+p = Path('data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/posts.csv')
+head = p.read_bytes()[:40]
+assert not head.startswith(b'version https://git-lfs.github.com/spec/v1'), head
+assert p.stat().st_size > 2000, p.stat().st_size
+print('csv smudged ok', p.stat().st_size)
+"
+```
+
+Expected: `csv smudged ok` plus a byte size.
+
+```bash
+PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run {preprocessed_run}
+PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run {preprocessed_run}
+```
+
+Expected: migration reports `uploaded 1 object`. Verifier prints `OK: 1/1 objects present with matching sha256`.
+
+Running migrate without flags must be non-zero. Running it against the old dataset id is allowed only as an extra check; this pull request's inventory file must be the new dataset's file.
+
+```bash
+PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; c=load_twitter_campaign_config('{campaign_id}'); print(c['row_count'], c['engine_type'], len(c['features']), c['dataset_id'])"
+```
+
+Expected: `{row_count} openai 7 twitter_5901767a-e609-46fc-9a17-742516b548f2`.
+
+```bash
+PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; c=load_twitter_campaign_config('twitter_2026_09_06_192847_llm_features_v1'); print(c['row_count'], c['dataset_id'])"
+```
+
+Expected: `6374 twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547`.
+
+```bash
+PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; load_twitter_campaign_config('bluesky_2026_09_03_235130_llm_features_v1')"
+```
+
+Expected: non-zero exit and `ValueError` naming the rejected campaign id.
+
+If the optional disposable smoke runs, expected stdout includes `s3_smoke_resume_evidence_ok` for `is_news_or_opinion`. Delete the disposable prefix before merge.
+
+Do not add pytest.
+
+## Pass / fail
+
+The step passes when the new YAML loads by campaign id, the old campaign still loads, unknown ids fail with the id in the message, migrate and verify take dataset id and run flags, one new `posts.csv` object is on S3 with matching SHA-256, and Git LFS still holds the local copy.
+
+The step fails when any item below is true.
+
+- loader still accepts only `twitter_2026_09_06_192847_llm_features_v1`
+- 2026-09-05 YAML was edited or no longer loads
+- migrate still pins the old csv when invoked for the new dataset
+- raw csv, Bluesky, or Reddit objects were uploaded
+- SHA-256 was taken from ETag
+- LFS pointer text was uploaded
+- official seven-feature production labeling started
+- pytest was added
+
+## PR artifact and commit rules
+
+- One independently mergeable PR stacked on Step 2.
+- Logical commits: loader plus migrate/verify flags, new YAML, inventory, changelog.
+- PR title suggestion: `Add campaign YAML for the new collection, unlock the campaign loader, copy posts.csv to S3`.

--- a/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step4.md
+++ b/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step4.md
@@ -1,0 +1,201 @@
+# Step 4: Smoke and generate seven LLM features for the new Twitter posts
+
+## Goal
+
+One pull request runs the seven ten-post smokes, posts cost on the parent issue, waits for owner sign-off, then labels every preprocessed row on OpenAI Batch with `gpt-5.4-nano`, one feature at a time. The pull request carries documentation and run artifacts only. It does not change product code.
+
+## Dependencies
+
+- **Step 3 merged** on the GitHub stack: csv on S3, new campaign YAML, directory loader, migrate/verify flags.
+- **Parent issue owner sign-off** after Phase A, before Phase B. Sign-off is a comment on the parent issue. It is not a GitHub `blocked-by`. Merged Step 3 is not permission to label the full preprocessed set.
+
+Pinned identities: see `campaign_contract.md`. Replace `{campaign_id}`, `{preprocessed_run}`, and `{row_count}` from Step 2 / Step 3 YAML.
+
+## Caller / unit of work
+
+Phase A (each feature, YAML order). Interrupt and resume only on `is_news_or_opinion`:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/generate_features/smoke_twitter_campaign.py \
+  --campaign-id {campaign_id} \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run {preprocessed_run} \
+  --feature is_news_or_opinion \
+  --output-dir docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/smoke/is_news_or_opinion
+```
+
+Repeat for `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tiered` without a second interrupt.
+
+Aggregate after all seven cost reports exist:
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/campaign_cost_report.py \
+  --aggregate \
+  --campaign-id {campaign_id} \
+  --smoke-reports-dir docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/smoke \
+  --output docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/smoke/parent_cost_aggregate.json \
+  --full-run-row-count {row_count}
+```
+
+Phase B (each feature, same order, after parent sign-off):
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/generate_twitter_features.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run {preprocessed_run} \
+  --campaign-id {campaign_id} \
+  --features is_news_or_opinion \
+  --batch-size 2000
+```
+
+Watcher during or after a production feature (optional, `--once` only):
+
+```bash
+PYTHONPATH=. uv run python data_platform/generate_features/feature_progress_watcher.py \
+  --once \
+  --platform twitter \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --campaign-id {campaign_id} \
+  --feature is_news_or_opinion
+```
+
+Expected: prepared markdown printed, `github_write_skipped=true`, no GitHub post.
+
+**One implementation scope:** run the callers above. Commit temporary smoke Git copies in Phase A. Post per-feature costs on this issue and the aggregate on the parent. Stop. After the owner comments on the parent, run production serially, write seven run reports, delete temporary smoke Git copies. Do not edit Python under `data_platform/` or `lib/`.
+
+**Out of scope:** product-code changes, pytest, GitHub posting from repository code, wide join, changing filter YAML, Bedrock, Perspective `is_toxic_tiered`, parallel OpenAI Batch jobs.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/campaign_contract.md` | Identities, part layout, schemas |
+| `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step3.md` | Tooling that must already be on the stack |
+| `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml` | Feature order and row count |
+| `/workspace/data_platform/generate_features/smoke_twitter_campaign.py` | Phase A caller |
+| `/workspace/data_platform/generate_features/generate_twitter_features.py` | Phase B caller |
+| `/workspace/data_platform/generate_features/generate_features.py` | `_smoke_rows_by_id` fold |
+
+## Files allowed to change
+
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/smoke/**` (temporary Phase A copies, deleted before merge)
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/is_news_or_opinion_run_report.md` (new, keep)
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/is_political_run_report.md` (new, keep)
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/is_likely_spam_run_report.md` (new, keep)
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/is_self_contained_run_report.md` (new, keep)
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/is_structurally_complete_run_report.md` (new, keep)
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/political_stance_run_report.md` (new, keep)
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/llm_toxicity_tiered_run_report.md` (new, keep)
+- `/workspace/CHANGELOG.md`
+
+Do not edit this step file except to correct a spec bug. Do not edit `plan.md` or `campaign_contract.md` during implementation except to fill Step 2 identities if they were still placeholders.
+
+## Files forbidden to change
+
+- Any file under `/workspace/data_platform/` except changelog listed above
+- `/workspace/lib/`
+- `/workspace/tests/`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/**`
+- Any committed parquet or csv label file
+
+## Locked contracts
+
+Serial feature order:
+
+1. `is_news_or_opinion` (interrupt-and-resume once during its smoke)
+2. `is_political`
+3. `is_likely_spam`
+4. `is_self_contained`
+5. `is_structurally_complete`
+6. `political_stance`
+7. `llm_toxicity_tiered`
+
+`resume_evidence.json` is required on `is_news_or_opinion` only. The other six features must not write it.
+
+After parent approval, each feature must have:
+
+- `smoke/input.parquet`, `smoke/output.parquet`, `smoke/cost_report.json` (untagged)
+- `smoke/resume_evidence.json` on `is_news_or_opinion` only
+- `batches/part-00000.parquet` (10 smoke rows + up to 1,990 new)
+- later `batches/part-*.parquet` objects covering the remaining rows
+- last part size `row_count % 2000` when that remainder is not 0
+- `final.parquet` with `{row_count}` unique `source_record_id` values
+- `manifest.json` with `engine_type=openai` and `expected_row_count={row_count}`
+- `progress.jsonl` with one record per finished part
+
+Preserve original smoke `batch_id` and `request_id` on the ten folded rows. One OpenAI Batch job in flight per feature. Do not start the next feature's production command until the previous feature's `final.parquet` validates.
+
+Do not use `--full-run-row-count 6374`.
+
+## Two-phase pull request flow
+
+### Phase A
+
+1. Confirm Step 3 is on the stack below this branch.
+2. Run `smoke_twitter_campaign.py` for all seven features. Interrupt and resume only `is_news_or_opinion`.
+3. Commit temporary Git copies under `reports/smoke/{feature}/`.
+4. Post each per-feature `estimated_full_run_usd_avg` and `estimated_full_run_usd_max` on this issue.
+5. Write and post `parent_cost_aggregate.json` on the parent issue.
+6. Stop. Leave the stack pull request as draft. Do not start production.
+
+### Phase B
+
+1. Confirm the parent issue has an explicit owner comment signing off on Step 3, the seven smokes, and the aggregate cost.
+2. Run the seven production commands in order.
+3. Validate S3 artifacts and row counts for each feature before starting the next.
+4. Write the seven `*_run_report.md` files.
+5. Delete temporary `reports/smoke/` Git copies. S3 smoke evidence remains.
+6. Mark the stack pull request ready.
+
+## Exact commands and expected output
+
+List one feature prefix:
+
+```bash
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/{campaign_id}/is_news_or_opinion/ --recursive
+```
+
+Expected after Phase A: smoke objects only. No `batches/part-*.parquet`.
+
+Expected after Phase B: `batches/part-*.parquet` objects covering `{row_count}` rows, `final.parquet`, `manifest.json`, `progress.jsonl`.
+
+Phase A smoke stdout for `is_news_or_opinion` includes `s3_smoke_resume_evidence_ok`. The other six features include `resume_evidence_absent`.
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import json
+from pathlib import Path
+p = Path("docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/smoke/parent_cost_aggregate.json")
+doc = json.loads(p.read_text())
+print(doc.get("full_run_row_count") or doc.get("row_count"))
+print(doc.get("estimated_full_run_usd_avg"))
+print(doc.get("estimated_full_run_usd_max"))
+PY
+```
+
+Expected: printed full-run row count equals campaign YAML `row_count`, plus average and max USD estimates.
+
+Do not add pytest.
+
+## Pass / fail
+
+The step passes when seven smokes and the aggregate cost are posted on the parent, the owner signs off in a comment, each feature `final.parquet` has `{row_count}` unique valid labels, smoke rows keep original ids inside `part-00000`, resume evidence exists only for `is_news_or_opinion`, seven run reports are committed, and temporary Git smoke copies are gone.
+
+The step fails when any item below is true.
+
+- product Python changed
+- production started before the parent owner comment
+- `--full-run-row-count 6374` was used
+- `resume_evidence.json` was written for a feature other than `is_news_or_opinion`
+- smoke rows were relabeled into `part-00000`
+- more than one OpenAI Batch job ran at a time for a feature
+- pytest was added
+
+## PR artifact and commit rules
+
+- One independently mergeable PR stacked on Step 3. Phase A and Phase B share that PR.
+- Logical commits: Phase A smoke copies, Phase B run reports, changelog if used, deletion of smoke copies.
+- PR title suggestion: `Smoke and generate seven LLM features for the new Twitter posts`.

--- a/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step5.md
+++ b/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step5.md
@@ -1,0 +1,158 @@
+# Step 5: Join seven Twitter LLM features and write the MirrorView curated export
+
+## Goal
+
+Operators need one wide table and a MirrorView export for the new campaign, so the implementer joins seven verified `final.parquet` files to the new preprocessed `posts.csv` on `source_record_id`, uploads `wide/features.parquet`, and writes a curated run through `data_platform/curate/configs/twitter/mirrorview.yaml`.
+
+## Dependencies
+
+- **Step 4 merged** on the GitHub stack: seven features each have `final.parquet` with `{row_count}` unique ids and a matching `manifest.json`.
+- Step 3 identities and S3 csv must still match the new inventory hash.
+
+Replace `{campaign_id}`, `{preprocessed_run}`, and `{row_count}` from the Step 3 campaign YAML.
+
+## Caller / unit of work
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run {preprocessed_run} \
+  --campaign-id {campaign_id} \
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/{campaign_id}/wide/features.parquet
+```
+
+**One implementation scope:** change `consolidate_twitter_llm_campaign.py` so expected wide row count comes from `load_twitter_campaign_config(campaign_id)["row_count"]`, not `TWITTER_EXPECTED_WIDE_ROW_COUNT = 6374`. Require CLI `--dataset-id` and `--preprocessed-run` to match that YAML. Download the new dataset's `posts.csv` (not parquet). Verify each feature manifest `row_count={row_count}` and SHA-256 of `final.parquet`. Inner-join on `source_record_id` to the 21-column contract. Upload `wide/features.parquet` and `wide/manifest.json`. Run `apply_rules` with `twitter/mirrorview.yaml`. Write curated output with `TwitterStorageManager("curated", dataset_id)`. Write `reports/wide_run_report.md` with curated row count and `political_stance` × `llm_toxicity_tier` crosstab.
+
+Resolve prefixes with `FeaturePaths.for_campaign(..., platform="twitter", dataset_id=...)`. Left table is csv. Parquet campaign objects may need `CampaignObjectStore` because dataset format is csv.
+
+Reuse join helpers from `data_platform/curate/consolidate.py` only where they already take column lists. Do not change Bluesky `PREPROCESSED_WIDE_COLUMNS` or `EXPECTED_WIDE_ROW_COUNT = 200000`. Do not change `twitter/mirrorview.yaml` filter semantics.
+
+**Out of scope:** relabeling features, pytest, GitHub posting, lifecycle rules, converting the dated dataset to parquet.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/data_platform/curate/consolidate_twitter_llm_campaign.py` | Hardcoded `TWITTER_EXPECTED_WIDE_ROW_COUNT = 6374` |
+| `/workspace/data_platform/generate_features/twitter_campaign_config.py` | Directory loader from Step 3 |
+| `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml` | New `row_count` |
+| `/workspace/data_platform/curate/consolidate.py` | `LLM_CAMPAIGN_FEATURE_NAMES`, feature aliases |
+| `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml` | Filter set. Do not edit. |
+| `/workspace/data_platform/utils/storage.py` | `TwitterStorageManager` |
+| `/workspace/data_platform/generate_features/s3_feature_campaign.py` | `FeaturePaths.for_campaign` |
+| `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/campaign_contract.md` | 21-column contract |
+
+## Files allowed to change
+
+- `/workspace/data_platform/curate/consolidate_twitter_llm_campaign.py`
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/reports/wide_run_report.md` (new)
+- `/workspace/CHANGELOG.md`
+
+Do not edit other plan files except this step file when correcting the spec.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/curate/consolidate.py` unless a tiny helper must accept a column list without changing Bluesky behavior. Prefer keeping Twitter columns inside the Twitter module.
+- `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py`
+- `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/tests/**`
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/dataset.json`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/**`
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/plan.md`
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step1.md`
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step2.md`
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step3.md`
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/steps/step4.md`
+
+## Locked contracts
+
+Wide file: exactly 21 columns in this order.
+
+`tweet_id`, `record_id`, `url`, `username`, `author_handle`, `text`, `created_at`, `like_count`, `retweet_count`, `reply_count`, `quote_count`, `keyword`, `sync_timestamp`, `source_record_id`, `news_or_opinion_category`, `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tier`
+
+Row count: campaign YAML `row_count`. Distinct `source_record_id`: that same count. Sort: `source_record_id ASC`. No nulls in the seven label columns.
+
+Wide manifest links all seven feature manifests plus the preprocessed csv SHA-256 from `data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/s3_preprocessed_inventory.json`.
+
+Forbidden wide columns: `toxicity_prob`, `toxicity_tier`, any `is_toxic_tiered` field, `label_timestamp`, `run_id`, `author_id`.
+
+Left table key:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/posts.csv`
+
+Read that object as csv. Do not require `posts.parquet`.
+
+Curation: `TwitterStorageManager("curated", dataset_id)` writes `curated/<timestamp>/mirrorview.parquet` plus `metadata.json`. Filename stem is `mirrorview` from the YAML.
+
+Re-running the consolidator against campaign id `twitter_2026_09_06_192847_llm_features_v1` must still expect 6374 rows, because that YAML still says `row_count: 6374`. Do not leave a module constant that forces 6374 for every Twitter campaign.
+
+## Ordered implementation work
+
+1. Load expected row count from `load_twitter_campaign_config`. Fail if CLI dataset id or preprocessed run disagrees with the YAML.
+2. Verify seven manifests before writing wide output.
+3. Join, upload wide parquet and manifest.
+4. Apply MirrorView rules. Write curated run.
+5. Write `reports/wide_run_report.md` with curated row count and the stance by toxicity crosstab for rows that survive the filters.
+6. Run the runtime checks below.
+
+## Exact commands and expected output
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run {preprocessed_run} \
+  --campaign-id {campaign_id} \
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/{campaign_id}/wide/features.parquet
+```
+
+Expected stdout includes each accepted manifest digest, `wide_rows={row_count}`, `wide_columns=21`, `sort_key=source_record_id ASC`, the wide manifest URI, `curated_rows=...`, and `curated_crosstab_political_stance_by_llm_toxicity_tier=` JSON.
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/{campaign_id}/wide/features.parquet /tmp/twitter_2026_09_07_wide.parquet
+PYTHONPATH=. uv run python - <<'PY'
+import pyarrow.parquet as pq
+t = pq.read_table("/tmp/twitter_2026_09_07_wide.parquet")
+want = [
+    "tweet_id","record_id","url","username","author_handle","text","created_at",
+    "like_count","retweet_count","reply_count","quote_count","keyword","sync_timestamp",
+    "source_record_id","news_or_opinion_category","is_political","is_likely_spam",
+    "is_self_contained","is_structurally_complete","political_stance","llm_toxicity_tier",
+]
+assert t.column_names == want, t.column_names
+print("wide ok", t.num_rows, len(t.column_names))
+PY
+```
+
+Expected: `wide ok {row_count} 21`.
+
+The pull request body and `wide_run_report.md` must include the curated crosstab of `political_stance` × `llm_toxicity_tier` for curated rows.
+
+Do not add pytest.
+
+## Pass / fail
+
+The step passes when `wide/features.parquet` has `{row_count}` rows, 21 columns, and no missing feature values; the wide manifest links seven feature manifests and the new csv hash; MirrorView curation writes `curated/<timestamp>/mirrorview.parquet` through `TwitterStorageManager`; and the committed report includes curated row count plus the stance by toxicity crosstab.
+
+The step fails when any item below is true.
+
+- expected row count is still the module constant 6374 for the new campaign
+- left table loaded from parquet or from a converted copy of `posts.csv`
+- wide column order differs from the contract
+- Bluesky `EXPECTED_WIDE_ROW_COUNT` is changed
+- join uses `tweet_id` instead of `source_record_id`
+- curated files land under `wide/curated/` or through `BlueskyStorageManager`
+- filter YAML semantics changed
+- pytest was added
+
+## PR artifact and commit rules
+
+- One independently mergeable PR stacked on Step 4.
+- Logical commits: consolidator row-count source, live run report, changelog.
+- PR title suggestion: `Join seven Twitter LLM features and write the MirrorView curated export`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The 2026-09-05 Twitter LLM campaign is closed. Operators need a second, identical pipeline on a new dated collection, without a written five-PR contract that keeps that campaign working and repeats the parent cost gate.

## Solution

Adds the plan package at `docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/`. It specifies a new ingest YAML and dataset, live recent-search sync, preprocess, directory campaign-YAML lookup, S3 copy of preprocessed `posts.csv` only, seven OpenAI Batch features after parent sign-off, and the MirrorView export.

## Purpose

Locks the next Twitter campaign before `/implement-epic`. Product code is out of scope. Implementation is one child issue at a time.

Parent: #251. Children: #252, #253, #254, #255, #256.

## How to run

The plan is markdown only. Read `docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/plan.md` and `campaign_contract.md`. Implementation starts with `/implement-epic` on #251, one child per stacked PR, beginning with #252.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a079c8-82d8-77df-8356-1d33113a8500?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a079c8-82d8-77df-8356-1d33113a8500&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

