### PR TITLE
Add campaign YAML for the new collection, unlock the campaign loader, copy posts.csv to S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 2026-09-08
 
-1. Twitter preprocess on the 2026-09-07 collection kept 6,408 of 6,900 posts. The preprocessed `posts.csv` is stored in Git LFS. [PR #261](https://github.com/METResearchGroup/mirrorView-task/pull/261)
-2. A dated Mirrorview Twitter ingest config and a recent-search run (6,900 unique posts inside the 7-day window) are now in the repo. `posts.csv` is stored in Git LFS. [PR #259](https://github.com/METResearchGroup/mirrorView-task/pull/259)
+1. The 2026-09-07 Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_08_014808_llm_features_v1` for 6,408 posts, and the 2026-09-05 campaign still loads. [PR #263](https://github.com/METResearchGroup/mirrorView-task/pull/263)
+2. Twitter preprocess on the 2026-09-07 collection kept 6,408 of 6,900 posts. The preprocessed `posts.csv` is stored in Git LFS. [PR #261](https://github.com/METResearchGroup/mirrorView-task/pull/261)
+3. A dated Mirrorview Twitter ingest config and a recent-search run (6,900 unique posts inside the 7-day window) are now in the repo. `posts.csv` is stored in Git LFS. [PR #259](https://github.com/METResearchGroup/mirrorView-task/pull/259)
 
 ## 2026-09-07
 

--- a/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/s3_preprocessed_inventory.json
+++ b/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/s3_preprocessed_inventory.json
@@ -1,0 +1,16 @@
+{
+  "bucket": "mirrorview-experimental-artifacts",
+  "region": "us-east-2",
+  "dataset_id": "twitter_5901767a-e609-46fc-9a17-742516b548f2",
+  "preprocessed_run": "2026_09_08-01:48:08",
+  "uploaded_at": "2026_09_08-01:59:38",
+  "object_count": 1,
+  "objects": [
+    {
+      "repo_relative_path": "data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/posts.csv",
+      "s3_key": "data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/posts.csv",
+      "bytes": 2604868,
+      "sha256": "0461a0dc7ac5ecf1c5699fa893013dc7165af482a5347067e413bf4315ffdbd2"
+    }
+  ]
+}

--- a/data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml
+++ b/data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml
@@ -1,0 +1,16 @@
+campaign_id: twitter_2026_09_08_014808_llm_features_v1
+platform: twitter
+dataset_id: twitter_5901767a-e609-46fc-9a17-742516b548f2
+preprocessed_run: "2026_09_08-01:48:08"
+row_count: 6408
+batch_size: 2000
+engine_type: openai
+model_id: gpt-5.4-nano
+features:
+  - is_news_or_opinion
+  - is_political
+  - is_likely_spam
+  - is_self_contained
+  - is_structurally_complete
+  - political_stance
+  - llm_toxicity_tiered

--- a/data_platform/generate_features/twitter_campaign_config.py
+++ b/data_platform/generate_features/twitter_campaign_config.py
@@ -1,28 +1,57 @@
-"""Load the Twitter LLM campaign YAML for one locked campaign id."""
+"""Load a Twitter LLM campaign YAML by scanning the twitter configs directory."""
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from data_platform.utils.config_paths import load_yaml_config
 from lib.constants import REPO_ROOT
 
-ACCEPTED_CAMPAIGN_ID = "twitter_2026_09_06_192847_llm_features_v1"
-CAMPAIGN_YAML_PATH = (
-    REPO_ROOT
-    / "data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml"
+TWITTER_CAMPAIGN_CONFIG_DIR = (
+    REPO_ROOT / "data_platform/generate_features/configs/twitter"
 )
+CAMPAIGN_YAML_GLOB = "*.yaml"
+UNSUPPORTED_CAMPAIGN_ID_PREFIX = "unsupported twitter campaign id: "
 
 
 def load_twitter_campaign_config(campaign_id: str) -> dict[str, Any]:
-    """Return the campaign YAML for the locked Twitter campaign id.
+    """Return the campaign YAML mapping whose campaign_id matches.
+
+    Parameters
+    ----------
+    campaign_id
+        Campaign id stored on a Twitter campaign YAML file.
+
+    Returns
+    -------
+    dict[str, Any]
+        The YAML mapping for that campaign.
 
     Raises
     ------
     ValueError
-        If ``campaign_id`` is not the accepted Twitter campaign id. The
-        message names the rejected id.
+        If no YAML matches, or if two files share the same campaign id.
+        A missing match uses the prefix ``unsupported twitter campaign id:``.
     """
-    if campaign_id != ACCEPTED_CAMPAIGN_ID:
-        raise ValueError(f"unsupported twitter campaign id: {campaign_id}")
-    return load_yaml_config(CAMPAIGN_YAML_PATH)
+    matches = _matching_campaign_configs(campaign_id)
+    if len(matches) > 1:
+        raise ValueError(f"duplicate twitter campaign id: {campaign_id}")
+    if not matches:
+        raise ValueError(f"{UNSUPPORTED_CAMPAIGN_ID_PREFIX}{campaign_id}")
+    return matches[0]
+
+
+def _matching_campaign_configs(campaign_id: str) -> list[dict[str, Any]]:
+    """Return YAML mappings under the Twitter config dir with this campaign id."""
+    matches: list[dict[str, Any]] = []
+    for yaml_path in _twitter_campaign_yaml_paths():
+        mapping = load_yaml_config(yaml_path)
+        if mapping.get("campaign_id") == campaign_id:
+            matches.append(mapping)
+    return matches
+
+
+def _twitter_campaign_yaml_paths() -> list[Path]:
+    """Return Twitter campaign YAML files in sorted path order."""
+    return sorted(TWITTER_CAMPAIGN_CONFIG_DIR.glob(CAMPAIGN_YAML_GLOB))

--- a/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
@@ -43,17 +43,22 @@ class TwitterPreprocessedS3Args:
     preprocessed_run: str
 
 
-def parse_args(argv: Sequence[str]) -> TwitterPreprocessedS3Args:
+def parse_args(argv: Sequence[str], description: str) -> TwitterPreprocessedS3Args:
     """Parse required ``--dataset-id`` and ``--preprocessed-run``.
+
+    Parameters
+    ----------
+    argv
+        Command-line tokens after the program name.
+    description
+        Argparse program description for this entry point.
 
     Raises
     ------
     SystemExit
         If either flag is missing. Exit code is non-zero.
     """
-    parser = argparse.ArgumentParser(
-        description="Copy one Twitter preprocessed posts.csv from Git LFS to S3."
-    )
+    parser = argparse.ArgumentParser(description=description)
     parser.add_argument("--dataset-id", required=True)
     parser.add_argument("--preprocessed-run", required=True)
     parsed = parser.parse_args(argv)
@@ -209,9 +214,12 @@ def upload_scoped_paths(s3: S3, paths: Sequence[str]) -> list[dict]:
     return rows
 
 
+MIGRATE_DESCRIPTION = "Copy one Twitter preprocessed posts.csv from Git LFS to S3."
+
+
 def main(argv: Sequence[str]) -> None:
     """Pull LFS, upload the scoped csv, write inventory, and print the object count."""
-    args = parse_args(argv)
+    args = parse_args(argv, MIGRATE_DESCRIPTION)
     paths = scoped_repo_relative_paths(args.dataset_id, args.preprocessed_run)
     run_git_lfs_pull(paths)
     rows = upload_scoped_paths(S3(BUCKET, region_name=REGION), paths)

--- a/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+++ b/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
@@ -1,18 +1,23 @@
-"""Copy the pinned Twitter preprocessed posts csv from Git LFS to S3.
+"""Copy a Twitter preprocessed posts csv from Git LFS to S3.
 
 Run from the repo root:
 
     export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
     export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-    PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+    PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py \\
+        --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \\
+        --preprocessed-run 2026_09_08-01:48:08
 """
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import json
 import subprocess
+import sys
 from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 from lib.aws.s3 import S3
@@ -21,19 +26,62 @@ from lib.timestamp_utils import get_current_timestamp
 
 BUCKET = "mirrorview-experimental-artifacts"
 REGION = "us-east-2"
-DATASET_ID = "twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547"
-PREPROCESSED_RUN = "2026_09_06-19:28:47"
 EXPECTED_OBJECT_COUNT = 1
 LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1"
 DUPLICATE_PREFIX = "data_platform/data_platform/"
+TWITTER_DATA_PREFIX = "data_platform/data/twitter"
+PREPROCESSED_DIRNAME = "preprocessed"
+POSTS_CSV_NAME = "posts.csv"
+INVENTORY_FILENAME = "s3_preprocessed_inventory.json"
 
-DATASET_ROOT = f"data_platform/data/twitter/{DATASET_ID}"
-POSTS_CSV_PATH = f"{DATASET_ROOT}/preprocessed/{PREPROCESSED_RUN}/posts.csv"
-INVENTORY_PATH = REPO_ROOT / DATASET_ROOT / "s3_preprocessed_inventory.json"
-LFS_INCLUDE_PATTERNS: tuple[str, ...] = (POSTS_CSV_PATH,)
+
+@dataclass(frozen=True)
+class TwitterPreprocessedS3Args:
+    """Required dataset id and preprocessed run for migrate and verify."""
+
+    dataset_id: str
+    preprocessed_run: str
 
 
-def scoped_repo_relative_paths() -> list[str]:
+def parse_args(argv: Sequence[str]) -> TwitterPreprocessedS3Args:
+    """Parse required ``--dataset-id`` and ``--preprocessed-run``.
+
+    Raises
+    ------
+    SystemExit
+        If either flag is missing. Exit code is non-zero.
+    """
+    parser = argparse.ArgumentParser(
+        description="Copy one Twitter preprocessed posts.csv from Git LFS to S3."
+    )
+    parser.add_argument("--dataset-id", required=True)
+    parser.add_argument("--preprocessed-run", required=True)
+    parsed = parser.parse_args(argv)
+    return TwitterPreprocessedS3Args(
+        dataset_id=parsed.dataset_id,
+        preprocessed_run=parsed.preprocessed_run,
+    )
+
+
+def dataset_root_relative(dataset_id: str) -> str:
+    """Return the repo-relative Twitter dataset root for ``dataset_id``."""
+    return f"{TWITTER_DATA_PREFIX}/{dataset_id}"
+
+
+def posts_csv_relative_path(dataset_id: str, preprocessed_run: str) -> str:
+    """Return the repo-relative preprocessed ``posts.csv`` path."""
+    return (
+        f"{dataset_root_relative(dataset_id)}/"
+        f"{PREPROCESSED_DIRNAME}/{preprocessed_run}/{POSTS_CSV_NAME}"
+    )
+
+
+def inventory_path_for(dataset_id: str) -> Path:
+    """Return the inventory JSON path under the Twitter dataset root."""
+    return REPO_ROOT / dataset_root_relative(dataset_id) / INVENTORY_FILENAME
+
+
+def scoped_repo_relative_paths(dataset_id: str, preprocessed_run: str) -> list[str]:
     """Return the locked upload paths. Must have length EXPECTED_OBJECT_COUNT.
 
     Raises
@@ -42,7 +90,7 @@ def scoped_repo_relative_paths() -> list[str]:
         If the list does not have exactly ``EXPECTED_OBJECT_COUNT`` entries
         or the path is missing on disk.
     """
-    paths = [POSTS_CSV_PATH]
+    paths = [posts_csv_relative_path(dataset_id, preprocessed_run)]
     if len(paths) != EXPECTED_OBJECT_COUNT:
         raise RuntimeError(f"expected {EXPECTED_OBJECT_COUNT} scoped paths, built {len(paths)}")
     missing = [path for path in paths if not (REPO_ROOT / path).is_file()]
@@ -132,13 +180,18 @@ def upload_and_verify(s3: S3, repo_relative_path: str, data: bytes) -> dict:
     }
 
 
-def write_inventory(rows: list[dict], path: Path) -> None:
+def write_inventory(
+    rows: list[dict],
+    path: Path,
+    dataset_id: str,
+    preprocessed_run: str,
+) -> None:
     """Write inventory JSON including bucket, region, dataset_id, and preprocessed_run."""
     inventory = {
         "bucket": BUCKET,
         "region": REGION,
-        "dataset_id": DATASET_ID,
-        "preprocessed_run": PREPROCESSED_RUN,
+        "dataset_id": dataset_id,
+        "preprocessed_run": preprocessed_run,
         "uploaded_at": get_current_timestamp(),
         "object_count": len(rows),
         "objects": sorted(rows, key=lambda row: row["repo_relative_path"]),
@@ -146,19 +199,30 @@ def write_inventory(rows: list[dict], path: Path) -> None:
     path.write_text(json.dumps(inventory, indent=2) + "\n")
 
 
-def main() -> None:
-    """Pull LFS, upload the scoped csv, write inventory, and print the object count."""
-    paths = scoped_repo_relative_paths()
-    run_git_lfs_pull(LFS_INCLUDE_PATTERNS)
-    s3 = S3(BUCKET, region_name=REGION)
+def upload_scoped_paths(s3: S3, paths: Sequence[str]) -> list[dict]:
+    """Upload each scoped path and print the verified S3 URI."""
     rows = []
     for path in paths:
         row = upload_and_verify(s3, path, read_scoped_bytes(path))
         print(f"verified s3://{BUCKET}/{row['s3_key']} ({row['bytes']} bytes)")
         rows.append(row)
-    write_inventory(rows, INVENTORY_PATH)
+    return rows
+
+
+def main(argv: Sequence[str]) -> None:
+    """Pull LFS, upload the scoped csv, write inventory, and print the object count."""
+    args = parse_args(argv)
+    paths = scoped_repo_relative_paths(args.dataset_id, args.preprocessed_run)
+    run_git_lfs_pull(paths)
+    rows = upload_scoped_paths(S3(BUCKET, region_name=REGION), paths)
+    write_inventory(
+        rows,
+        inventory_path_for(args.dataset_id),
+        args.dataset_id,
+        args.preprocessed_run,
+    )
     print(f"uploaded {len(rows)} object")
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])

--- a/data_platform/scripts/verify_twitter_preprocessed_s3.py
+++ b/data_platform/scripts/verify_twitter_preprocessed_s3.py
@@ -27,6 +27,8 @@ from data_platform.scripts.migrate_twitter_preprocessed_to_s3 import (
 )
 from lib.aws.s3 import S3
 
+VERIFY_DESCRIPTION = "Check a Twitter preprocessed S3 inventory against the bucket."
+
 
 def verify_inventory(inventory: dict, s3: S3) -> list[str]:
     """Re-download every inventory object and report length or SHA-256 mismatches.
@@ -78,7 +80,7 @@ def fail_if_inventory_header_invalid(inventory: dict, preprocessed_run: str) -> 
 
 def main(argv: Sequence[str]) -> None:
     """Load the inventory, confirm bucket and count, and print OK or FAIL."""
-    args = parse_args(argv)
+    args = parse_args(argv, VERIFY_DESCRIPTION)
     inventory = json.loads(inventory_path_for(args.dataset_id).read_text())
     fail_if_inventory_header_invalid(inventory, args.preprocessed_run)
     objects = inventory["objects"]

--- a/data_platform/scripts/verify_twitter_preprocessed_s3.py
+++ b/data_platform/scripts/verify_twitter_preprocessed_s3.py
@@ -1,24 +1,28 @@
-"""Check the Twitter preprocessed S3 inventory against the bucket.
+"""Check a Twitter preprocessed S3 inventory against the bucket.
 
 Run from the repo root:
 
     export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
     export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
-    PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py
+    PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py \\
+        --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \\
+        --preprocessed-run 2026_09_08-01:48:08
 """
 
 from __future__ import annotations
 
 import json
+import sys
+from collections.abc import Sequence
 
 from botocore.exceptions import ClientError
 
 from data_platform.scripts.migrate_twitter_preprocessed_to_s3 import (
     BUCKET,
     EXPECTED_OBJECT_COUNT,
-    INVENTORY_PATH,
-    PREPROCESSED_RUN,
     REGION,
+    inventory_path_for,
+    parse_args,
     sha256_hex,
 )
 from lib.aws.s3 import S3
@@ -49,28 +53,35 @@ def verify_inventory(inventory: dict, s3: S3) -> list[str]:
     return problems
 
 
-def main() -> None:
-    """Load the inventory, confirm bucket and count, and print OK or FAIL."""
-    inventory = json.loads(INVENTORY_PATH.read_text())
-    objects = inventory["objects"]
+def fail_if_inventory_header_invalid(inventory: dict, preprocessed_run: str) -> None:
+    """Exit 1 when bucket, region, run, or object count do not match the contract."""
     if inventory["bucket"] != BUCKET or inventory["region"] != REGION:
         print(
             f"FAIL: inventory targets {inventory['bucket']} in {inventory['region']}, "
             f"expected {BUCKET} in {REGION}"
         )
         raise SystemExit(1)
-    if inventory.get("preprocessed_run") != PREPROCESSED_RUN:
+    if inventory.get("preprocessed_run") != preprocessed_run:
         print(
             f"FAIL: inventory preprocessed_run {inventory.get('preprocessed_run')!r}, "
-            f"expected {PREPROCESSED_RUN!r}"
+            f"expected {preprocessed_run!r}"
         )
         raise SystemExit(1)
+    objects = inventory["objects"]
     if inventory["object_count"] != EXPECTED_OBJECT_COUNT or len(objects) != EXPECTED_OBJECT_COUNT:
         print(
             f"FAIL: inventory lists {inventory['object_count']} objects with "
             f"{len(objects)} rows, expected {EXPECTED_OBJECT_COUNT}"
         )
         raise SystemExit(1)
+
+
+def main(argv: Sequence[str]) -> None:
+    """Load the inventory, confirm bucket and count, and print OK or FAIL."""
+    args = parse_args(argv)
+    inventory = json.loads(inventory_path_for(args.dataset_id).read_text())
+    fail_if_inventory_header_invalid(inventory, args.preprocessed_run)
+    objects = inventory["objects"]
     problems = verify_inventory(inventory, S3(BUCKET, region_name=REGION))
     if problems:
         for problem in problems:
@@ -81,4 +92,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])

--- a/docs/plans/2026-09-08_campaign_yaml_loader_s3_dbd325/plan.md
+++ b/docs/plans/2026-09-08_campaign_yaml_loader_s3_dbd325/plan.md
@@ -1,0 +1,69 @@
+# Add campaign YAML, unlock the Twitter campaign loader, and copy posts.csv to S3
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Campaign workers need the 2026-09-07 preprocessed csv on S3, a campaign YAML for that collection, and a loader that finds the YAML by campaign id. This pull request ships that product code. It does not label the 6,408 posts.
+
+## Happy flow
+
+An operator passes dataset id and preprocessed run to the migrate command. The command uploads one `posts.csv` object, writes a SHA-256 inventory, and the campaign loader then returns the new YAML by campaign id while the 2026-09-05 campaign still loads.
+
+```mermaid
+flowchart TD
+    A[Require dataset id and preprocessed run] --> B[Refuse Git LFS pointer text]
+    B --> C[Upload one posts.csv object]
+    C --> D[Write SHA-256 inventory]
+    D --> E[Add 2026-09-07 campaign YAML]
+    E --> F[Load campaign by scanning Twitter YAML files]
+    F --> G[Old campaign id still loads]
+```
+
+## Approach
+
+Reuse the existing migrate, verify, and campaign loader entry points. Replace the pinned 2026-09-05 dataset and run with required command flags. Add one new YAML. Scan the Twitter campaign config directory instead of locking a single file. Skip disposable smoke. Skip pytest.
+
+## Decisions
+
+- Dataset identity is `twitter_5901767a-e609-46fc-9a17-742516b548f2`.
+- Preprocessed run is `2026_09_08-01:48:08`.
+- Row count is `6408`.
+- Campaign id is `twitter_2026_09_08_014808_llm_features_v1`.
+- Migrate and verify require `--dataset-id` and `--preprocessed-run`. They must not default to the 2026-09-05 dataset. Missing flags must exit non-zero.
+- Upload only `posts.csv` for that dataset and run. Expected object count is 1. Hash is SHA-256 of bytes. Never use S3 ETag. Abort if the file still starts with Git LFS pointer text.
+- Inventory path is `data_platform/data/twitter/{dataset_id}/s3_preprocessed_inventory.json`.
+- Do not edit the 2026-09-05 campaign YAML. That campaign id must still load with row count 6374.
+- Loader scans `data_platform/generate_features/configs/twitter/*.yaml`. Two files with the same campaign id raise. No match raises with `unsupported twitter campaign id: {campaign_id}`.
+- Do not label 6408 rows. Do not write primary batches. Do not add pytest. Official seven-feature smoke is child #255.
+
+## Steps
+
+### Step 1: Require dataset id and preprocessed run on migrate and verify
+
+Add required `--dataset-id` and `--preprocessed-run` flags. Derive the csv path and inventory path from those flags. See [steps/step1.md](steps/step1.md).
+
+### Step 2: Add the 2026-09-07 campaign YAML
+
+Add `mirrorview_2026-09-07_llm_features_v1.yaml` with the locked campaign id, dataset id, preprocessed run, row count 6408, batch size 2000, OpenAI engine, model `gpt-5.4-nano`, and seven features in YAML order. See [steps/step2.md](steps/step2.md).
+
+### Step 3: Scan the Twitter campaign YAML directory
+
+Change the Twitter campaign loader to return the YAML whose campaign id matches. Keep the 2026-09-05 campaign loadable. Reject unknown ids with the id in the message. See [steps/step3.md](steps/step3.md).
+
+### Step 4: Copy posts.csv to S3 and write the inventory
+
+Pull Git LFS bytes, run migrate and verify against the new dataset, and commit the inventory. See [steps/step4.md](steps/step4.md).
+
+## What "done" looks like
+
+1. Migrate and verify require `--dataset-id` and `--preprocessed-run` and exit non-zero without them.
+2. One `posts.csv` object is on S3 for the new dataset and run, with a matching SHA-256 inventory.
+3. The new campaign YAML loads by campaign id with row count 6408, engine openai, seven features, and the locked dataset id.
+4. The 2026-09-05 campaign still loads with row count 6374.
+5. An unknown campaign id fails and names that id.
+6. Git LFS still holds the local csv. No pytest was added. No full labeling ran.

--- a/docs/plans/2026-09-08_campaign_yaml_loader_s3_dbd325/steps/step1.md
+++ b/docs/plans/2026-09-08_campaign_yaml_loader_s3_dbd325/steps/step1.md
@@ -1,0 +1,88 @@
+# Step 1: Require dataset id and preprocessed run on migrate and verify
+
+## Scope
+
+- **Caller:** `data_platform/scripts/migrate_twitter_preprocessed_to_s3.py` `main`, then `data_platform/scripts/verify_twitter_preprocessed_s3.py` `main`.
+- **Task:** Add required `--dataset-id` and `--preprocessed-run`. Derive inventory and csv paths from those flags. Do not default to the 2026-09-05 dataset.
+- **Out of scope:** Uploading in this step, campaign YAML, loader change, labeling, pytest, smoke.
+
+## Files to inspect (read-only)
+
+- `/workspace/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py`
+- `/workspace/data_platform/scripts/verify_twitter_preprocessed_s3.py`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/s3_preprocessed_inventory.json` (shape to copy later. Do not edit.)
+
+## Files allowed to change
+
+- `/workspace/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py`
+- `/workspace/data_platform/scripts/verify_twitter_preprocessed_s3.py`
+
+## Files forbidden to change
+
+- `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml`
+- `/workspace/data_platform/generate_features/twitter_campaign_config.py`
+- `/workspace/data_platform/generate_features/smoke_twitter_campaign.py`
+- `/workspace/data_platform/generate_features/generate_twitter_features.py`
+- `/workspace/data_platform/generate_features/registry.py`
+- `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml`
+- `/workspace/data_platform/curate/consolidate.py`
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/**`
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/**`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/**`
+- Any file under `/workspace/tests/`
+- Any file outside the allowed list for this pull request
+
+## Locked contracts
+
+Required flags: `--dataset-id` and `--preprocessed-run`. No default dataset id. No default preprocessed run. Running without flags must be non-zero.
+
+Scoped upload path:
+
+```text
+data_platform/data/twitter/{dataset_id}/preprocessed/{preprocessed_run}/posts.csv
+```
+
+Inventory path:
+
+```text
+data_platform/data/twitter/{dataset_id}/s3_preprocessed_inventory.json
+```
+
+Expected object count stays 1. Hash is SHA-256 of bytes. Never use S3 ETag. Abort if the scoped file begins with `version https://git-lfs.github.com/spec/v1`.
+
+Do not upload raw csv, metadata, Bluesky, or Reddit.
+
+## Given / when / then (Phase 4, no new pytest)
+
+```text
+given the migrate script with no command flags
+when PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+then exit code is non-zero
+
+given the verify script with no command flags
+when PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py
+then exit code is non-zero
+```
+
+## Exact commands and expected output
+
+```bash
+PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py
+echo migrate_exit=$?
+PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py
+echo verify_exit=$?
+```
+
+Expected: both exit codes are non-zero. Stderr names the missing `--dataset-id` and `--preprocessed-run` flags.
+
+Do not add pytest.
+
+## Pass / fail
+
+The step passes when both scripts require the two flags and exit non-zero without them, and paths are derived from those flags.
+
+The step fails when any item below is true.
+
+- either script still pins `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` or `2026_09_06-19:28:47` as a default
+- missing flags exit 0
+- pytest was added

--- a/docs/plans/2026-09-08_campaign_yaml_loader_s3_dbd325/steps/step2.md
+++ b/docs/plans/2026-09-08_campaign_yaml_loader_s3_dbd325/steps/step2.md
@@ -1,0 +1,117 @@
+# Step 2: Add the 2026-09-07 campaign YAML
+
+## Scope
+
+- **Caller:** `data_platform.generate_features.twitter_campaign_config.load_twitter_campaign_config` after Step 3. This step only adds the YAML file.
+- **Task:** Add `mirrorview_2026-09-07_llm_features_v1.yaml` with identities from the preprocess child.
+- **Out of scope:** Changing the loader in this step, editing the 2026-09-05 YAML, labeling, pytest.
+
+## Files to inspect (read-only)
+
+- `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml` (shape to copy. Do not edit.)
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/metadata.json`
+
+## Files allowed to change
+
+- `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml` (new)
+
+## Files forbidden to change
+
+- `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml`
+- `/workspace/data_platform/generate_features/twitter_campaign_config.py`
+- `/workspace/data_platform/generate_features/registry.py`
+- `/workspace/data_platform/generate_features/smoke_twitter_campaign.py`
+- `/workspace/data_platform/generate_features/generate_twitter_features.py`
+- `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml`
+- `/workspace/data_platform/curate/consolidate.py`
+- Any file under `/workspace/tests/`
+- Any file outside the allowed list for this pull request
+
+## Locked contracts
+
+Path:
+
+```text
+data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml
+```
+
+Required fields:
+
+```yaml
+campaign_id: twitter_2026_09_08_014808_llm_features_v1
+platform: twitter
+dataset_id: twitter_5901767a-e609-46fc-9a17-742516b548f2
+preprocessed_run: "2026_09_08-01:48:08"
+row_count: 6408
+batch_size: 2000
+engine_type: openai
+model_id: gpt-5.4-nano
+features:
+  - is_news_or_opinion
+  - is_political
+  - is_likely_spam
+  - is_self_contained
+  - is_structurally_complete
+  - political_stance
+  - llm_toxicity_tiered
+```
+
+Do not reuse campaign id `twitter_2026_09_06_192847_llm_features_v1`. Do not use row count 6374.
+
+## Given / when / then (Phase 4, no new pytest)
+
+```text
+given the new campaign YAML file
+when the file is loaded as YAML
+then campaign_id is twitter_2026_09_08_014808_llm_features_v1
+and dataset_id is twitter_5901767a-e609-46fc-9a17-742516b548f2
+and preprocessed_run is 2026_09_08-01:48:08
+and row_count is 6408
+and batch_size is 2000
+and engine_type is openai
+and model_id is gpt-5.4-nano
+and features has seven names in the locked order
+```
+
+## Exact commands and expected output
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+from pathlib import Path
+import yaml
+path = Path("data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml")
+raw = yaml.safe_load(path.read_text())
+assert raw["campaign_id"] == "twitter_2026_09_08_014808_llm_features_v1"
+assert raw["dataset_id"] == "twitter_5901767a-e609-46fc-9a17-742516b548f2"
+assert raw["preprocessed_run"] == "2026_09_08-01:48:08"
+assert raw["row_count"] == 6408
+assert raw["batch_size"] == 2000
+assert raw["engine_type"] == "openai"
+assert raw["model_id"] == "gpt-5.4-nano"
+assert raw["features"] == [
+    "is_news_or_opinion",
+    "is_political",
+    "is_likely_spam",
+    "is_self_contained",
+    "is_structurally_complete",
+    "political_stance",
+    "llm_toxicity_tiered",
+]
+print("yaml_ok", raw["campaign_id"], raw["row_count"])
+PY
+```
+
+Expected: `yaml_ok twitter_2026_09_08_014808_llm_features_v1 6408`.
+
+Do not add pytest.
+
+## Pass / fail
+
+The step passes when the new YAML exists with the locked identities and seven features in order, and the 2026-09-05 YAML is unchanged.
+
+The step fails when any item below is true.
+
+- 2026-09-05 YAML was edited
+- row_count is 6374
+- campaign id reuses `twitter_2026_09_06_192847_llm_features_v1`
+- pytest was added

--- a/docs/plans/2026-09-08_campaign_yaml_loader_s3_dbd325/steps/step3.md
+++ b/docs/plans/2026-09-08_campaign_yaml_loader_s3_dbd325/steps/step3.md
@@ -1,0 +1,97 @@
+# Step 3: Scan the Twitter campaign YAML directory
+
+## Scope
+
+- **Caller:** `data_platform.generate_features.twitter_campaign_config.load_twitter_campaign_config`.
+- **Task:** Scan `data_platform/generate_features/configs/twitter/*.yaml` for a mapping whose `campaign_id` matches. Remove the single-file campaign id lock.
+- **Out of scope:** Changing smoke, generate, registry, watcher, curate, pytest, S3 upload.
+
+## Files to inspect (read-only)
+
+- `/workspace/data_platform/generate_features/twitter_campaign_config.py`
+- `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml`
+- `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml`
+- `/workspace/data_platform/generate_features/smoke_twitter_campaign.py` (calls the loader. Do not edit.)
+
+## Files allowed to change
+
+- `/workspace/data_platform/generate_features/twitter_campaign_config.py`
+
+## Files forbidden to change
+
+- `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml`
+- `/workspace/data_platform/generate_features/smoke_twitter_campaign.py`
+- `/workspace/data_platform/generate_features/generate_twitter_features.py`
+- `/workspace/data_platform/generate_features/registry.py`
+- `/workspace/data_platform/generate_features/feature_progress_watcher.py`
+- `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml`
+- `/workspace/data_platform/curate/consolidate.py`
+- Any file under `/workspace/tests/`
+- Any file outside the allowed list for this pull request
+
+## Locked contracts
+
+`load_twitter_campaign_config(campaign_id)`:
+
+1. Iterate YAML files under `data_platform/generate_features/configs/twitter/`.
+2. Load each mapping. If `campaign_id` matches, return it.
+3. If two files match, raise `ValueError` naming the id.
+4. If none match, raise `ValueError` whose message includes `unsupported twitter campaign id: {campaign_id}`.
+
+Remove `ACCEPTED_CAMPAIGN_ID` and `CAMPAIGN_YAML_PATH`.
+
+After this change:
+
+- `load_twitter_campaign_config("twitter_2026_09_06_192847_llm_features_v1")` returns the 2026-09-05 YAML (`row_count` 6374).
+- `load_twitter_campaign_config("twitter_2026_09_08_014808_llm_features_v1")` returns the 2026-09-07 YAML (`row_count` 6408).
+- `load_twitter_campaign_config("bluesky_2026_09_03_235130_llm_features_v1")` raises and names that id.
+
+## Given / when / then (Phase 4, no new pytest)
+
+```text
+given both Twitter campaign YAML files
+when load_twitter_campaign_config("twitter_2026_09_08_014808_llm_features_v1")
+then row_count is 6408, engine_type is openai, features length is 7,
+     and dataset_id is twitter_5901767a-e609-46fc-9a17-742516b548f2
+
+given both Twitter campaign YAML files
+when load_twitter_campaign_config("twitter_2026_09_06_192847_llm_features_v1")
+then row_count is 6374 and dataset_id is twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547
+
+given both Twitter campaign YAML files
+when load_twitter_campaign_config("bluesky_2026_09_03_235130_llm_features_v1")
+then ValueError names unsupported twitter campaign id: bluesky_2026_09_03_235130_llm_features_v1
+```
+
+## Exact commands and expected output
+
+```bash
+PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; c=load_twitter_campaign_config('twitter_2026_09_08_014808_llm_features_v1'); print(c['row_count'], c['engine_type'], len(c['features']), c['dataset_id'])"
+```
+
+Expected: `6408 openai 7 twitter_5901767a-e609-46fc-9a17-742516b548f2`.
+
+```bash
+PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; c=load_twitter_campaign_config('twitter_2026_09_06_192847_llm_features_v1'); print(c['row_count'], c['dataset_id'])"
+```
+
+Expected: `6374 twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547`.
+
+```bash
+PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; load_twitter_campaign_config('bluesky_2026_09_03_235130_llm_features_v1')"
+```
+
+Expected: non-zero exit and `ValueError` naming `bluesky_2026_09_03_235130_llm_features_v1`.
+
+Do not add pytest.
+
+## Pass / fail
+
+The step passes when both campaign ids load with the locked row counts and dataset ids, and an unknown id fails with that id in the message.
+
+The step fails when any item below is true.
+
+- loader still accepts only `twitter_2026_09_06_192847_llm_features_v1`
+- 2026-09-05 YAML was edited or no longer loads
+- unknown id error omits `unsupported twitter campaign id:`
+- pytest was added

--- a/docs/plans/2026-09-08_campaign_yaml_loader_s3_dbd325/steps/step4.md
+++ b/docs/plans/2026-09-08_campaign_yaml_loader_s3_dbd325/steps/step4.md
@@ -1,0 +1,122 @@
+# Step 4: Copy posts.csv to S3 and write the inventory
+
+## Scope
+
+- **Caller:** `data_platform/scripts/migrate_twitter_preprocessed_to_s3.py` `main`, then `data_platform/scripts/verify_twitter_preprocessed_s3.py` `main`.
+- **Task:** Pull Git LFS bytes for the new preprocessed csv, upload that one object, write inventory under the new dataset, and verify SHA-256.
+- **Out of scope:** Labeling 6408 rows, disposable smoke, primary `batches/part-*.parquet`, pytest, Bluesky, Reddit, raw csv, metadata upload.
+
+## Files to inspect (read-only)
+
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/posts.csv`
+- `/workspace/data_platform/scripts/migrate_twitter_preprocessed_to_s3.py`
+- `/workspace/data_platform/scripts/verify_twitter_preprocessed_s3.py`
+- `/workspace/AGENTS.md`
+
+## Files allowed to change
+
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/s3_preprocessed_inventory.json` (new)
+
+## Files forbidden to change
+
+- `/workspace/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/**`
+- `/workspace/data_platform/data/bluesky/**`
+- `/workspace/data_platform/data/reddit/**`
+- `/workspace/.gitattributes`
+- `/workspace/.gitignore`
+- Any file under `/workspace/tests/`
+- Any file outside the allowed list for this pull request
+
+## Locked contracts
+
+Upload only:
+
+```text
+s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/posts.csv
+```
+
+Expected object count is 1. Hash is SHA-256 of object bytes. Never use S3 ETag. Abort if the local file still starts with Git LFS pointer text.
+
+Storage for reading local dataset files:
+
+```bash
+export DATA_PLATFORM_STORAGE_BACKEND=local
+```
+
+AWS:
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+```
+
+Do not upload raw csv, metadata, Bluesky, or Reddit.
+
+## Given / when / then (Phase 4, no new pytest)
+
+```text
+given the Git LFS preprocessed posts.csv for the new dataset
+when the first 40 bytes are read
+then they do not start with Git LFS pointer text
+and file size is greater than 2000 bytes
+
+given that smudged csv and AWS credentials
+when migrate runs with --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2
+     and --preprocessed-run 2026_09_08-01:48:08
+then stdout includes uploaded 1 object
+
+given the written inventory
+when verify runs with the same flags
+then stdout is OK: 1/1 objects present with matching sha256
+```
+
+## Exact commands and expected output
+
+```bash
+export DATA_PLATFORM_STORAGE_BACKEND=local
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+aws sts get-caller-identity
+```
+
+Expected: JSON with `"Arn"` containing the lab IAM user and exit 0.
+
+```bash
+git lfs pull --include "data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/posts.csv"
+python3 -c "
+from pathlib import Path
+p = Path('data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/posts.csv')
+head = p.read_bytes()[:40]
+assert not head.startswith(b'version https://git-lfs.github.com/spec/v1'), head
+assert p.stat().st_size > 2000, p.stat().st_size
+print('csv smudged ok', p.stat().st_size)
+"
+```
+
+Expected: `csv smudged ok` plus a byte size.
+
+```bash
+PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run 2026_09_08-01:48:08
+PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run 2026_09_08-01:48:08
+```
+
+Expected: migration reports `uploaded 1 object`. Verifier prints `OK: 1/1 objects present with matching sha256`.
+
+Do not add pytest.
+
+## Pass / fail
+
+The step passes when one new `posts.csv` object is on S3 with matching SHA-256, inventory lives under the new dataset, and Git LFS still holds the local copy.
+
+The step fails when any item below is true.
+
+- migrate still pins the old csv when invoked for the new dataset
+- raw csv, Bluesky, or Reddit objects were uploaded
+- SHA-256 was taken from ETag
+- LFS pointer text was uploaded
+- official seven-feature production labeling started
+- pytest was added


### PR DESCRIPTION
Fixes #254

Part of #251

## Summary

Adds campaign YAML for the 2026-09-07 Twitter collection, loads Twitter campaign ids by scanning that config directory, and copies the new preprocessed `posts.csv` to S3.

Operators pass `--dataset-id` and `--preprocessed-run` to migrate and verify. The loader returns the YAML whose `campaign_id` matches. The 2026-09-05 campaign still loads.

## Purpose

The preprocess child left 6,408 posts in Git LFS. Campaign workers need those bytes on `mirrorview-experimental-artifacts`, a campaign YAML for that run, and a loader that can find more than one Twitter campaign id.

This pull request ships that product code. Labeling the 6,408 posts, writing primary batches, changing `FEATURE_REGISTRY`, and the official seven-feature smoke are out of scope. Those belong to child #255.

## Architecture

Components:

- `migrate_twitter_preprocessed_to_s3.py` requires `--dataset-id` and `--preprocessed-run`, pulls Git LFS, rejects pointer text, uploads one csv, and writes a SHA-256 inventory under that dataset.
- `verify_twitter_preprocessed_s3.py` takes the same flags, re-downloads the object, and compares SHA-256. It never uses ETag as a content hash.
- `twitter_campaign_config.py` scans `data_platform/generate_features/configs/twitter/*.yaml` for a matching `campaign_id`.
- The new YAML names campaign `twitter_2026_09_08_014808_llm_features_v1`.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    Migrate[Migrate] --> OldCsv[Pinned 2026-09-05 csv]
    Loader[Loader] --> OneId[One locked campaign id]
  end
```

New flow:

```mermaid
flowchart LR
  subgraph after [After]
    Flags[dataset id and preprocessed run] --> Migrate[Migrate one posts.csv]
    Migrate --> S3[(S3 posts.csv)]
    YAML[2026-09-07 campaign YAML] --> Loader[Directory scan by campaign id]
    OldYAML[2026-09-05 campaign YAML] --> Loader
    Loader --> NewId[New campaign loads]
    Loader --> OldId[Old campaign still loads]
  end
```

## Interfaces

### Campaign identities

- campaign_id: `twitter_2026_09_08_014808_llm_features_v1`
- dataset_id: `twitter_5901767a-e609-46fc-9a17-742516b548f2`
- preprocessed_run: `2026_09_08-01:48:08`
- row_count: `6408`
- batch_size: `2000`
- engine_type: `openai`
- model_id: `gpt-5.4-nano`

YAML path: `data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml`

Seven features in YAML order: `is_news_or_opinion`, `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tiered`.

`load_twitter_campaign_config` still loads `twitter_2026_09_06_192847_llm_features_v1` with row_count 6374. If two files share an id, the loader raises `ValueError` naming that id. If none match, the loader raises `ValueError` whose message includes `unsupported twitter campaign id: {campaign_id}`.

### S3 object

`s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/posts.csv`

sha256: `0461a0dc7ac5ecf1c5699fa893013dc7165af482a5347067e413bf4315ffdbd2`

bytes: `2604868`

Inventory: `data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/s3_preprocessed_inventory.json`

Expected object count is 1. Hash is SHA-256 of object bytes.

### CLI

Migrate and verify require `--dataset-id` and `--preprocessed-run`. Running without those flags exits non-zero. They do not default to the 2026-09-05 dataset.

## How to run

From the repo root:

```bash
export DATA_PLATFORM_STORAGE_BACKEND=local
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
git lfs pull --include "data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/posts.csv"
PYTHONPATH=. uv run python data_platform/scripts/migrate_twitter_preprocessed_to_s3.py \
  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
  --preprocessed-run 2026_09_08-01:48:08
PYTHONPATH=. uv run python data_platform/scripts/verify_twitter_preprocessed_s3.py \
  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
  --preprocessed-run 2026_09_08-01:48:08
```

Expected: `uploaded 1 object`, then `OK: 1/1 objects present with matching sha256`.

```bash
PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; c=load_twitter_campaign_config('twitter_2026_09_08_014808_llm_features_v1'); print(c['row_count'], c['engine_type'], len(c['features']), c['dataset_id'])"
```

Expected: `6408 openai 7 twitter_5901767a-e609-46fc-9a17-742516b548f2`.

```bash
PYTHONPATH=. uv run python -c "from data_platform.generate_features.twitter_campaign_config import load_twitter_campaign_config; c=load_twitter_campaign_config('twitter_2026_09_06_192847_llm_features_v1'); print(c['row_count'], c['dataset_id'])"
```

Expected: `6374 twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547`.

Plan: `docs/plans/2026-09-08_campaign_yaml_loader_s3_dbd325/plan.md`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring and selecting multiple Twitter feature-generation campaigns.
  - Added a Twitter campaign using OpenAI-based content analysis, including political classification, spam detection, stance detection, completeness checks, and tiered toxicity analysis.
  - Added inventory metadata for a preprocessed Twitter dataset stored in S3.

- **Improvements**
  - Migration and verification tools now accept dataset and preprocessing-run parameters, enabling reuse across different Twitter datasets and runs.
  - Added validation to detect invalid inventory metadata and mismatched preprocessing runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->