### PR TITLE
Consolidate seven Reddit LLM features and write the MirrorView curated export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 11. Operators can review the ten-comment `is_structurally_complete` smoke for the pinned Reddit campaign, including an estimated 400000-row Bedrock Converse cost of 7.1974 USD on average and 9.394 USD at the token maximum. [PR #246](https://github.com/METResearchGroup/mirrorView-task/pull/246)
 12. Operators can review the ten-comment `political_stance` smoke for the pinned Reddit campaign, including an estimated 400000-row OpenAI Batch cost of 23.744 USD on average and 30.04 USD at the token maximum. [PR #247](https://github.com/METResearchGroup/mirrorView-task/pull/247)
 13. Operators can review the ten-comment `llm_toxicity_tiered` smoke for the pinned Reddit campaign, including an estimated 400000-row OpenAI Batch cost of 21.144 USD on average and 27.34 USD at the token maximum. The same pull request records the mixed-engine parent cost aggregate across all seven campaign features. [PR #248](https://github.com/METResearchGroup/mirrorView-task/pull/248)
+14. Operators now have a Reddit table of 400,000 labeled comments with 16 columns, plus a MirrorView curated export of 43,061 left/right comments that records political stance by toxicity tier. [PR #258](https://github.com/METResearchGroup/mirrorView-task/pull/258)
 
 ## 2026-09-06
 

--- a/data_platform/curate/consolidate.py
+++ b/data_platform/curate/consolidate.py
@@ -187,25 +187,31 @@ def build_wide_table(config: ConsolidateConfig) -> pd.DataFrame:
         conn.close()
 
 
-def llm_campaign_wide_columns() -> tuple[str, ...]:
-    """Return the nineteen wide columns in campaign order."""
-    label_columns = tuple(
+def _llm_campaign_label_columns() -> tuple[str, ...]:
+    return tuple(
         alias
         for feature_name in LLM_CAMPAIGN_FEATURE_NAMES
         for _, alias in FEATURE_WIDE_COLUMNS[feature_name]
     )
-    return PREPROCESSED_WIDE_COLUMNS + label_columns
+
+
+def llm_campaign_wide_columns() -> tuple[str, ...]:
+    """Return the nineteen wide columns in campaign order."""
+    return PREPROCESSED_WIDE_COLUMNS + _llm_campaign_label_columns()
 
 
 def _sql_path(path: Path) -> str:
     return path.resolve().as_posix().replace("'", "''")
 
 
-def _campaign_posts_cte_sql(posts_file: Path) -> str:
+def _campaign_posts_cte_sql(
+    posts_file: Path,
+    columns: tuple[str, ...] = PREPROCESSED_WIDE_COLUMNS,
+) -> str:
     id_column = STANDARDIZED_SOURCE_RECORD_ID_COLUMN
     selected = ", ".join(
         f"CAST({column} AS VARCHAR) AS {column}" if column == id_column else column
-        for column in PREPROCESSED_WIDE_COLUMNS
+        for column in columns
     )
     return f"posts AS (SELECT {selected} FROM read_parquet('{_sql_path(posts_file)}'))"
 
@@ -224,7 +230,11 @@ def _campaign_feature_ctes(feature_files: dict[str, Path]) -> list[str]:
     ]
 
 
-def _campaign_join_sql(posts_file: Path, feature_files: dict[str, Path]) -> str:
+def _campaign_join_sql(
+    posts_file: Path,
+    feature_files: dict[str, Path],
+    columns: tuple[str, ...] = PREPROCESSED_WIDE_COLUMNS,
+) -> str:
     id_column = STANDARDIZED_SOURCE_RECORD_ID_COLUMN
     join_clauses = [
         f"INNER JOIN feat_{feature_name} USING ({id_column})"
@@ -235,8 +245,10 @@ def _campaign_join_sql(posts_file: Path, feature_files: dict[str, Path]) -> str:
         for feature_name in LLM_CAMPAIGN_FEATURE_NAMES
         for _, alias in FEATURE_WIDE_COLUMNS[feature_name]
     ]
-    posts_cols = [f"posts.{column}" for column in PREPROCESSED_WIDE_COLUMNS]
-    ctes = ",\n".join([_campaign_posts_cte_sql(posts_file), *_campaign_feature_ctes(feature_files)])
+    posts_cols = [f"posts.{column}" for column in columns]
+    ctes = ",\n".join(
+        [_campaign_posts_cte_sql(posts_file, columns), *_campaign_feature_ctes(feature_files)]
+    )
     return f"""
 WITH {ctes}
 SELECT {", ".join(posts_cols + label_cols)}
@@ -273,12 +285,7 @@ def build_llm_campaign_wide_table(
 
 def reddit_llm_campaign_wide_columns() -> tuple[str, ...]:
     """Return the sixteen wide columns in Reddit campaign order."""
-    label_columns = tuple(
-        alias
-        for feature_name in LLM_CAMPAIGN_FEATURE_NAMES
-        for _, alias in FEATURE_WIDE_COLUMNS[feature_name]
-    )
-    return REDDIT_PREPROCESSED_WIDE_COLUMNS + label_columns
+    return REDDIT_PREPROCESSED_WIDE_COLUMNS + _llm_campaign_label_columns()
 
 
 def build_reddit_llm_campaign_wide_table(
@@ -295,4 +302,14 @@ def build_reddit_llm_campaign_wide_table(
     KeyError
         When a campaign feature path is missing from ``feature_files``.
     """
-    raise NotImplementedError
+    missing = [name for name in LLM_CAMPAIGN_FEATURE_NAMES if name not in feature_files]
+    if missing:
+        raise KeyError(f"missing campaign feature parquet paths: {missing}")
+    sql = _campaign_join_sql(
+        comments_file, feature_files, columns=REDDIT_PREPROCESSED_WIDE_COLUMNS
+    )
+    conn = duckdb.connect()
+    try:
+        return conn.execute(sql).fetchdf()
+    finally:
+        conn.close()

--- a/data_platform/curate/consolidate.py
+++ b/data_platform/curate/consolidate.py
@@ -61,7 +61,9 @@ PREPROCESSED_WIDE_COLUMNS: tuple[str, ...] = (
     STANDARDIZED_SOURCE_RECORD_ID_COLUMN,
 )
 
+REDDIT_PREPROCESSED_WIDE_COLUMNS: tuple[str, ...] = ()
 EXPECTED_WIDE_ROW_COUNT = 200000
+REDDIT_EXPECTED_WIDE_ROW_COUNT = 400000
 WIDE_SORT_KEY = f"{STANDARDIZED_SOURCE_RECORD_ID_COLUMN} ASC"
 
 
@@ -257,3 +259,14 @@ def build_llm_campaign_wide_table(
         return conn.execute(sql).fetchdf()
     finally:
         conn.close()
+
+
+def reddit_llm_campaign_wide_columns() -> tuple[str, ...]:
+    raise NotImplementedError
+
+
+def build_reddit_llm_campaign_wide_table(
+    comments_file: Path,
+    feature_files: dict[str, Path],
+) -> pd.DataFrame:
+    raise NotImplementedError

--- a/data_platform/curate/consolidate.py
+++ b/data_platform/curate/consolidate.py
@@ -61,7 +61,17 @@ PREPROCESSED_WIDE_COLUMNS: tuple[str, ...] = (
     STANDARDIZED_SOURCE_RECORD_ID_COLUMN,
 )
 
-REDDIT_PREPROCESSED_WIDE_COLUMNS: tuple[str, ...] = ()
+REDDIT_PREPROCESSED_WIDE_COLUMNS: tuple[str, ...] = (
+    "comment_fullname",
+    "record_id",
+    "author",
+    "body",
+    "created_at",
+    "sync_timestamp",
+    "text",
+    "author_handle",
+    STANDARDIZED_SOURCE_RECORD_ID_COLUMN,
+)
 EXPECTED_WIDE_ROW_COUNT = 200000
 REDDIT_EXPECTED_WIDE_ROW_COUNT = 400000
 WIDE_SORT_KEY = f"{STANDARDIZED_SOURCE_RECORD_ID_COLUMN} ASC"
@@ -262,11 +272,27 @@ def build_llm_campaign_wide_table(
 
 
 def reddit_llm_campaign_wide_columns() -> tuple[str, ...]:
-    raise NotImplementedError
+    """Return the sixteen wide columns in Reddit campaign order."""
+    label_columns = tuple(
+        alias
+        for feature_name in LLM_CAMPAIGN_FEATURE_NAMES
+        for _, alias in FEATURE_WIDE_COLUMNS[feature_name]
+    )
+    return REDDIT_PREPROCESSED_WIDE_COLUMNS + label_columns
 
 
 def build_reddit_llm_campaign_wide_table(
     comments_file: Path,
     feature_files: dict[str, Path],
 ) -> pd.DataFrame:
+    """Inner-join pinned comments to seven campaign ``final.parquet`` files on ``source_record_id``.
+
+    Rows are sorted by ``source_record_id`` ascending. Duplicate feature ids keep
+    the latest ``label_timestamp``.
+
+    Raises
+    ------
+    KeyError
+        When a campaign feature path is missing from ``feature_files``.
+    """
     raise NotImplementedError

--- a/data_platform/curate/consolidate_reddit_llm_campaign.py
+++ b/data_platform/curate/consolidate_reddit_llm_campaign.py
@@ -33,8 +33,13 @@ from __future__ import annotations
 
 import argparse
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
+import pandas as pd
+
+from data_platform.curate.apply_rules import FilterStepResult
 from data_platform.curate.consolidate import (
     LLM_CAMPAIGN_FEATURE_NAMES,
     REDDIT_EXPECTED_WIDE_ROW_COUNT,
@@ -43,37 +48,159 @@ from data_platform.curate.consolidate import (
     build_reddit_llm_campaign_wide_table,
     reddit_llm_campaign_wide_columns,
 )
+from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
 
 
-def parse_args(argv: list[str] | None = None):
+MIRRORVIEW_RULES_PATH = (
+    Path(__file__).resolve().parent / "configs" / "reddit" / "mirrorview.yaml"
+)
+WIDE_MANIFEST_FILENAME = "manifest.json"
+WIDE_PARQUET_FILENAME = "features.parquet"
+REDDIT_CAMPAIGN_PLATFORM = "reddit"
+PREPROCESSED_COMMENTS_FILENAME = "comments.parquet"
+STANCE_CROSSTAB_ROWS = ("left", "right")
+TOXICITY_CROSSTAB_COLUMNS = ("low", "medium", "high")
+FORBIDDEN_WIDE_COLUMNS = frozenset(
+    {
+        "toxicity_prob",
+        "toxicity_tier",
+        "label_timestamp",
+        "run_id",
+        "is_toxic_tiered",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CampaignConsolidateArgs:
+    """CLI inputs for the Reddit LLM campaign wide join."""
+
+    dataset_id: str
+    preprocessed_run: str
+    campaign_id: str
+    output_s3_uri: str
+    curate_config: Path
+
+
+@dataclass(frozen=True)
+class FeatureInputRecord:
+    """Verified feature ``final.parquet`` and its manifest metadata."""
+
+    feature_name: str
+    final_key: str
+    final_sha256: str
+    final_row_count: int
+    manifest_key: str
+    manifest_sha256: str
+    local_parquet: Path
+
+
+@dataclass(frozen=True)
+class PreprocessedInputRecord:
+    """Pinned preprocessed comments used as the wide-join left table."""
+
+    key: str
+    sha256: str
+    local_parquet: Path
+
+
+@dataclass(frozen=True)
+class CuratedDatasetRecord:
+    """MirrorView-filtered rows plus stance by toxicity counts."""
+
+    row_count: int
+    parquet_key: str
+    parquet_sha256: str
+    metadata_key: str
+    metadata_sha256: str
+    rules_hash: str
+    filter_steps: list[dict[str, Any]]
+    stance_by_toxicity: dict[str, dict[str, int]]
+
+
+@dataclass(frozen=True)
+class WideConsolidateResult:
+    """Uploaded wide Parquet, manifest, and optional curated export."""
+
+    wide_rows: int
+    wide_columns: tuple[str, ...]
+    wide_parquet_uri: str
+    wide_parquet_sha256: str
+    manifest_uri: str
+    sort_key: str
+    feature_inputs: tuple[FeatureInputRecord, ...]
+    preprocessed: PreprocessedInputRecord
+    curated: CuratedDatasetRecord | None
+
+
+def parse_args(argv: list[str] | None = None) -> CampaignConsolidateArgs:
+    parser = argparse.ArgumentParser(
+        description="Join seven Reddit LLM campaign features into one wide Parquet object."
+    )
+    parser.add_argument("--dataset-id", required=True)
+    parser.add_argument("--preprocessed-run", required=True)
+    parser.add_argument("--campaign-id", required=True)
+    parser.add_argument("--output-s3-uri", required=True)
+    parser.add_argument(
+        "--curate-config",
+        default=str(MIRRORVIEW_RULES_PATH),
+        help="YAML rules applied to the wide table after the join.",
+    )
+    parsed = parser.parse_args(argv)
+    return CampaignConsolidateArgs(
+        dataset_id=parsed.dataset_id,
+        preprocessed_run=parsed.preprocessed_run,
+        campaign_id=parsed.campaign_id,
+        output_s3_uri=parsed.output_s3_uri,
+        curate_config=Path(parsed.curate_config),
+    )
+
+
+def verify_feature_manifest(
+    store: CampaignObjectStore,
+    feature_name: str,
+    campaign_id: str,
+    dataset_id: str,
+) -> tuple[str, dict[str, Any]]:
     raise NotImplementedError
 
 
-def verify_feature_manifest(store, feature_name: str, campaign_id: str, dataset_id: str):
+def download_campaign_inputs(
+    store: CampaignObjectStore,
+    args: CampaignConsolidateArgs,
+    work_dir: Path,
+) -> tuple[PreprocessedInputRecord, tuple[FeatureInputRecord, ...]]:
     raise NotImplementedError
 
 
-def download_campaign_inputs(store, args, work_dir: Path):
+def validate_wide_table(wide: pd.DataFrame) -> None:
     raise NotImplementedError
 
 
-def validate_wide_table(wide) -> None:
+def curate_mirrorview_dataset(
+    store: CampaignObjectStore,
+    wide: pd.DataFrame,
+    args: CampaignConsolidateArgs,
+) -> CuratedDatasetRecord:
     raise NotImplementedError
 
 
-def curate_mirrorview_dataset(store, wide, args):
+def upload_wide_artifacts(
+    store: CampaignObjectStore,
+    wide: pd.DataFrame,
+    args: CampaignConsolidateArgs,
+    preprocessed: PreprocessedInputRecord,
+    feature_inputs: tuple[FeatureInputRecord, ...],
+    curated: CuratedDatasetRecord | None,
+) -> tuple[str, str, str]:
     raise NotImplementedError
 
 
-def upload_wide_artifacts(store, wide, args, preprocessed, feature_inputs, curated):
+def run_campaign_consolidation(args: CampaignConsolidateArgs) -> WideConsolidateResult:
     raise NotImplementedError
 
 
-def run_campaign_consolidation(args):
-    raise NotImplementedError
-
-
-def print_result(result) -> None:
+def print_result(result: WideConsolidateResult) -> None:
     raise NotImplementedError
 
 

--- a/data_platform/curate/consolidate_reddit_llm_campaign.py
+++ b/data_platform/curate/consolidate_reddit_llm_campaign.py
@@ -32,14 +32,18 @@ Run from the repo root:
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any
 
+import boto3
 import pandas as pd
 
-from data_platform.curate.apply_rules import FilterStepResult
+from data_platform.curate.apply_rules import FilterStepResult, apply_rules, load_rules_config
 from data_platform.curate.consolidate import (
     LLM_CAMPAIGN_FEATURE_NAMES,
     REDDIT_EXPECTED_WIDE_ROW_COUNT,
@@ -48,16 +52,28 @@ from data_platform.curate.consolidate import (
     build_reddit_llm_campaign_wide_table,
     reddit_llm_campaign_wide_columns,
 )
-from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
-
+from data_platform.curate.runner import build_curate_metadata
+from data_platform.generate_features.s3_feature_campaign import (
+    S3_KEY_PREFIX,
+    CampaignObjectStore,
+    FeaturePaths,
+    parse_s3_uri,
+    s3_uri,
+)
+from data_platform.utils.dataset import dataset_root, relative_run_path
+from data_platform.utils.object_store import DEFAULT_S3_REGION, sha256_hex
+from data_platform.utils.platform_specific_columns import STANDARDIZED_SOURCE_RECORD_ID_COLUMN
+from data_platform.utils.storage import DATA_ROOT, RedditStorageManager
+from lib.timestamp_utils import get_current_timestamp
 
 MIRRORVIEW_RULES_PATH = (
     Path(__file__).resolve().parent / "configs" / "reddit" / "mirrorview.yaml"
 )
 WIDE_MANIFEST_FILENAME = "manifest.json"
 WIDE_PARQUET_FILENAME = "features.parquet"
-REDDIT_CAMPAIGN_PLATFORM = "reddit"
 PREPROCESSED_COMMENTS_FILENAME = "comments.parquet"
+REDDIT_CAMPAIGN_PLATFORM = "reddit"
+SHA256_READ_CHUNK_BYTES = 1024 * 1024
 STANCE_CROSSTAB_ROWS = ("left", "right")
 TOXICITY_CROSSTAB_COLUMNS = ("low", "medium", "high")
 FORBIDDEN_WIDE_COLUMNS = frozenset(
@@ -156,13 +172,89 @@ def parse_args(argv: list[str] | None = None) -> CampaignConsolidateArgs:
     )
 
 
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(SHA256_READ_CHUNK_BYTES), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _json_bytes(document: dict[str, Any]) -> bytes:
+    return json.dumps(document, indent=2).encode("utf-8")
+
+
+def _repo_relative(path: Path) -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(repo_root).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def _s3_client() -> Any:
+    return boto3.client("s3", region_name=DEFAULT_S3_REGION)
+
+
+def _feature_paths(campaign_id: str, feature_name: str, dataset_id: str) -> FeaturePaths:
+    return FeaturePaths.for_campaign(
+        campaign_id,
+        feature_name,
+        platform=REDDIT_CAMPAIGN_PLATFORM,
+        dataset_id=dataset_id,
+    )
+
+
+def _preprocessed_comments_key(dataset_id: str, preprocessed_run: str) -> str:
+    return (
+        f"{S3_KEY_PREFIX}/{REDDIT_CAMPAIGN_PLATFORM}/{dataset_id}/"
+        f"preprocessed/{preprocessed_run}/{PREPROCESSED_COMMENTS_FILENAME}"
+    )
+
+
+def _wide_prefix(output_key: str) -> str:
+    if not output_key.endswith(WIDE_PARQUET_FILENAME):
+        raise ValueError(
+            f"output-s3-uri must end with {WIDE_PARQUET_FILENAME}, got {output_key!r}"
+        )
+    return output_key[: -len(WIDE_PARQUET_FILENAME)]
+
+
+def _download_key(client: Any, bucket: str, key: str, dest: Path) -> str:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    client.download_file(bucket, key, str(dest))
+    return _sha256_file(dest)
+
+
+def _upload_bytes(store: CampaignObjectStore, key: str, body: bytes) -> str:
+    stored = store.get(key)
+    if stored is None:
+        return store.put_new(key, body).sha256
+    return store.replace(key, body, etag=stored.etag).sha256
+
+
 def verify_feature_manifest(
     store: CampaignObjectStore,
     feature_name: str,
     campaign_id: str,
     dataset_id: str,
 ) -> tuple[str, dict[str, Any]]:
-    raise NotImplementedError
+    """Return manifest SHA-256 and parsed JSON after checking row count 400000."""
+    paths = _feature_paths(campaign_id, feature_name, dataset_id)
+    stored = store.get(paths.manifest_key)
+    if stored is None:
+        raise FileNotFoundError(f"missing feature manifest: {paths.uri(paths.manifest_key)}")
+    manifest = json.loads(stored.body)
+    final = manifest.get("final_parquet") or {}
+    if final.get("row_count") != REDDIT_EXPECTED_WIDE_ROW_COUNT:
+        raise ValueError(
+            f"{feature_name} final.parquet row_count is {final.get('row_count')}, "
+            f"expected {REDDIT_EXPECTED_WIDE_ROW_COUNT}"
+        )
+    digest = sha256_hex(stored.body)
+    print(f"accepted {feature_name} manifest sha256={digest}")
+    return digest, manifest
 
 
 def download_campaign_inputs(
@@ -170,11 +262,120 @@ def download_campaign_inputs(
     args: CampaignConsolidateArgs,
     work_dir: Path,
 ) -> tuple[PreprocessedInputRecord, tuple[FeatureInputRecord, ...]]:
-    raise NotImplementedError
+    """Download pinned comments and seven verified ``final.parquet`` files."""
+    client = _s3_client()
+    comments_key = _preprocessed_comments_key(args.dataset_id, args.preprocessed_run)
+    comments_path = work_dir / PREPROCESSED_COMMENTS_FILENAME
+    comments_sha = _download_key(client, store.bucket, comments_key, comments_path)
+    preprocessed = PreprocessedInputRecord(
+        key=comments_key, sha256=comments_sha, local_parquet=comments_path
+    )
+    features = tuple(
+        _download_feature_final(store, client, args, work_dir, feature_name)
+        for feature_name in LLM_CAMPAIGN_FEATURE_NAMES
+    )
+    return preprocessed, features
+
+
+def _download_feature_final(
+    store: CampaignObjectStore,
+    client: Any,
+    args: CampaignConsolidateArgs,
+    work_dir: Path,
+    feature_name: str,
+) -> FeatureInputRecord:
+    paths = _feature_paths(args.campaign_id, feature_name, args.dataset_id)
+    manifest_sha, manifest = verify_feature_manifest(
+        store, feature_name, args.campaign_id, args.dataset_id
+    )
+    final = manifest["final_parquet"]
+    local_path = work_dir / feature_name / "final.parquet"
+    digest = _download_key(client, store.bucket, paths.final_key, local_path)
+    expected = str(final["sha256"]).lower()
+    if digest != expected:
+        raise ValueError(
+            f"{feature_name} final.parquet SHA-256 mismatch: manifest {expected}, object {digest}"
+        )
+    return FeatureInputRecord(
+        feature_name=feature_name,
+        final_key=paths.final_key,
+        final_sha256=digest,
+        final_row_count=int(final["row_count"]),
+        manifest_key=paths.manifest_key,
+        manifest_sha256=manifest_sha,
+        local_parquet=local_path,
+    )
 
 
 def validate_wide_table(wide: pd.DataFrame) -> None:
-    raise NotImplementedError
+    """Raise ValueError when the wide table misses the Step 11 contract."""
+    expected = reddit_llm_campaign_wide_columns()
+    actual = tuple(wide.columns)
+    if actual != expected:
+        raise ValueError(f"wide columns {actual} do not match {expected}")
+    _validate_wide_rows(wide)
+    forbidden = FORBIDDEN_WIDE_COLUMNS.intersection(actual)
+    if forbidden:
+        raise ValueError(f"wide table contains forbidden columns: {sorted(forbidden)}")
+    _validate_wide_labels(wide, expected)
+
+
+def _validate_wide_rows(wide: pd.DataFrame) -> None:
+    id_column = STANDARDIZED_SOURCE_RECORD_ID_COLUMN
+    if len(wide) != REDDIT_EXPECTED_WIDE_ROW_COUNT:
+        raise ValueError(f"wide_rows={len(wide)}, expected {REDDIT_EXPECTED_WIDE_ROW_COUNT}")
+    unique_ids = wide[id_column].astype(str).nunique()
+    if unique_ids != REDDIT_EXPECTED_WIDE_ROW_COUNT:
+        raise ValueError(
+            f"distinct source_record_id={unique_ids}, expected {REDDIT_EXPECTED_WIDE_ROW_COUNT}"
+        )
+    ids = wide[id_column].astype(str)
+    if not ids.is_monotonic_increasing:
+        raise ValueError("wide rows are not sorted by source_record_id ASC")
+
+
+def _validate_wide_labels(wide: pd.DataFrame, expected_columns: tuple[str, ...]) -> None:
+    label_columns = expected_columns[len(REDDIT_PREPROCESSED_WIDE_COLUMNS) :]
+    null_counts = {
+        column: int(wide[column].isna().sum())
+        for column in label_columns
+        if int(wide[column].isna().sum()) > 0
+    }
+    if null_counts:
+        raise ValueError(f"null feature values: {null_counts}")
+
+
+def _filter_step_record(step: FilterStepResult) -> dict[str, Any]:
+    return {
+        **step.rule.model_dump(),
+        "records_before": step.records_before,
+        "records_passing": step.records_passing,
+    }
+
+
+def _stance_by_toxicity(filtered: pd.DataFrame) -> dict[str, dict[str, int]]:
+    counts: dict[str, dict[str, int]] = {
+        stance: {tier: 0 for tier in TOXICITY_CROSSTAB_COLUMNS} for stance in STANCE_CROSSTAB_ROWS
+    }
+    grouped = filtered.groupby(["political_stance", "llm_toxicity_tier"], dropna=False).size()
+    for (stance, tier), row_count in grouped.items():
+        stance_key = str(stance)
+        tier_key = str(tier)
+        if stance_key not in STANCE_CROSSTAB_ROWS:
+            continue
+        counts[stance_key][tier_key] = int(row_count)
+    return counts
+
+
+def _full_data_key(path: Path) -> str:
+    return f"{S3_KEY_PREFIX}/{path.relative_to(DATA_ROOT).as_posix()}"
+
+
+def _object_sha256(store: CampaignObjectStore, key: str) -> str:
+    stored = store.get(key)
+    if stored is None:
+        raise FileNotFoundError(f"missing object after write: {s3_uri(store.bucket, key)}")
+    return sha256_hex(stored.body)
 
 
 def curate_mirrorview_dataset(
@@ -182,7 +383,95 @@ def curate_mirrorview_dataset(
     wide: pd.DataFrame,
     args: CampaignConsolidateArgs,
 ) -> CuratedDatasetRecord:
-    raise NotImplementedError
+    """Apply existing MirrorView YAML filters and upload to the dataset ``curated/`` stage."""
+    rules = load_rules_config(args.curate_config)
+    rules_hash = hashlib.sha256(args.curate_config.read_bytes()).hexdigest()
+    applied = apply_rules(wide, rules)
+    filtered = applied.dataframe
+    curated_storage = RedditStorageManager("curated", args.dataset_id)
+    run_dir = curated_storage.create_new_run_dir(get_current_timestamp())
+    export_filename = curated_storage.filename_for(rules.output.stem)
+    output_path = curated_storage.write_dataframe(filtered, run_dir, filename=export_filename)
+    stance_by_toxicity = _stance_by_toxicity(filtered)
+    dataset = dataset_root(REDDIT_CAMPAIGN_PLATFORM, args.dataset_id)
+    preprocessed_dir = dataset / "preprocessed" / args.preprocessed_run
+    metadata = build_curate_metadata(
+        dataset_id=args.dataset_id,
+        rules_name=rules.name,
+        rules_hash=rules_hash,
+        source_preprocessed_runs=[relative_run_path(dataset, preprocessed_dir)],
+        wide_df=wide,
+        filtered_df=filtered,
+        rules_result=applied,
+        export_filename=export_filename,
+    )
+    metadata["crosstab_political_stance_by_llm_toxicity_tier"] = stance_by_toxicity
+    metadata_path = curated_storage.write_run_metadata(run_dir, metadata)
+    parquet_key = _full_data_key(output_path)
+    metadata_key = _full_data_key(metadata_path)
+    return CuratedDatasetRecord(
+        row_count=len(filtered),
+        parquet_key=parquet_key,
+        parquet_sha256=_object_sha256(store, parquet_key),
+        metadata_key=metadata_key,
+        metadata_sha256=_object_sha256(store, metadata_key),
+        rules_hash=rules_hash,
+        filter_steps=[_filter_step_record(step) for step in applied.steps],
+        stance_by_toxicity=stance_by_toxicity,
+    )
+
+
+def _feature_manifest_block(
+    store: CampaignObjectStore, record: FeatureInputRecord
+) -> dict[str, Any]:
+    return {
+        "manifest_uri": s3_uri(store.bucket, record.manifest_key),
+        "manifest_sha256": record.manifest_sha256,
+        "final_parquet": {
+            "key": record.final_key,
+            "sha256": record.final_sha256,
+            "row_count": record.final_row_count,
+        },
+    }
+
+
+def _wide_manifest_document(
+    store: CampaignObjectStore,
+    args: CampaignConsolidateArgs,
+    wide_key: str,
+    wide_sha: str,
+    preprocessed: PreprocessedInputRecord,
+    feature_inputs: tuple[FeatureInputRecord, ...],
+    curated: CuratedDatasetRecord | None,
+) -> dict[str, Any]:
+    document: dict[str, Any] = {
+        "dataset_id": args.dataset_id,
+        "preprocessed_run": args.preprocessed_run,
+        "campaign_id": args.campaign_id,
+        "row_count": REDDIT_EXPECTED_WIDE_ROW_COUNT,
+        "columns": list(reddit_llm_campaign_wide_columns()),
+        "sort_key": WIDE_SORT_KEY,
+        "wide_parquet": {
+            "key": wide_key,
+            "sha256": wide_sha,
+            "row_count": REDDIT_EXPECTED_WIDE_ROW_COUNT,
+        },
+        "preprocessed": {"key": preprocessed.key, "sha256": preprocessed.sha256},
+        "features": {
+            record.feature_name: _feature_manifest_block(store, record)
+            for record in feature_inputs
+        },
+    }
+    if curated is not None:
+        document["curated"] = {
+            "rules_config": _repo_relative(args.curate_config),
+            "rules_hash": curated.rules_hash,
+            "row_count": curated.row_count,
+            "parquet": {"key": curated.parquet_key, "sha256": curated.parquet_sha256},
+            "metadata": {"key": curated.metadata_key, "sha256": curated.metadata_sha256},
+            "crosstab_political_stance_by_llm_toxicity_tier": curated.stance_by_toxicity,
+        }
+    return document
 
 
 def upload_wide_artifacts(
@@ -193,15 +482,60 @@ def upload_wide_artifacts(
     feature_inputs: tuple[FeatureInputRecord, ...],
     curated: CuratedDatasetRecord | None,
 ) -> tuple[str, str, str]:
-    raise NotImplementedError
+    """Upload ``features.parquet`` and ``manifest.json``. Return parquet SHA-256, parquet URI, manifest URI."""
+    bucket, wide_key = parse_s3_uri(args.output_s3_uri)
+    if bucket != store.bucket:
+        raise ValueError(f"output bucket {bucket} does not match campaign bucket {store.bucket}")
+    wide_sha = _upload_bytes(store, wide_key, wide.to_parquet(index=False))
+    manifest_key = f"{_wide_prefix(wide_key)}{WIDE_MANIFEST_FILENAME}"
+    manifest = _wide_manifest_document(
+        store, args, wide_key, wide_sha, preprocessed, feature_inputs, curated
+    )
+    _upload_bytes(store, manifest_key, _json_bytes(manifest))
+    return wide_sha, s3_uri(store.bucket, wide_key), s3_uri(store.bucket, manifest_key)
 
 
 def run_campaign_consolidation(args: CampaignConsolidateArgs) -> WideConsolidateResult:
-    raise NotImplementedError
+    """Download inputs, join, validate, upload wide artifacts, and curate."""
+    paths = _feature_paths(args.campaign_id, LLM_CAMPAIGN_FEATURE_NAMES[0], args.dataset_id)
+    store = CampaignObjectStore(paths.bucket)
+    with TemporaryDirectory() as tmp:
+        preprocessed, features = download_campaign_inputs(store, args, Path(tmp))
+        wide = build_reddit_llm_campaign_wide_table(
+            preprocessed.local_parquet,
+            {record.feature_name: record.local_parquet for record in features},
+        )
+        validate_wide_table(wide)
+        curated = curate_mirrorview_dataset(store, wide, args)
+        wide_sha, parquet_uri, manifest_uri = upload_wide_artifacts(
+            store, wide, args, preprocessed, features, curated
+        )
+    return WideConsolidateResult(
+        wide_rows=len(wide),
+        wide_columns=tuple(wide.columns),
+        wide_parquet_uri=parquet_uri,
+        wide_parquet_sha256=wide_sha,
+        manifest_uri=manifest_uri,
+        sort_key=WIDE_SORT_KEY,
+        feature_inputs=features,
+        preprocessed=preprocessed,
+        curated=curated,
+    )
 
 
 def print_result(result: WideConsolidateResult) -> None:
-    raise NotImplementedError
+    """Print the Step 11 stdout contract plus curated row count."""
+    print(f"wide_rows={result.wide_rows}")
+    print(f"wide_columns={len(result.wide_columns)}")
+    print(f"manifest={result.manifest_uri}")
+    print(f"sort_key={result.sort_key}")
+    if result.curated is None:
+        return
+    bucket, _ = parse_s3_uri(result.wide_parquet_uri)
+    print(f"curated_rows={result.curated.row_count}")
+    print(f"curated={s3_uri(bucket, result.curated.parquet_key)}")
+    print("curated_crosstab_political_stance_by_llm_toxicity_tier=")
+    print(json.dumps(result.curated.stance_by_toxicity, indent=2))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/data_platform/curate/consolidate_reddit_llm_campaign.py
+++ b/data_platform/curate/consolidate_reddit_llm_campaign.py
@@ -1,0 +1,88 @@
+"""Join pinned Reddit comments with seven campaign LLM feature files into one wide Parquet object.
+
+Runtime validation (automated tests are forbidden by Step 11):
+
+given seven feature manifests whose final.parquet SHA-256 and row_count are 400000
+when the CLI joins pinned comments on source_record_id
+then stdout includes each accepted manifest digest, wide_rows=400000, wide_columns=16,
+     sort_key=source_record_id ASC, and the wide manifest URI
+
+given a missing or SHA-mismatched feature final.parquet
+when the CLI verifies inputs
+then it raises before writing wide/features.parquet
+
+given the uploaded wide parquet
+when DuckDB describes columns and counts distinct source_record_id
+then columns match the sixteen-name contract, n=uniq=400000, and no llm_toxicity_tier is null
+
+given the same wide table and data_platform/curate/configs/reddit/mirrorview.yaml
+when apply_rules runs
+then curated row count and political_stance x llm_toxicity_tier counts are written
+     under the dataset curated/ stage, in a timestamped run directory
+
+Run from the repo root:
+
+    PYTHONPATH=. python data_platform/curate/consolidate_reddit_llm_campaign.py \\
+        --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079 \\
+        --preprocessed-run 2026_09_03-23:39:28 \\
+        --campaign-id reddit_2026_09_03_233928_llm_features_v1 \\
+        --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/wide/features.parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from data_platform.curate.consolidate import (
+    LLM_CAMPAIGN_FEATURE_NAMES,
+    REDDIT_EXPECTED_WIDE_ROW_COUNT,
+    REDDIT_PREPROCESSED_WIDE_COLUMNS,
+    WIDE_SORT_KEY,
+    build_reddit_llm_campaign_wide_table,
+    reddit_llm_campaign_wide_columns,
+)
+
+
+def parse_args(argv: list[str] | None = None):
+    raise NotImplementedError
+
+
+def verify_feature_manifest(store, feature_name: str, campaign_id: str, dataset_id: str):
+    raise NotImplementedError
+
+
+def download_campaign_inputs(store, args, work_dir: Path):
+    raise NotImplementedError
+
+
+def validate_wide_table(wide) -> None:
+    raise NotImplementedError
+
+
+def curate_mirrorview_dataset(store, wide, args):
+    raise NotImplementedError
+
+
+def upload_wide_artifacts(store, wide, args, preprocessed, feature_inputs, curated):
+    raise NotImplementedError
+
+
+def run_campaign_consolidation(args):
+    raise NotImplementedError
+
+
+def print_result(result) -> None:
+    raise NotImplementedError
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = run_campaign_consolidation(args)
+    print_result(result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/wide_run_report.md
+++ b/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/wide_run_report.md
@@ -1,0 +1,117 @@
+# Wide consolidation and MirrorView curation report
+
+## Approval
+
+The epic manager started this step after all seven S3 `final.parquet` objects were verified at 400000 rows and 0 failed, with Phase B reports committed on stack PRs #242 through #248. The owner said not to merge those PRs first. This step did not call OpenAI or Bedrock. Inputs are the seven `final.parquet` objects from issues #222 through #228.
+
+Feature reports (read-only here; hashes below are S3 bytes, not ETag):
+
+- [`is_news_or_opinion_run_report.md`](is_news_or_opinion_run_report.md) (issue #222, PR #242)
+- [`is_political_run_report.md`](is_political_run_report.md) (issue #223, PR #243)
+- [`is_likely_spam_run_report.md`](is_likely_spam_run_report.md) (issue #224, PR #244)
+- [`is_self_contained_run_report.md`](is_self_contained_run_report.md) (issue #225, PR #245)
+- [`is_structurally_complete_run_report.md`](is_structurally_complete_run_report.md) (issue #226, PR #246)
+- [`political_stance_run_report.md`](political_stance_run_report.md) (issue #227, PR #247)
+- [`llm_toxicity_tiered_run_report.md`](llm_toxicity_tiered_run_report.md) (issue #228, PR #248)
+
+## Pinned identity
+
+| Field | Value |
+|-------|-------|
+| Dataset id | `reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079` |
+| Preprocessed run | `2026_09_03-23:39:28` |
+| Preprocessed row count | 400000 |
+| Campaign id | `reddit_2026_09_03_233928_llm_features_v1` |
+| Join key | `source_record_id` |
+| Sort | `source_record_id ASC` |
+| Wide columns | 16 |
+
+## Inputs
+
+Preprocessed comments SHA-256: `c81ff327c2bc5a612b0f38b9d799e618f9d03ea3d3c4aff2d0f2a5f52a06ea31`
+
+| Feature | Manifest SHA-256 | `final.parquet` SHA-256 | Rows |
+|---------|------------------|-------------------------|------|
+| `is_news_or_opinion` | `bd52ead3736c3c9a6d4a3bb9e0617cc6dcfc200f58513366ed919bcfb25319ac` | `f75e63e66cf95afdc5267a04fa8e2b5b45326e7cba9f12873bb86e296a07d390` | 400000 |
+| `is_political` | `146d8c1e83e414d99e2f6b16e0a0dc6e1be7fbeb90e565f02b956bd9a2849996` | `041802dc9197b0f28bfa91e9f17d0bb8da9f5b02317dd5b78a87b48dc757dece` | 400000 |
+| `is_likely_spam` | `acac3b81c2fa835cc002c3ee76ceaa358c15be9c2353626d054d992967442b9a` | `a2b835f2a2a350a427e9081a6e6d0d43f64b47a252466bd8ac7169de015f2484` | 400000 |
+| `is_self_contained` | `eab5a83e6775d33511f3ed6870f11260a091b9e184a83885249287cf8ff6212e` | `fcddb19da531d013150716341657ba7115844913b63850afe1fd80a01a5d77e5` | 400000 |
+| `is_structurally_complete` | `da58b5082bb6fb07b56644c2b43703d339839fda282041888d7092282f6e2d4e` | `161d85dfb7262bd67b4ae8c60abce9b96d290c52f74e62e5f261cf2289216140` | 400000 |
+| `political_stance` | `4e1f21b2f8e48a529c89f7922f02fe5a32333ca26e4ef423c1d09978a66fb7f9` | `a034021e56646cabb69dc2ba8baf81d1042581cd710edbdd576702b26e801d24` | 400000 |
+| `llm_toxicity_tiered` | `8c555b34fae3621770b379ad0a3174ed1fdf7601e2190ff922c6e51cc2606d66` | `bb0c0dabfc3b759b4c4403c1f2c68e04a2e94c41369de11e971d8d9177ce300c` | 400000 |
+
+Each feature `final.parquet` SHA-256 matched its provenance manifest before the join.
+
+## Wide outputs
+
+| Object | URI | SHA-256 |
+|--------|-----|---------|
+| Wide parquet | `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/wide/features.parquet` | `e83dc0329cf1189eec1c27c6063c64260f191ae40ce24fee3efcd9be2f73df47` |
+| Wide manifest | `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/wide/manifest.json` | `3a01829edf5a4de789968ad10e89f2b9bd1f394aa5951b98443b293591f24087` |
+
+Wide objects are untagged. The join is an inner join on `CAST(source_record_id AS VARCHAR)`. Duplicate feature rows keep the latest `label_timestamp`. Perspective columns are absent. Bluesky post columns (`uri`, `url`, engagement counts) are absent.
+
+Column order:
+
+`comment_fullname`, `record_id`, `author`, `body`, `created_at`, `sync_timestamp`, `text`, `author_handle`, `source_record_id`, `news_or_opinion_category`, `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tier`
+
+## Validation
+
+All checks passed on 2026-09-07 after the consolidate CLI uploaded the wide objects.
+
+| Check | Result |
+|-------|--------|
+| Sixteen columns in contract order | PASS |
+| `wide_rows=400000` and 400000 distinct `source_record_id` | PASS |
+| File order matches `source_record_id ASC` | PASS (`t1_mpxmfe6` … `t1_n0o71e2`) |
+| Nulls on seven label columns | 0 |
+| Missing preprocessed comments after join | 0 |
+| Forbidden columns (`toxicity_prob`, `toxicity_tier`, `label_timestamp`, `run_id`, `is_toxic_tiered`) | absent |
+| Wide parquet SHA-256 matches manifest | PASS |
+| All seven feature manifests linked by SHA-256 | PASS |
+| Wide parquet and manifest untagged | PASS |
+
+## MirrorView curated dataset
+
+The export uses the same dataset-stage layout as local `curate_reddit.py` runs: `curated/<timestamp>/mirrorview.parquet` plus `metadata.json` under `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/`. It is not stored under the campaign `wide/` prefix. Writes went through `RedditStorageManager("curated", dataset_id)`.
+
+Rules file: `data_platform/curate/configs/reddit/mirrorview.yaml` (SHA-256 `62a0ee4f4b8528b7e75382b0ddab3f21857b9f23101f5ebdc5d0926c99aa53ff`). Filters are AND, in YAML order. YAML was not edited.
+
+| Filter | Records before | Records passing |
+|--------|----------------|-----------------|
+| `news_or_opinion_category` eq `opinion` | 400000 | 299283 |
+| `is_political` eq true | 299283 | 248326 |
+| `is_likely_spam` eq false | 248326 | 248184 |
+| `political_stance` in `left`, `right` | 248184 | 100764 |
+| `is_self_contained` eq true | 100764 | 45385 |
+| `is_structurally_complete` eq true | 45385 | 43061 |
+
+**Curated row count: 43061**
+
+| Object | URI | SHA-256 |
+|--------|-----|---------|
+| Curated parquet | `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/curated/2026_09_07-21:47:32/mirrorview.parquet` | `1db34b0f6b5d4bab42e3a3a57306de0397e4478a3906f7aa75e9229bc58d804f` |
+| Curated metadata | `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/curated/2026_09_07-21:47:32/metadata.json` | `740b9e5cb7cc9253a60bb959265fd07cd72afb41b466086130b861c01dfd9886` |
+
+### Row count by political stance × LLM toxicity tier
+
+| political_stance | low | medium | high | total |
+|------------------|-----|--------|------|-------|
+| left | 13423 | 15047 | 641 | 29111 |
+| right | 7998 | 5680 | 272 | 13950 |
+| total | 21421 | 20727 | 913 | 43061 |
+
+## Command
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/curate/consolidate_reddit_llm_campaign.py \
+  --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079 \
+  --preprocessed-run 2026_09_03-23:39:28 \
+  --campaign-id reddit_2026_09_03_233928_llm_features_v1 \
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/wide/features.parquet
+```
+
+Stdout included seven accepted manifest digests, `wide_rows=400000`, `wide_columns=16`, `sort_key=source_record_id ASC`, `curated_rows=43061`, and the stance × toxicity table above.


### PR DESCRIPTION
# Consolidate seven Reddit LLM features and write the MirrorView curated export

Fixes #229

Part of #218

## Summary

Adds `consolidate_reddit_llm_campaign.py` to join seven verified `final.parquet` files to pinned preprocessed comments, upload `wide/features.parquet` with a SHA-256 manifest, and write a MirrorView curated export for dataset `reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079`.

The caller verifies each feature manifest, inner-joins on `source_record_id`, sorts ascending, writes untagged `wide/features.parquet` and `wide/manifest.json`, applies existing MirrorView AND filters, and writes `curated/<timestamp>/mirrorview.parquet` with `metadata.json` under the dataset curated stage.

## Purpose

Analysts need one sixteen-column wide table with no missing labels before MirrorView filters run, so the implementer validates 400,000 unique `source_record_id` rows, applies `reddit/mirrorview.yaml` without changing filter semantics, and commits `reports/wide_run_report.md` with a stance-by-toxicity crosstab.

Out of scope: re-running features, editing YAML semantics, Perspective columns, smoke artifacts, and automated tests.

## Architecture

Components:

- `consolidate_reddit_llm_campaign.py`: CLI entry point. Verifies inputs, orchestrates join, curation, and uploads.
- `consolidate.py`: DuckDB wide join helpers and Reddit sixteen-column contract.
- `apply_rules.py`: loads `mirrorview.yaml` and returns filtered dataframe plus per-step counts.
- `RedditStorageManager`: writes curated parquet and metadata under `curated/<timestamp>/`.
- `CampaignObjectStore`: reads feature inputs and writes wide objects under the campaign prefix.

Existing flow (seven separate feature outputs):

```mermaid
flowchart LR
  subgraph before [Before]
    C[comments.parquet] --> F1[is_news_or_opinion]
    C --> F2[other features]
    F1 --> R1[seven final.parquet files]
    F2 --> R1
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    CLI[consolidate_reddit_llm_campaign.py] --> J[Wide join on source_record_id]
    J --> W[wide/features.parquet]
    J --> M[wide/manifest.json]
    J --> AR[apply_rules mirrorview.yaml]
    AR --> CV[curated/mirrorview.parquet]
    AR --> MD[curated/metadata.json]
  end
```

## Interfaces

### CLI

`PYTHONPATH=. uv run python data_platform/curate/consolidate_reddit_llm_campaign.py`

Flags:

- `--dataset-id`: `reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079`
- `--preprocessed-run`: `2026_09_03-23:39:28`
- `--campaign-id`: `reddit_2026_09_03_233928_llm_features_v1`
- `--output-s3-uri`: full URI ending in `wide/features.parquet`
- `--curate-config`: optional. Defaults to `data_platform/curate/configs/reddit/mirrorview.yaml`

### Data / schema contracts

| Field | Type | Notes |
| ----- | ---- | ----- |
| Wide rows | int | Exactly 400000 |
| Wide columns | sixteen names | Nine preprocessed plus seven labels; see step spec |
| Sort | string | `source_record_id ASC` |
| `wide/manifest.json` | JSON | SHA-256 for wide parquet, preprocessed hash, seven feature manifest links |
| Curated parquet | Parquet | MirrorView-filtered subset of wide rows |
| Curated metadata | JSON | Rules hash, filter step counts, stance by toxicity crosstab |

### Configuration

- `data_platform/curate/configs/reddit/mirrorview.yaml`: locked AND filters. Not edited in the pull request.
- `LAB_AWS_ACCESS_KEY_ID` / `LAB_AWS_ACCESS_KEY_SECRET`: export as standard AWS variables before S3 access.

## How to run

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
uv sync
```

```bash
PYTHONPATH=. uv run python data_platform/curate/consolidate_reddit_llm_campaign.py \
  --dataset-id reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079 \
  --preprocessed-run 2026_09_03-23:39:28 \
  --campaign-id reddit_2026_09_03_233928_llm_features_v1 \
  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/features/reddit_2026_09_03_233928_llm_features_v1/wide/features.parquet
```

Measured on 2026-09-07: seven accepted manifest digests, `wide_rows=400000`, `wide_columns=16`, `sort_key=source_record_id ASC`, `curated_rows=43061`. Wide parquet SHA-256 `e83dc0329cf1189eec1c27c6063c64260f191ae40ce24fee3efcd9be2f73df47`. Curated URI `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/curated/2026_09_07-21:47:32/mirrorview.parquet`. DuckDB validation printed `wide validation ok`.

Plan step: `docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/steps/step11.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for consolidating Reddit campaign data with preprocessed comments and multiple language-model feature datasets into a validated wide table.
  - Added configurable campaign column selection while preserving existing defaults.
  - Added automated input verification, dataset validation, curation, and artifact publishing.
  - Consolidation results now include manifests, integrity hashes, curation metadata, filter outcomes, and summary analysis of political stance and toxicity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
