### PR TITLE
Preprocess the new dated Twitter collection and store it in Git LFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2026-09-08
 
-1. A dated Mirrorview Twitter ingest config and a recent-search run (6,900 unique posts inside the 7-day window) are now in the repo. `posts.csv` is stored in Git LFS. [PR #259](https://github.com/METResearchGroup/mirrorView-task/pull/259)
+1. Twitter preprocess on the 2026-09-07 collection kept 6,408 of 6,900 posts. The preprocessed `posts.csv` is stored in Git LFS. [PR #261](https://github.com/METResearchGroup/mirrorView-task/pull/261)
+2. A dated Mirrorview Twitter ingest config and a recent-search run (6,900 unique posts inside the 7-day window) are now in the repo. `posts.csv` is stored in Git LFS. [PR #259](https://github.com/METResearchGroup/mirrorView-task/pull/259)
 
 ## 2026-09-07
 

--- a/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/metadata.json
+++ b/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/metadata.json
@@ -1,0 +1,15 @@
+{
+  "dataset_id": "twitter_5901767a-e609-46fc-9a17-742516b548f2",
+  "source_raw_run": "raw/2026_09_08-01:37:50",
+  "source_raw_runs": [
+    "raw/2026_09_08-01:37:50"
+  ],
+  "preprocess_timestamp": "2026_09_08-01:48:08",
+  "row_counts": {
+    "input": 6900,
+    "output": 6408
+  },
+  "files": {
+    "posts": "posts.csv"
+  }
+}

--- a/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/posts.csv
+++ b/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/posts.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0461a0dc7ac5ecf1c5699fa893013dc7165af482a5347067e413bf4315ffdbd2
+size 2604868

--- a/docs/plans/2026-09-08_preprocess_twitter_lfs_dd2dbb/plan.md
+++ b/docs/plans/2026-09-08_preprocess_twitter_lfs_dd2dbb/plan.md
@@ -1,0 +1,56 @@
+# Preprocess the dated Twitter collection and store it in Git LFS
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Operators need a preprocessed copy of the 2026-09-07 Mirrorview Twitter collection so later feature work can load a stable csv. This pull request runs the existing Twitter preprocess command on local disk, then commits `posts.csv` through Git LFS and `metadata.json` as an ordinary git file. Feature labeling, campaign YAML, and S3 stay out of the pull request.
+
+## Happy flow
+
+An operator sets local storage, runs the existing preprocess command with the locked dataset id, and gets a timestamped preprocessed folder. Git tracks the csv through Git LFS.
+
+```mermaid
+flowchart TD
+    A[Confirm raw run is completed] --> B[Set local storage backend]
+    B --> C[Run Twitter preprocess]
+    C --> D[Check format, row counts, and non-empty text]
+    D --> E[Commit posts.csv as Git LFS]
+```
+
+## Approach
+
+Reuse the existing Twitter preprocess entry point. Do not add preprocess Python. Do not pass a YAML config. Keep `dataset.json` format as csv. Write the campaign id from the preprocess timestamp so the next child can copy it.
+
+## Decisions
+
+- Dataset identity stays `twitter_5901767a-e609-46fc-9a17-742516b548f2`.
+- Storage backend must be `local`. Unset storage would look on S3, and this collection is not on S3.
+- Do not pass `--config`. There is no Twitter preprocess YAML.
+- `dataset.json` format stays `csv`. The preprocessed records file is `posts.csv`.
+- Row count is `row_counts.output`. It may be below 6900 because validators, prior-preprocessed skips, and previously used stimuli drop rows. Do not force 6374.
+- Campaign id is `twitter_` plus the preprocess timestamp with `-` changed to `_` and `:` removed, then `_llm_features_v1`.
+- Git LFS stores preprocessed `posts.csv`. `metadata.json` is an ordinary git file.
+- The coding phases add no new Python product code. Phase 4 is the given, when, and then checks in the step files. Do not add pytest.
+
+## Steps
+
+### Step 1: Confirm the completed raw run
+
+Confirm the locked raw folder is present, `sync_status` is completed, and local storage is set before preprocess runs. See [steps/step1.md](steps/step1.md).
+
+### Step 2: Run preprocess and commit Git LFS files
+
+Run the locked preprocess command, check format and row counts, derive the campaign id, and commit `posts.csv` through Git LFS with `metadata.json` as an ordinary git file. See [steps/step2.md](steps/step2.md).
+
+## What "done" looks like
+
+1. A preprocessed run folder exists under the locked dataset with `posts.csv` and `metadata.json`.
+2. `dataset.json` format is `csv`.
+3. Preprocessed `posts.csv` is Git LFS. `metadata.json` is an ordinary git file.
+4. The pull request records `preprocessed_run`, `row_count`, derived `campaign_id`, and `format=csv`.
+5. No preprocess Python, ingest, feature, curate, or S3 work ran.

--- a/docs/plans/2026-09-08_preprocess_twitter_lfs_dd2dbb/steps/step1.md
+++ b/docs/plans/2026-09-08_preprocess_twitter_lfs_dd2dbb/steps/step1.md
@@ -1,0 +1,99 @@
+# Step 1: Confirm the completed raw run
+
+## Scope
+
+- **Caller:** `data_platform/preprocessing/preprocess_twitter.py` `main`, which calls `preprocess_records`. Step 1 does not run the caller. It only confirms the raw input the caller will load.
+- **Task:** Confirm the locked raw run is present and completed, and that local storage is set, before preprocess writes files.
+- **Out of scope:** Running preprocess, changing preprocess Python, ingest, features, curate, S3, adding pytest.
+
+## Files to inspect (read-only)
+
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/dataset.json` (format must stay `csv`)
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/2026_09_08-01:37:50/metadata.json` (must be `sync_status=completed`, `row_count=6900`)
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/2026_09_08-01:37:50/posts.csv` (Git LFS csv already on this stack)
+- `/workspace/data_platform/preprocessing/preprocess_twitter.py` (caller. Do not edit.)
+- `/workspace/.gitattributes` (Step 1 of the ingest child already marks this dataset csv as Git LFS. Do not edit.)
+
+## Files allowed to change
+
+None in this step. Confirmation only.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/preprocessing/**`
+- `/workspace/data_platform/ingestion/**`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/.gitignore`
+- `/workspace/.gitattributes`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/**`
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/**`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/**`
+- Any file under `/workspace/tests/`
+- Any file outside the allowed list for this pull request
+
+## Locked contracts
+
+Raw run path:
+
+```text
+data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/2026_09_08-01:37:50
+```
+
+`sync_status` is `completed`. Raw `row_count` is `6900`. `dataset.json` format is `csv`. Username is empty.
+
+Storage must be local:
+
+```bash
+export DATA_PLATFORM_STORAGE_BACKEND=local
+```
+
+Do not upload to S3 in this child.
+
+## Given / when / then (Phase 4, no new pytest)
+
+```text
+given the locked dataset from the ingest child
+when dataset.json and the raw run metadata are read
+then format is csv
+and sync_status is completed
+and row_count is 6900
+and DATA_PLATFORM_STORAGE_BACKEND is local
+```
+
+## Exact commands and expected output
+
+```bash
+export DATA_PLATFORM_STORAGE_BACKEND=local
+python - <<'PY'
+from pathlib import Path
+import json
+dataset_id = "twitter_5901767a-e609-46fc-9a17-742516b548f2"
+root = Path("data_platform/data/twitter") / dataset_id
+dataset = json.loads((root / "dataset.json").read_text())
+assert dataset.get("format") == "csv", dataset
+run_dir = root / "raw" / "2026_09_08-01:37:50"
+meta = json.loads((run_dir / "metadata.json").read_text())
+assert meta["sync_status"] == "completed", meta["sync_status"]
+assert int(meta["row_count"]) == 6900, meta["row_count"]
+assert (run_dir / "posts.csv").is_file()
+print("raw_run=2026_09_08-01:37:50")
+print("sync_status=completed")
+print("row_count=6900")
+print("format=csv")
+PY
+```
+
+Expected: `sync_status=completed`, `row_count=6900`, `format=csv`.
+
+## Pass / fail
+
+The step passes when the locked raw run is completed with 6900 rows, format is csv, and local storage is set.
+
+The step fails when any item below is true.
+
+- `sync_status` is not `completed`
+- raw `row_count` is not 6900
+- `dataset.json` format is not `csv`
+- `DATA_PLATFORM_STORAGE_BACKEND` is unset or is not `local`
+- preprocess Python changed

--- a/docs/plans/2026-09-08_preprocess_twitter_lfs_dd2dbb/steps/step2.md
+++ b/docs/plans/2026-09-08_preprocess_twitter_lfs_dd2dbb/steps/step2.md
@@ -1,0 +1,169 @@
+# Step 2: Run preprocess and commit Git LFS files
+
+## Scope
+
+- **Caller:** `data_platform/preprocessing/preprocess_twitter.py` `main`, which calls `preprocess_records`.
+- **Task:** Run that CLI once with local storage, then commit preprocessed `posts.csv` through Git LFS and `metadata.json` as an ordinary git file. Record `preprocessed_run`, `row_count`, and derived `campaign_id`.
+- **Out of scope:** Changing preprocess Python, ingest, features, curate, S3 upload, converting csv to parquet, changing `dataset.json` format, labeling posts, adding pytest.
+
+Stdout includes:
+
+```text
+preprocess_records: kept {kept} of {input_count} (skipped {skipped} already in a prior preprocessed run, skipped {skipped_stimuli} already used as stimuli) -> {output_dir}
+```
+
+`{output_dir}` is `data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/`.
+
+## Files to inspect (read-only)
+
+- `/workspace/data_platform/preprocessing/preprocess_twitter.py` (`--dataset-id` only. Do not edit.)
+- `/workspace/data_platform/preprocessing/runner.py` (print line and `metadata.json` shape. Do not edit.)
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/dataset.json`
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/2026_09_08-01:37:50/`
+- `/workspace/.gitattributes` (already marks this dataset csv as Git LFS. Do not edit.)
+
+## Files allowed to change
+
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/dataset.json` only if preprocess rewrites it and format stays `csv`
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/posts.csv`
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/metadata.json`
+- `/workspace/CHANGELOG.md`
+
+`{preprocessed_run}` is created at runtime. Do not invent it.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/preprocessing/**`
+- `/workspace/data_platform/ingestion/**`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/data_platform/ingestion/configs/twitter/mirrorview_2026-09-07.yaml`
+- `/workspace/.gitignore`
+- `/workspace/.gitattributes`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/**`
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/**`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/**`
+- Any file under `/workspace/tests/`
+- Any file outside the allowed list
+
+## Locked contracts
+
+```bash
+export DATA_PLATFORM_STORAGE_BACKEND=local
+PYTHONPATH=. uv run python data_platform/preprocessing/preprocess_twitter.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2
+```
+
+Do not pass a preprocess YAML. Do not pass `--config`.
+
+`dataset.json` format stays `csv`. Preprocessed records filename is `posts.csv`.
+
+`metadata.json` must include `dataset_id`, `preprocess_timestamp`, and `row_counts.output`. `preprocess_timestamp` equals the run folder name.
+
+Campaign id for later children:
+
+```text
+twitter_{preprocess_timestamp with '-' -> '_' and ':' removed}_llm_features_v1
+```
+
+Row count is `row_counts.output`. It may be below the raw row count because validators, prior-preprocessed skips, and previously used stimuli drop rows. That lower count is the campaign size. Do not force 6374.
+
+Git LFS must store preprocessed `posts.csv`. `metadata.json` is an ordinary git file.
+
+Do not upload to S3.
+
+## Given / when / then (Phase 4, no new pytest)
+
+```text
+given the completed raw run and local storage
+when PYTHONPATH=. uv run python data_platform/preprocessing/preprocess_twitter.py --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2
+then stdout includes preprocess_records: kept {kept} of {input_count} ... -> {output_dir}
+and exit code is 0
+
+given that preprocessed run
+when dataset.json, metadata.json, and posts.csv are checked
+then format is csv
+and preprocess_timestamp equals the run folder name
+and csv row count equals row_counts.output
+and every text cell is non-empty
+and git check-attr filter on posts.csv prints filter: lfs
+```
+
+## Exact commands and expected output
+
+Run preprocess from the repo root with `PYTHONPATH=.` and local storage.
+
+```bash
+export DATA_PLATFORM_STORAGE_BACKEND=local
+PYTHONPATH=. uv run python data_platform/preprocessing/preprocess_twitter.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2
+```
+
+Expected stdout matches `preprocess_records: kept {kept} of {input_count} ... -> {output_dir}` and exit 0.
+
+Then:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import csv, json
+dataset_id = "twitter_5901767a-e609-46fc-9a17-742516b548f2"
+root = Path("data_platform/data/twitter") / dataset_id
+dataset = json.loads((root / "dataset.json").read_text())
+assert dataset.get("format") == "csv", dataset
+pre_root = root / "preprocessed"
+runs = sorted(p for p in pre_root.iterdir() if p.is_dir())
+assert runs, f"no preprocessed runs under {pre_root}"
+run_dir = runs[-1]
+meta = json.loads((run_dir / "metadata.json").read_text())
+assert meta["dataset_id"] == dataset_id
+assert meta["preprocess_timestamp"] == run_dir.name
+row_count = int(meta["row_counts"]["output"])
+assert row_count > 0
+posts = run_dir / "posts.csv"
+assert posts.is_file()
+with posts.open(newline="", encoding="utf-8") as handle:
+    rows = list(csv.DictReader(handle))
+assert len(rows) == row_count, (len(rows), row_count)
+assert all(row.get("text") for row in rows)
+campaign_id = (
+    "twitter_"
+    + run_dir.name.replace("-", "_").replace(":", "")
+    + "_llm_features_v1"
+)
+print(f"preprocessed_run={run_dir.name}")
+print(f"row_count={row_count}")
+print(f"campaign_id={campaign_id}")
+print("format=csv")
+PY
+```
+
+Expected: prints `preprocessed_run`, `row_count`, derived `campaign_id`, and `format=csv`.
+
+```bash
+git add \
+  data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/dataset.json \
+  data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/posts.csv \
+  data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/metadata.json
+git check-attr filter -- data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/{preprocessed_run}/posts.csv
+git lfs ls-files | grep twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed
+```
+
+Expected: `filter: lfs` for preprocessed `posts.csv`.
+
+The implementation pull request body must include `preprocessed_run`, `row_count`, derived `campaign_id`, `format=csv`, `Fixes #253`, and `Part of #251`.
+
+Do not add pytest.
+
+## Pass / fail
+
+The step passes when preprocess writes `posts.csv` and `metadata.json` under the new dataset, format stays `csv`, `posts.csv` is Git LFS, and the pull request records run timestamp, row count, and derived campaign id.
+
+The step fails when any item below is true.
+
+- preprocess Python changed
+- `dataset.json` format is not `csv`
+- `posts.csv` is not Git LFS
+- S3 upload ran
+- a new pytest file was added
+- row count was forced to 6374


### PR DESCRIPTION
# Preprocess the new dated Twitter collection and store it in Git LFS

Fixes #253
Part of #251

## Summary

Adds a preprocessed csv of the 2026-09-07 Mirrorview Twitter collection. Operators run the existing Twitter preprocess command on local disk and get a Git LFS `posts.csv` plus an ordinary `metadata.json` file.

## Purpose

The next Mirrorview Twitter campaign needs a filtered, standardized table from the new dated ingest. Feature labeling, campaign YAML, and S3 copy stay out of this pull request.

## Architecture

Components:

- `preprocess_twitter.py` is the existing preprocess entrypoint. It is unchanged.
- Local disk is the storage backend. Unset storage would look on S3, and this collection is not on S3.
- Local Git LFS stores preprocessed `posts.csv`. Ordinary git stores `metadata.json`.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    C1[Operator] --> R1[raw posts.csv]
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    C2[Operator] --> P[preprocess_twitter.py]
    P --> R2[raw posts.csv]
    P --> O[preprocessed posts.csv]
  end
```

## Interfaces

### Configuration

- `DATA_PLATFORM_STORAGE_BACKEND=local` is required
- `--dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2`
- No `--config`
- No Twitter preprocess YAML

### Data / schema contracts

| Field | Value |
| ----- | ----- |
| dataset_id | twitter_5901767a-e609-46fc-9a17-742516b548f2 |
| format | csv |
| raw run | data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/raw/2026_09_08-01:37:50 |
| preprocessed_run | 2026_09_08-01:48:08 |
| row_count | 6408 |
| campaign_id | twitter_2026_09_08_014808_llm_features_v1 |
| Git LFS | preprocessed posts.csv |
| ordinary git | metadata.json |

Raw input was 6900 completed posts. Preprocess kept 6408. It skipped 0 already-preprocessed rows and 0 previously used stimuli. Validators dropped the rest. Do not treat 6374 as the expected size.

`dataset.json` format stays `csv`. The records file is `posts.csv`.

Campaign id for later children is `twitter_` plus `preprocessed_run` with `-` changed to `_` and `:` removed, then `_llm_features_v1`.

## How to run

From the repo root. Set `DATA_PLATFORM_STORAGE_BACKEND=local` so preprocess reads the Git LFS files instead of S3.

```bash
export DATA_PLATFORM_STORAGE_BACKEND=local
PYTHONPATH=. uv run python data_platform/preprocessing/preprocess_twitter.py \
  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2
```

Expected: `preprocess_records: kept {kept} of {input_count} ... -> .../preprocessed/{preprocessed_run}` and exit 0.

Plan: `docs/plans/2026-09-08_preprocess_twitter_lfs_dd2dbb/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added metadata for the Twitter dataset, including source information, preprocessing time, input and output record counts, and the associated posts data file.
  - Improved dataset traceability and usability for consumers reviewing processing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->