### PR TITLE
Join seven Twitter LLM features and write the MirrorView curated export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## 2026-09-08
 
-1. Operators now have seven OpenAI Batch labels for all 6,408 Twitter posts from the 2026-09-07 collection, with four batch objects and a run report per feature. [PR #264](https://github.com/METResearchGroup/mirrorView-task/pull/264)
-2. The 2026-09-07 Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_08_014808_llm_features_v1` for 6,408 posts, and the 2026-09-05 campaign still loads. [PR #263](https://github.com/METResearchGroup/mirrorView-task/pull/263)
-3. Twitter preprocess on the 2026-09-07 collection kept 6,408 of 6,900 posts. The preprocessed `posts.csv` is stored in Git LFS. [PR #261](https://github.com/METResearchGroup/mirrorView-task/pull/261)
-4. A dated Mirrorview Twitter ingest config and a recent-search run (6,900 unique posts inside the 7-day window) are now in the repo. `posts.csv` is stored in Git LFS. [PR #259](https://github.com/METResearchGroup/mirrorView-task/pull/259)
+1. Operators now have a Twitter table of 6,408 labeled posts with 21 columns, plus a MirrorView curated export that records political stance by toxicity tier. [PR #265](https://github.com/METResearchGroup/mirrorView-task/pull/265)
+2. Operators now have seven OpenAI Batch labels for all 6,408 Twitter posts from the 2026-09-07 collection, with four batch objects and a run report per feature. [PR #264](https://github.com/METResearchGroup/mirrorView-task/pull/264)
+3. The 2026-09-07 Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_08_014808_llm_features_v1` for 6,408 posts, and the 2026-09-05 campaign still loads. [PR #263](https://github.com/METResearchGroup/mirrorView-task/pull/263)
+4. Twitter preprocess on the 2026-09-07 collection kept 6,408 of 6,900 posts. The preprocessed `posts.csv` is stored in Git LFS. [PR #261](https://github.com/METResearchGroup/mirrorView-task/pull/261)
+5. A dated Mirrorview Twitter ingest config and a recent-search run (6,900 unique posts inside the 7-day window) are now in the repo. `posts.csv` is stored in Git LFS. [PR #259](https://github.com/METResearchGroup/mirrorView-task/pull/259)
 
 ## 2026-09-07
 

--- a/data_platform/curate/consolidate_twitter_llm_campaign.py
+++ b/data_platform/curate/consolidate_twitter_llm_campaign.py
@@ -1,12 +1,23 @@
 """Join pinned Twitter posts with seven campaign LLM feature files into one wide Parquet object.
 
-Runtime validation (automated tests are forbidden by issue 235):
+Expected wide row count comes from the campaign YAML for ``--campaign-id``.
+CLI ``--dataset-id`` and ``--preprocessed-run`` must match that YAML.
 
-given seven feature manifests whose final.parquet SHA-256 and row_count are 6374,
-     and posts.csv whose SHA-256 matches the inventory
-when the CLI joins pinned posts on source_record_id
-then stdout includes each accepted manifest digest, wide_rows=6374, wide_columns=21,
+Runtime validation (automated tests are forbidden by issue 256):
+
+given campaign YAML row_count 6408, seven feature manifests whose final.parquet
+     SHA-256 and row_count are 6408, and posts.csv whose SHA-256 matches the inventory
+when the CLI joins pinned posts on source_record_id with matching dataset id and run
+then stdout includes each accepted manifest digest, wide_rows=6408, wide_columns=21,
      sort_key=source_record_id ASC, and the wide manifest URI
+
+given CLI --dataset-id or --preprocessed-run that disagrees with the campaign YAML
+when parse_args runs
+then it raises ValueError before writing wide/features.parquet
+
+given campaign id twitter_2026_09_06_192847_llm_features_v1
+when load_twitter_campaign_config returns that YAML
+then expected wide row count is 6374
 
 given a missing or SHA-mismatched feature final.parquet, or a posts.csv SHA-256
      that does not match the inventory
@@ -15,7 +26,7 @@ then it raises before writing wide/features.parquet
 
 given the uploaded wide parquet
 when the columns and row count are checked
-then column names match the 21-name contract, n=6374, and no llm_toxicity_tier is null
+then column names match the 21-name contract, n=6408, and no llm_toxicity_tier is null
 
 given the same wide table and data_platform/curate/configs/twitter/mirrorview.yaml
 when apply_rules runs
@@ -26,10 +37,10 @@ then curated row count and political_stance x llm_toxicity_tier counts are writt
 Run from the repo root:
 
     PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \\
-        --dataset-id twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547 \\
-        --preprocessed-run 2026_09_06-19:28:47 \\
-        --campaign-id twitter_2026_09_06_192847_llm_features_v1 \\
-        --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/features/twitter_2026_09_06_192847_llm_features_v1/wide/features.parquet
+        --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \\
+        --preprocessed-run 2026_09_08-01:48:08 \\
+        --campaign-id twitter_2026_09_08_014808_llm_features_v1 \\
+        --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/twitter_2026_09_08_014808_llm_features_v1/wide/features.parquet
 """
 
 from __future__ import annotations
@@ -66,6 +77,9 @@ from data_platform.generate_features.s3_feature_campaign import (
     parse_s3_uri,
     s3_uri,
 )
+from data_platform.generate_features.twitter_campaign_config import (
+    load_twitter_campaign_config,
+)
 from data_platform.utils.dataset import dataset_root, relative_run_path
 from data_platform.utils.object_store import DEFAULT_S3_REGION, S3_KEY_PREFIX, sha256_hex
 from data_platform.utils.platform_specific_columns import STANDARDIZED_SOURCE_RECORD_ID_COLUMN
@@ -76,7 +90,6 @@ MIRRORVIEW_RULES_PATH = (
     Path(__file__).resolve().parent / "configs" / "twitter" / "mirrorview.yaml"
 )
 TWITTER_PLATFORM = "twitter"
-TWITTER_EXPECTED_WIDE_ROW_COUNT = 6374
 WIDE_MANIFEST_FILENAME = "manifest.json"
 WIDE_PARQUET_FILENAME = "features.parquet"
 CURATED_EXPORT_SUFFIX = "parquet"
@@ -121,6 +134,7 @@ class CampaignConsolidateArgs:
     campaign_id: str
     output_s3_uri: str
     curate_config: Path
+    expected_row_count: int
 
 
 @dataclass(frozen=True)
@@ -184,13 +198,54 @@ def twitter_llm_campaign_wide_columns() -> tuple[str, ...]:
     return TWITTER_PREPROCESSED_WIDE_COLUMNS + label_columns
 
 
+def _require_cli_matches_campaign(
+    dataset_id: str,
+    preprocessed_run: str,
+    campaign: dict[str, Any],
+) -> None:
+    yaml_dataset_id = str(campaign["dataset_id"])
+    yaml_preprocessed_run = str(campaign["preprocessed_run"])
+    if dataset_id != yaml_dataset_id:
+        raise ValueError(
+            f"--dataset-id {dataset_id} does not match campaign YAML {yaml_dataset_id}"
+        )
+    if preprocessed_run != yaml_preprocessed_run:
+        raise ValueError(
+            f"--preprocessed-run {preprocessed_run} does not match campaign YAML "
+            f"{yaml_preprocessed_run}"
+        )
+
+
+def expected_wide_row_count(
+    campaign_id: str,
+    dataset_id: str,
+    preprocessed_run: str,
+) -> int:
+    """Return campaign YAML row_count after CLI identities match that YAML.
+
+    Raises
+    ------
+    ValueError
+        When ``--dataset-id`` or ``--preprocessed-run`` disagrees with the YAML.
+    """
+    campaign = load_twitter_campaign_config(campaign_id)
+    _require_cli_matches_campaign(dataset_id, preprocessed_run, campaign)
+    return int(campaign["row_count"])
+
+
 def parse_args(argv: list[str] | None = None) -> CampaignConsolidateArgs:
     """Parse dataset id, preprocessed run, campaign id, and output S3 URI.
 
     Returns
     -------
     CampaignConsolidateArgs
-        Frozen CLI inputs, with curate YAML defaulting to Twitter MirrorView.
+        Frozen CLI inputs, with curate YAML defaulting to Twitter MirrorView
+        and ``expected_row_count`` taken from the campaign YAML.
+
+    Raises
+    ------
+    ValueError
+        When ``--dataset-id`` or ``--preprocessed-run`` disagrees with the YAML.
     """
     parser = argparse.ArgumentParser(
         description="Join seven Twitter LLM campaign features into one wide Parquet object."
@@ -211,6 +266,11 @@ def parse_args(argv: list[str] | None = None) -> CampaignConsolidateArgs:
         campaign_id=parsed.campaign_id,
         output_s3_uri=parsed.output_s3_uri,
         curate_config=Path(parsed.curate_config),
+        expected_row_count=expected_wide_row_count(
+            parsed.campaign_id,
+            parsed.dataset_id,
+            parsed.preprocessed_run,
+        ),
     )
 
 
@@ -271,12 +331,14 @@ def _download_key(client: Any, bucket: str, key: str, dest: Path) -> str:
     return _sha256_file(dest)
 
 
-def _require_final_row_count(feature_name: str, manifest: dict[str, Any]) -> dict[str, Any]:
+def _require_final_row_count(
+    feature_name: str, manifest: dict[str, Any], expected_row_count: int
+) -> dict[str, Any]:
     final = manifest.get("final_parquet") or {}
-    if final.get("row_count") != TWITTER_EXPECTED_WIDE_ROW_COUNT:
+    if final.get("row_count") != expected_row_count:
         raise ValueError(
             f"{feature_name} final.parquet row_count is {final.get('row_count')}, "
-            f"expected {TWITTER_EXPECTED_WIDE_ROW_COUNT}"
+            f"expected {expected_row_count}"
         )
     return final
 
@@ -284,24 +346,23 @@ def _require_final_row_count(feature_name: str, manifest: dict[str, Any]) -> dic
 def verify_feature_manifest(
     store: CampaignObjectStore,
     feature_name: str,
-    campaign_id: str,
-    dataset_id: str,
+    args: CampaignConsolidateArgs,
 ) -> tuple[str, dict[str, Any]]:
-    """Return manifest SHA-256 and parsed JSON after checking row count 6374.
+    """Return manifest SHA-256 and parsed JSON after checking YAML row count.
 
     Raises
     ------
     FileNotFoundError
         When the feature manifest object is missing.
     ValueError
-        When ``final_parquet.row_count`` is not 6374.
+        When ``final_parquet.row_count`` is not the campaign YAML row count.
     """
-    paths = _twitter_feature_paths(campaign_id, feature_name, dataset_id)
+    paths = _twitter_feature_paths(args.campaign_id, feature_name, args.dataset_id)
     stored = store.get(paths.manifest_key)
     if stored is None:
         raise FileNotFoundError(f"missing feature manifest: {paths.uri(paths.manifest_key)}")
     manifest = json.loads(stored.body)
-    _require_final_row_count(feature_name, manifest)
+    _require_final_row_count(feature_name, manifest, args.expected_row_count)
     digest = sha256_hex(stored.body)
     print(f"accepted {feature_name} manifest sha256={digest}")
     return digest, manifest
@@ -334,9 +395,7 @@ def _download_feature_final(
     feature_name: str,
 ) -> FeatureInputRecord:
     paths = _twitter_feature_paths(args.campaign_id, feature_name, args.dataset_id)
-    manifest_sha, manifest = verify_feature_manifest(
-        store, feature_name, args.campaign_id, args.dataset_id
-    )
+    manifest_sha, manifest = verify_feature_manifest(store, feature_name, args)
     local_path = work_dir / feature_name / "final.parquet"
     digest = _download_key(client, store.bucket, paths.final_key, local_path)
     _require_sha256(
@@ -477,14 +536,14 @@ def build_twitter_llm_campaign_wide_table(
         conn.close()
 
 
-def _validate_wide_rows(wide: pd.DataFrame) -> None:
+def _validate_wide_rows(wide: pd.DataFrame, expected_row_count: int) -> None:
     id_column = STANDARDIZED_SOURCE_RECORD_ID_COLUMN
-    if len(wide) != TWITTER_EXPECTED_WIDE_ROW_COUNT:
-        raise ValueError(f"wide_rows={len(wide)}, expected {TWITTER_EXPECTED_WIDE_ROW_COUNT}")
+    if len(wide) != expected_row_count:
+        raise ValueError(f"wide_rows={len(wide)}, expected {expected_row_count}")
     unique_ids = wide[id_column].astype(str).nunique()
-    if unique_ids != TWITTER_EXPECTED_WIDE_ROW_COUNT:
+    if unique_ids != expected_row_count:
         raise ValueError(
-            f"distinct source_record_id={unique_ids}, expected {TWITTER_EXPECTED_WIDE_ROW_COUNT}"
+            f"distinct source_record_id={unique_ids}, expected {expected_row_count}"
         )
     if not wide[id_column].astype(str).is_monotonic_increasing:
         raise ValueError("wide rows are not sorted by source_record_id ASC")
@@ -501,13 +560,13 @@ def _validate_wide_labels(wide: pd.DataFrame, expected_columns: tuple[str, ...])
         raise ValueError(f"null feature values: {null_counts}")
 
 
-def validate_wide_table(wide: pd.DataFrame) -> None:
+def validate_wide_table(wide: pd.DataFrame, expected_row_count: int) -> None:
     """Raise ValueError when the wide table misses the Twitter campaign contract."""
     expected = twitter_llm_campaign_wide_columns()
     actual = tuple(wide.columns)
     if actual != expected:
         raise ValueError(f"wide columns {actual} do not match {expected}")
-    _validate_wide_rows(wide)
+    _validate_wide_rows(wide, expected_row_count)
     forbidden = FORBIDDEN_WIDE_COLUMNS.intersection(actual)
     if forbidden:
         raise ValueError(f"wide table contains forbidden columns: {sorted(forbidden)}")
@@ -713,13 +772,13 @@ def _wide_manifest_document(
         "dataset_id": args.dataset_id,
         "preprocessed_run": args.preprocessed_run,
         "campaign_id": args.campaign_id,
-        "row_count": TWITTER_EXPECTED_WIDE_ROW_COUNT,
+        "row_count": args.expected_row_count,
         "columns": list(twitter_llm_campaign_wide_columns()),
         "sort_key": WIDE_SORT_KEY,
         "wide_parquet": {
             "key": wide_key,
             "sha256": wide_sha,
-            "row_count": TWITTER_EXPECTED_WIDE_ROW_COUNT,
+            "row_count": args.expected_row_count,
         },
         "preprocessed": {"key": preprocessed.key, "sha256": preprocessed.sha256},
         "features": {
@@ -775,7 +834,7 @@ def run_campaign_consolidation(args: CampaignConsolidateArgs) -> WideConsolidate
             preprocessed.local_csv,
             {record.feature_name: record.local_parquet for record in features},
         )
-        validate_wide_table(wide)
+        validate_wide_table(wide, args.expected_row_count)
         curated = curate_mirrorview_dataset(store, wide, args)
         wide_sha, parquet_uri, manifest_uri = upload_wide_artifacts(
             store, wide, args, preprocessed, features, curated

--- a/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/plan.md
+++ b/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/plan.md
@@ -1,0 +1,80 @@
+# Join seven Twitter LLM features and write the MirrorView curated export
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, frequent commits
+- Use only the approved live runtime checks. Do not add or run automated tests.
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Operators need one Twitter table with 21 columns and a MirrorView curated export for the 2026-09-07 collection. This pull request teaches the existing consolidator to take expected row count from the campaign YAML, joins seven verified feature files to the pinned preprocessed csv, uploads the wide table, applies the existing Twitter MirrorView filters, and records the curated row count plus the stance by toxicity table.
+
+## Happy flow
+
+An operator runs the consolidator with the locked dataset id, preprocessed run, and campaign id. The script checks that those flags match the YAML, checks hashes, writes the wide table of 6,408 rows, writes a timestamped MirrorView export, and prints the curated counts.
+
+```mermaid
+flowchart TD
+    A[Load campaign YAML] --> B[Fail if CLI dataset or run disagrees]
+    B --> C[Download pinned posts csv]
+    C --> D[Check csv SHA-256 against inventory]
+    D --> E[Check seven feature manifests]
+    E --> F[Inner join on source_record_id]
+    F --> G[Upload wide parquet and manifest]
+    G --> H[Apply Twitter MirrorView filters]
+    H --> I[Write curated parquet and metadata]
+    I --> J[Write wide run report with crosstab]
+```
+
+## Approach
+
+Keep csv loading, Twitter column order, and MirrorView curation inside the existing Twitter consolidator. Read expected wide row count from the campaign YAML for the campaign id on the command line. Fail when `--dataset-id` or `--preprocessed-run` disagrees with that YAML. Leave Bluesky wide-row and column constants unchanged. Leave Twitter MirrorView filter semantics unchanged. Do not add pytest.
+
+## Decisions
+
+- Locked identities live in `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml`.
+- Expected wide row count is that YAML `row_count` (6408). Do not keep a module constant that forces 6374 for every Twitter campaign.
+- Campaign id `twitter_2026_09_06_192847_llm_features_v1` must still expect 6374, because `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml` still says `row_count: 6374`.
+- Fail if CLI `--dataset-id` or `--preprocessed-run` disagrees with the YAML for that campaign id.
+- Path helper calls use platform `twitter` and the locked dataset id.
+- The left table is S3 csv `posts.csv`. Verify SHA-256 against `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/s3_preprocessed_inventory.json`. The inventory hash for that object is `0461a0dc7ac5ecf1c5699fa893013dc7165af482a5347067e413bf4315ffdbd2`.
+- Join on `CAST(source_record_id AS VARCHAR)`. Sort `source_record_id ASC`.
+- Wide columns are the 21 names in contract order. Forbidden extra columns include `author_id`, `toxicity_prob`, `toxicity_tier`, any `is_toxic_tiered` field, `label_timestamp`, and `run_id`.
+- Feature label aliases stay as in the earlier campaign contract: `is_news_or_opinion.category` becomes `news_or_opinion_category`, and `llm_toxicity_tiered.toxicity_tier` becomes `llm_toxicity_tier`.
+- Curated files live under the dataset `curated/` stage, not under `wide/curated/`. Use `TwitterStorageManager("curated", dataset_id)` to create the run directory and write `metadata.json`. Upload parquet bytes to `curated/<timestamp>/mirrorview.parquet`. Do not change `twitter/mirrorview.yaml`. Do not change `dataset.json`.
+- The report must include curated row count and a `political_stance` by `llm_toxicity_tier` table for rows that survive the filters. Stance rows are `left` and `right`. Toxicity columns are `low`, `medium`, and `high`.
+- Copy report shape from `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md`. Write the new report under this plan folder. Do not edit the 2026-09-07 generate-features plan folder. Do not rewrite the 4a9cd5 epic package.
+- Implement-from-spec Phase 4 is the live runtime checks in the step files. Do not add files under `tests/`.
+- Stay on branch `cursor/epic-251-256-join-curate-mirrorview-8500`. Stack below is pull request 264.
+
+## Locked identities
+
+| Field | Value |
+|-------|-------|
+| Dataset id | `twitter_5901767a-e609-46fc-9a17-742516b548f2` |
+| Preprocessed run | `2026_09_08-01:48:08` |
+| Campaign id | `twitter_2026_09_08_014808_llm_features_v1` |
+| Row count | 6408 posts |
+| Inventory SHA-256 for posts.csv | `0461a0dc7ac5ecf1c5699fa893013dc7165af482a5347067e413bf4315ffdbd2` |
+
+## Steps
+
+### Step 1: Read expected wide row count from the campaign YAML
+
+Change `/workspace/data_platform/curate/consolidate_twitter_llm_campaign.py` so expected wide row count comes from `load_twitter_campaign_config(campaign_id)["row_count"]`. Fail if CLI dataset id or preprocessed run disagrees with that YAML. See [steps/step1.md](steps/step1.md).
+
+### Step 2: Run the live join and write the report
+
+Run the consolidator and the parquet column check. Write `/workspace/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/reports/wide_run_report.md` with curated row count and the stance by toxicity table. See [steps/step2.md](steps/step2.md).
+
+## What "done" looks like
+
+1. Wide `features.parquet` has 6408 rows and 21 columns in contract order, with no nulls in the seven label columns.
+2. Wide `manifest.json` links all seven feature manifests and the preprocessed csv SHA-256.
+3. MirrorView curation writes `curated/<timestamp>/mirrorview.parquet` and `metadata.json` through the Twitter curated-stage manager.
+4. The wide run report is committed with curated row count and the stance by toxicity table for valid curated rows.
+5. Filter YAML semantics are unchanged.
+6. The old campaign id still expects 6374 because that YAML still says 6374.
+7. No pytest file was added or run. Bluesky wide-row and column constants are unchanged.

--- a/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/reports/wide_run_report.md
+++ b/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/reports/wide_run_report.md
@@ -1,0 +1,113 @@
+# Wide consolidation and MirrorView curation report
+
+## Approval
+
+Phase B labeling finished on all seven features on pull request 264. This step did not call OpenAI. Inputs are the seven `final.parquet` objects for campaign `twitter_2026_09_08_014808_llm_features_v1`.
+
+## Pinned identity
+
+| Field | Value |
+|-------|-------|
+| Dataset id | `twitter_5901767a-e609-46fc-9a17-742516b548f2` |
+| Preprocessed run | `2026_09_08-01:48:08` |
+| Preprocessed row count | 6408 |
+| Preprocessed file | `posts.csv` |
+| Campaign id | `twitter_2026_09_08_014808_llm_features_v1` |
+| Join key | `source_record_id` |
+| Sort | `source_record_id ASC` |
+| Wide columns | 21 |
+
+## Inputs
+
+Preprocessed posts SHA-256: `0461a0dc7ac5ecf1c5699fa893013dc7165af482a5347067e413bf4315ffdbd2`
+
+The SHA-256 matches `data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/s3_preprocessed_inventory.json`.
+
+| Feature | Manifest SHA-256 | `final.parquet` SHA-256 | Rows |
+|---------|------------------|-------------------------|------|
+| `is_news_or_opinion` | `abe6a45094ad51d26d843c3af651214f9713c482be4ed0976dfb370e3d424574` | `fc8ab8676868fe426f1f26be496776919c637aab1ea5a30042402ccaeabf2421` | 6408 |
+| `is_political` | `6df5db12221cadc3bcb201081c14e0f1c65eb2f1c395075ab8031006fadffa93` | `f981f44ea8e9b42c3160d158a5de388b6fed0cbbfdb94a71d85ea340c56e8c53` | 6408 |
+| `is_likely_spam` | `2d84188dfe96a5b60799bf39643268d9b6410d1383c5abeb6760bdac2cc51833` | `0ce265bfd54601609d4b32937ce9d925fcb38cc4ae3e5f1916b83940541ec493` | 6408 |
+| `is_self_contained` | `7eb49dd608ffb883e813cb6806f9a243ca6ea46628f4c91d830c1e6a91783c7e` | `577c0da3d3412bb2cbc112844cc5485686c5a8cfdbc52e6aa0954bd100339872` | 6408 |
+| `is_structurally_complete` | `a1243a14fc8860b9239aa1f041555f1c617535558837b6140105c6a00acec7dc` | `6ba54e2d34087bcd651671bbe4180f46765d0c41c2159bd429270eff427739cd` | 6408 |
+| `political_stance` | `488360c09209720fc8ecb5d3b1180acd4c3d96f1a7f77757bcf5073e57c7d24c` | `d1566660247cd36c6fa4211952e28e91ce896db31c2d8a42ec04bfa6c7db2793` | 6408 |
+| `llm_toxicity_tiered` | `d25a94cf238021570a6ab3c70c7a2715f338807b88c4314b53c3f9e0744106d0` | `1011fa84ab7303463d3bcefed04de705232d171f662d03961f88c71f8e3747c6` | 6408 |
+
+Each feature `final.parquet` SHA-256 matched its parameter manifest before the join.
+
+## Wide outputs
+
+| Object | URI | SHA-256 |
+|--------|-----|---------|
+| Wide parquet | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/twitter_2026_09_08_014808_llm_features_v1/wide/features.parquet` | `b566bcba6c3e5fd83c6e35d7cf169dac68cd85bc1d425f159dbc068bb61b1ffe` |
+| Wide manifest | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/twitter_2026_09_08_014808_llm_features_v1/wide/manifest.json` | `7dae14e96ac61860ef6a66a754407b9609d7a17007177bce906478fffc5115fb` |
+
+Wide objects are untagged. The join is an inner join on `CAST(source_record_id AS VARCHAR)`. Duplicate feature rows keep the latest `label_timestamp`. The left table is csv `posts.csv`. `author_id` is absent.
+
+Column order:
+
+`tweet_id`, `record_id`, `url`, `username`, `author_handle`, `text`, `created_at`, `like_count`, `retweet_count`, `reply_count`, `quote_count`, `keyword`, `sync_timestamp`, `source_record_id`, `news_or_opinion_category`, `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tier`
+
+## Validation
+
+All checks passed on 2026-09-08 after download to `/tmp/twitter_2026_09_08_wide.parquet`.
+
+| Check | Result |
+|-------|--------|
+| Twenty-one columns in contract order | PASS |
+| `wide_rows=6408` and 6408 distinct `source_record_id` | PASS |
+| File order matches `source_record_id ASC` | PASS |
+| Nulls on seven label columns | 0 |
+| Missing preprocessed posts after join | 0 |
+| Forbidden columns (`toxicity_prob`, `toxicity_tier`, `label_timestamp`, `run_id`, `is_toxic_tiered`, `author_id`) | absent |
+| Wide parquet SHA-256 matches manifest | PASS |
+| All seven feature manifests linked by SHA-256 | PASS |
+| Preprocessed csv SHA-256 matches inventory | PASS |
+| Expected row count from campaign YAML | 6408 |
+
+## MirrorView curated dataset
+
+The export uses the dataset-stage layout: `curated/<timestamp>/mirrorview.parquet` plus `metadata.json` under `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/`. It is not stored under the campaign `wide/` prefix. `TwitterStorageManager("curated", dataset_id)` created the run directory and wrote `metadata.json`.
+
+Rules file: `data_platform/curate/configs/twitter/mirrorview.yaml` (SHA-256 `62a0ee4f4b8528b7e75382b0ddab3f21857b9f23101f5ebdc5d0926c99aa53ff`). Filters are AND, in YAML order. No extra toxicity filter.
+
+| Filter | Records before | Records passing |
+|--------|----------------|-----------------|
+| `news_or_opinion_category` eq `opinion` | 6408 | 3558 |
+| `is_political` eq true | 3558 | 3067 |
+| `is_likely_spam` eq false | 3067 | 3057 |
+| `political_stance` in `left`, `right` | 3057 | 2108 |
+| `is_self_contained` eq true | 2108 | 1326 |
+| `is_structurally_complete` eq true | 1326 | 1299 |
+
+Curated row count: 1299
+
+| Object | URI | SHA-256 |
+|--------|-----|---------|
+| Curated parquet | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/curated/2026_09_08-05:34:19/mirrorview.parquet` | `c2178c27165c26dd960bd470e3ee98791e7c98638a346eca0f0fafa1c065c8e2` |
+| Curated metadata | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/curated/2026_09_08-05:34:19/metadata.json` | `73de52372d6615b16cd8dc6817aa79b16fdcb061a1990147bad45f82db8f8733` |
+
+### Row count by political stance × LLM toxicity tier
+
+Valid curated rows only. Stance rows are `left` and `right`. Toxicity columns are `low`, `medium`, and `high`.
+
+| political_stance | low | medium | high | total |
+|------------------|-----|--------|------|-------|
+| left | 512 | 118 | 9 | 639 |
+| right | 342 | 245 | 73 | 660 |
+| total | 854 | 363 | 82 | 1299 |
+
+## Command
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run 2026_09_08-01:48:08 \
+  --campaign-id twitter_2026_09_08_014808_llm_features_v1 \
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/twitter_2026_09_08_014808_llm_features_v1/wide/features.parquet
+```
+
+Stdout included seven accepted manifest digests, `wide_rows=6408`, `wide_columns=21`, `sort_key=source_record_id ASC`, `curated_rows=1299`, and the stance × toxicity table above.

--- a/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/steps/step1.md
+++ b/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/steps/step1.md
@@ -1,0 +1,180 @@
+# Step 1: Read expected wide row count from the campaign YAML
+
+## Scope
+
+- **Caller:** `data_platform/curate/consolidate_twitter_llm_campaign.py` `main`
+- **Task:** Load expected wide row count from `load_twitter_campaign_config(campaign_id)["row_count"]`. Fail if CLI `--dataset-id` or `--preprocessed-run` disagrees with that YAML. Keep csv left-table load, manifest checks, 21-column join, wide upload, and MirrorView curation. Thread the YAML row count through manifest checks, wide validation, and the wide manifest.
+- **Out of scope:** pytest, GitHub posting, relabeling features, converting the dated dataset to parquet, editing Bluesky consolidator code, editing `twitter/mirrorview.yaml`, editing `consolidate.py`, editing `generate_features/**`.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/data_platform/curate/consolidate_twitter_llm_campaign.py` | Hardcoded `TWITTER_EXPECTED_WIDE_ROW_COUNT = 6374` |
+| `/workspace/data_platform/generate_features/twitter_campaign_config.py` | Directory loader. Do not edit. |
+| `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-07_llm_features_v1.yaml` | New `row_count` 6408 |
+| `/workspace/data_platform/generate_features/configs/twitter/mirrorview_2026-09-05_llm_features_v1.yaml` | Old `row_count` 6374. Do not edit. |
+| `/workspace/data_platform/curate/consolidate.py` | `LLM_CAMPAIGN_FEATURE_NAMES`, feature aliases. Do not edit. |
+| `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml` | Filter set. Do not edit. |
+| `/workspace/data_platform/utils/storage.py` | `TwitterStorageManager` |
+| `/workspace/data_platform/generate_features/s3_feature_campaign.py` | `FeaturePaths.for_campaign`, `CampaignObjectStore` |
+| `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md` | Report shape to copy in Step 2 |
+
+## Files allowed to change
+
+- `/workspace/data_platform/curate/consolidate_twitter_llm_campaign.py`
+
+## Files forbidden to change
+
+- `/workspace/data_platform/curate/consolidate.py`
+- `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py`
+- `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/tests/**`
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/dataset.json`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/**`
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/**`
+- Any file outside the allowed list
+
+## Locked identities
+
+| Field | Value |
+|-------|-------|
+| Dataset id | `twitter_5901767a-e609-46fc-9a17-742516b548f2` |
+| Preprocessed run | `2026_09_08-01:48:08` |
+| Campaign id | `twitter_2026_09_08_014808_llm_features_v1` |
+| Left table | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/preprocessed/2026_09_08-01:48:08/posts.csv` |
+| Inventory SHA-256 | `0461a0dc7ac5ecf1c5699fa893013dc7165af482a5347067e413bf4315ffdbd2` |
+| Wide rows | `6408` |
+| Wide columns | `21` |
+| Sort | `source_record_id ASC` |
+| Platform argument | `twitter` |
+| Rules | `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml` |
+
+Wide output URI:
+
+`s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/twitter_2026_09_08_014808_llm_features_v1/wide/features.parquet`
+
+Wide columns in this exact order:
+
+`tweet_id`, `record_id`, `url`, `username`, `author_handle`, `text`, `created_at`, `like_count`, `retweet_count`, `reply_count`, `quote_count`, `keyword`, `sync_timestamp`, `source_record_id`, `news_or_opinion_category`, `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tier`
+
+## Main caller
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run 2026_09_08-01:48:08 \
+  --campaign-id twitter_2026_09_08_014808_llm_features_v1 \
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/twitter_2026_09_08_014808_llm_features_v1/wide/features.parquet
+```
+
+## Work
+
+Follow `/implement-from-spec`. Full auto. Do not add pytest. Phase 4 is the given/when/then live checks below, written in the module docstring. The consolidator already exists, so do not replace working bodies with `NotImplementedError`.
+
+### Campaign YAML row count
+
+Call `load_twitter_campaign_config(campaign_id)`. Read `row_count`, `dataset_id`, and `preprocessed_run` from that mapping. Put `expected_row_count` on `CampaignConsolidateArgs`. Raise `ValueError` when CLI `--dataset-id` or `--preprocessed-run` disagrees with the YAML. Remove `TWITTER_EXPECTED_WIDE_ROW_COUNT`. Use the YAML row count for feature `final.parquet.row_count` checks, wide row count, distinct `source_record_id` count, and the wide manifest `row_count` fields.
+
+A run against `twitter_2026_09_06_192847_llm_features_v1` must still expect 6374 because that YAML still says 6374.
+
+### Path helper
+
+Call `FeaturePaths.for_campaign(campaign_id, feature_name, platform="twitter", dataset_id=dataset_id)`.
+
+### Posts csv
+
+Download the pinned S3 object as csv. Hash full object bytes with SHA-256. Compare to the inventory object for that key. Raise before joining if the hash does not match. Do not load `posts.parquet`. Do not convert the csv to a parquet left table.
+
+### Feature manifests
+
+For each name in `LLM_CAMPAIGN_FEATURE_NAMES`, load `manifest.json`, require `final_parquet.row_count` to equal the YAML row count, download `final.parquet`, and require its SHA-256 to match the manifest. Print `accepted {feature} manifest sha256={digest}` for each accepted manifest.
+
+### Join
+
+Keep the existing Twitter-local DuckDB join. `read_csv` for posts, `read_parquet` for features. Inner join on `CAST(source_record_id AS VARCHAR)`. Select only the 21 contract columns, in contract order. Sort `source_record_id ASC`. Duplicate feature ids keep the latest `label_timestamp`. Do not import or call `build_llm_campaign_wide_table`. Do not use Bluesky `PREPROCESSED_WIDE_COLUMNS` or `EXPECTED_WIDE_ROW_COUNT`.
+
+### Validate
+
+Raise if column names or order differ, if row count is not the YAML row count, if distinct `source_record_id` is not that count, if sort is not ascending, if any of the seven label columns has nulls, or if a forbidden column is present.
+
+### Wide upload and curation
+
+Keep the existing wide upload and MirrorView curation. Curated files stay under the dataset `curated/` stage as `mirrorview.parquet` plus `metadata.json`. Do not write under `wide/curated/`. Do not use `BlueskyStorageManager`. Do not change filter YAML semantics.
+
+### Stdout
+
+Print each accepted manifest digest, then:
+
+- `wide_rows=6408` for this campaign
+- `wide_columns=21`
+- `sort_key=source_record_id ASC`
+- `manifest=` plus the wide manifest URI
+- `curated_rows=` plus the filtered count
+- `curated=` plus the curated parquet URI
+- `curated_crosstab_political_stance_by_llm_toxicity_tier=` plus the JSON table
+
+## Implement-from-spec phases
+
+Phase 1 is this scope block.
+
+Phase 2 and Phase 3: add `expected_row_count` to `CampaignConsolidateArgs`. Add a helper that loads the campaign YAML and raises when CLI dataset id or preprocessed run disagrees. Keep existing join and curate bodies. Full auto, so do not wait. Commit.
+
+Phase 4: write the given/when/then live checks in the module docstring. Do not add `tests/`. Commit.
+
+Phase 5 units of work, in this order, one commit each:
+
+1. Load campaign YAML, fail on CLI identity mismatch, and thread `expected_row_count` through manifest checks, wide validation, and the wide manifest. Remove `TWITTER_EXPECTED_WIDE_ROW_COUNT`.
+
+Phase 6: checklist. The live commands in Step 2 are the designed checks. Do not run pytest.
+
+## Given / when / then (Phase 4)
+
+given campaign YAML row_count 6408, seven feature manifests whose final.parquet SHA-256 and row_count are 6408, and posts.csv whose SHA-256 matches the inventory
+when the CLI joins pinned posts on source_record_id with matching dataset id and preprocessed run
+then stdout includes each accepted manifest digest, wide_rows=6408, wide_columns=21, sort_key=source_record_id ASC, and the wide manifest URI
+
+given CLI --dataset-id or --preprocessed-run that disagrees with the campaign YAML
+when parse_args or run_campaign_consolidation runs
+then it raises ValueError before writing wide/features.parquet
+
+given campaign id twitter_2026_09_06_192847_llm_features_v1
+when load_twitter_campaign_config returns that YAML
+then expected wide row count is 6374
+
+given a missing or SHA-mismatched feature final.parquet, or a posts.csv SHA-256 that does not match the inventory
+when the CLI verifies inputs
+then it raises before writing wide/features.parquet
+
+given the uploaded wide parquet
+when the columns and row count are checked
+then column names match the 21-name contract, n=6408, and no llm_toxicity_tier is null
+
+given the same wide table and data_platform/curate/configs/twitter/mirrorview.yaml
+when apply_rules runs
+then curated row count and political_stance x llm_toxicity_tier counts are written under the dataset curated/ stage, in a timestamped run directory, as mirrorview.parquet plus metadata.json
+
+## Pass
+
+- Expected row count for the new campaign is 6408 from YAML, not a module constant of 6374.
+- CLI dataset id or preprocessed run that disagrees with YAML raises before the join.
+- Old campaign YAML still yields expected 6374.
+- Path building uses `FeaturePaths.for_campaign` with platform `twitter`.
+- Posts load from csv. Inventory SHA-256 is checked.
+- Join produces 21 columns in contract order.
+- Curation uses `TwitterStorageManager` and writes `mirrorview.parquet`.
+- No pytest files. No edits to forbidden files.
+
+## Fail
+
+- Expected row count is still the module constant 6374 for the new campaign.
+- Left table loaded from parquet.
+- `build_llm_campaign_wide_table` is called.
+- Bluesky `EXPECTED_WIDE_ROW_COUNT` is changed.
+- Curated files land under `wide/curated/` or through `BlueskyStorageManager`.
+- Filter YAML semantics changed.
+- Any file under `tests/` is added or edited.

--- a/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/steps/step2.md
+++ b/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/steps/step2.md
@@ -1,0 +1,98 @@
+# Step 2: Run the live join and write the report
+
+## Scope
+
+- **Caller:** the same consolidator `main` from Step 1, then the parquet assertion snippet below.
+- **Task:** Run the live consolidation against the locked campaign, confirm stdout and the downloaded wide parquet, copy logs to `/opt/cursor/artifacts/`, and write the wide run report with curated row count and the stance by toxicity table.
+- **Out of scope:** pytest, editing the consolidator after a green run except for docstring fixes required by `write-docstring`, editing forbidden product files.
+
+## Files to inspect (read-only)
+
+- `/workspace/data_platform/curate/consolidate_twitter_llm_campaign.py`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md`
+
+## Files allowed to change
+
+- `/workspace/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/reports/wide_run_report.md` (new)
+
+## Files forbidden to change
+
+- `/workspace/data_platform/curate/consolidate.py`
+- `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py`
+- `/workspace/data_platform/curate/configs/twitter/mirrorview.yaml`
+- `/workspace/data_platform/generate_features/**`
+- `/workspace/tests/**`
+- `/workspace/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/dataset.json`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/**`
+- `/workspace/docs/plans/2026-09-07_twitter_sync_preprocess_llm_curate_4a9cd5/**`
+
+## Live commands
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \
+  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
+  --preprocessed-run 2026_09_08-01:48:08 \
+  --campaign-id twitter_2026_09_08_014808_llm_features_v1 \
+  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/twitter_2026_09_08_014808_llm_features_v1/wide/features.parquet
+```
+
+Expected stdout includes each accepted manifest digest, `wide_rows=6408`, `wide_columns=21`, `sort_key=source_record_id ASC`, the wide manifest URI, `curated_rows=`, the curated parquet URI, and the stance by toxicity JSON table.
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/twitter_2026_09_08_014808_llm_features_v1/wide/features.parquet /tmp/twitter_2026_09_08_wide.parquet
+PYTHONPATH=. uv run python - <<'PY'
+import pyarrow.parquet as pq
+t = pq.read_table("/tmp/twitter_2026_09_08_wide.parquet")
+want = [
+    "tweet_id","record_id","url","username","author_handle","text","created_at",
+    "like_count","retweet_count","reply_count","quote_count","keyword","sync_timestamp",
+    "source_record_id","news_or_opinion_category","is_political","is_likely_spam",
+    "is_self_contained","is_structurally_complete","political_stance","llm_toxicity_tier",
+]
+assert t.column_names == want, t.column_names
+assert t.num_rows == 6408
+print("wide ok", t.num_rows, len(t.column_names))
+PY
+```
+
+Expected: `wide ok 6408 21`.
+
+Also list the curated prefix:
+
+```bash
+aws s3 ls s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/curated/
+```
+
+Copy consolidator stdout, wide validation, curated S3 listing, and the crosstab to `/opt/cursor/artifacts/`.
+
+## Report
+
+Write `/workspace/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/reports/wide_run_report.md` in the same shape as `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md`. It must include:
+
+- Pinned dataset id, preprocessed run, campaign id, 6408, 21 columns
+- Preprocessed csv SHA-256
+- Seven feature manifest and final.parquet SHA-256 values
+- Wide parquet and wide manifest URIs and SHA-256 values
+- Curated row count
+- Curated parquet and metadata URIs and SHA-256 values
+- Filter pass counts from YAML order
+- Crosstab of valid curated rows: `political_stance` rows `left` and `right` by `llm_toxicity_tier` columns `low`, `medium`, `high`, plus totals
+
+The crosstab is required. Do not omit it.
+
+## Pass
+
+- Live consolidator stdout matches the contract.
+- Downloaded wide parquet has 6408 rows and 21 named columns in order.
+- Report is committed with curated row count and the full stance by toxicity table.
+- Artifact logs exist under `/opt/cursor/artifacts/`.
+
+## Fail
+
+- Wide column order differs from the contract.
+- Report omits the crosstab or the curated row count.
+- Curated objects are missing from S3.
+- pytest is added or run.


### PR DESCRIPTION
# Join seven Twitter LLM features and write the MirrorView curated export

Fixes #256

Part of #251

## Summary

The Twitter consolidator now takes expected wide row count from the campaign YAML for `--campaign-id`. It joins seven verified `final.parquet` files to the 2026-09-07 preprocessed csv, uploads `wide/features.parquet` with a SHA-256 manifest, and writes a MirrorView curated export for dataset `twitter_5901767a-e609-46fc-9a17-742516b548f2`.

The CLI fails when `--dataset-id` or `--preprocessed-run` disagrees with that YAML. It writes a 21-column table of 6408 rows, applies `twitter/mirrorview.yaml`, and prints curated row count plus the stance by toxicity table.

## Purpose

Pull request 264 left seven isolated feature prefixes. MirrorView needs one 21-column table and the existing Twitter filter YAML. The previous consolidator forced 6374 rows for every Twitter campaign. The 2026-09-07 collection has 6408 posts, so expected count now comes from YAML `row_count`. Campaign `twitter_2026_09_06_192847_llm_features_v1` still expects 6374 because that YAML still says 6374.

Pytest, relabeling, and filter YAML edits are out of scope.

## Architecture

Components:

- `consolidate_twitter_llm_campaign.py` loads campaign YAML row count, downloads csv posts and seven feature files, inner-joins on `source_record_id`, validates the 21-column contract, uploads wide artifacts, and curates.
- `load_twitter_campaign_config` supplies `row_count`, `dataset_id`, and `preprocessed_run`.
- `FeaturePaths.for_campaign` builds Twitter campaign object keys with `platform=twitter`.
- `TwitterStorageManager` creates the curated run directory and writes `metadata.json`.
- S3 holds untagged `wide/features.parquet`, `wide/manifest.json`, and `curated/<timestamp>/mirrorview.parquet`.

Existing flow:

```mermaid
flowchart LR
  subgraph before [Before]
    C1[Operator] --> F1[Seven isolated final.parquet files]
    F1 --> K[Hardcoded 6374 wide row count]
  end
```

New flow:

```mermaid
flowchart TD
  subgraph after [After]
    C2[Operator] --> CLI[consolidate_twitter_llm_campaign.py]
    CLI --> YAML[Campaign YAML row_count]
    CLI --> CSV[Pinned posts.csv]
    CLI --> FEAT[Seven feature manifests]
    CLI --> WIDE[wide/features.parquet]
    CLI --> CUR[curated timestamped mirrorview.parquet]
  end
```

## Interfaces

### Locked identities

| Field | Value |
| --- | --- |
| Dataset id | `twitter_5901767a-e609-46fc-9a17-742516b548f2` |
| Preprocessed run | `2026_09_08-01:48:08` |
| Campaign id | `twitter_2026_09_08_014808_llm_features_v1` |
| Wide rows | 6408 |
| Wide columns | 21 |
| Join key | `source_record_id` |
| Inventory SHA-256 for posts.csv | `0461a0dc7ac5ecf1c5699fa893013dc7165af482a5347067e413bf4315ffdbd2` |

### Wide column order

`tweet_id`, `record_id`, `url`, `username`, `author_handle`, `text`, `created_at`, `like_count`, `retweet_count`, `reply_count`, `quote_count`, `keyword`, `sync_timestamp`, `source_record_id`, `news_or_opinion_category`, `is_political`, `is_likely_spam`, `is_self_contained`, `is_structurally_complete`, `political_stance`, `llm_toxicity_tier`

### Live result

- `wide_rows=6408`, `wide_columns=21`, `sort_key=source_record_id ASC`
- Curated rows: 1299 at `curated/2026_09_08-05:34:19/mirrorview.parquet`
- Wide parquet: `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/twitter_2026_09_08_014808_llm_features_v1/wide/features.parquet`
- Curated parquet: `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/curated/2026_09_08-05:34:19/mirrorview.parquet`

Row count by `political_stance` × `llm_toxicity_tier` (valid curated rows):

| political_stance | low | medium | high | total |
|------------------|-----|--------|------|-------|
| left | 512 | 118 | 9 | 639 |
| right | 342 | 245 | 73 | 660 |
| total | 854 | 363 | 82 | 1299 |

## How to run

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"

PYTHONPATH=. uv run python data_platform/curate/consolidate_twitter_llm_campaign.py \
  --dataset-id twitter_5901767a-e609-46fc-9a17-742516b548f2 \
  --preprocessed-run 2026_09_08-01:48:08 \
  --campaign-id twitter_2026_09_08_014808_llm_features_v1 \
  --output-s3-uri s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/features/twitter_2026_09_08_014808_llm_features_v1/wide/features.parquet
```

Expected: `wide_rows=6408`, `wide_columns=21`, `sort_key=source_record_id ASC`, `curated_rows=1299`, plus a timestamped `mirrorview.parquet` under the dataset `curated/` stage.

Plan: `docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/plan.md`

Live report: `docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/reports/wide_run_report.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Campaign consolidation now validates dataset and preprocessing run values against the selected campaign before writing data.
  - Wide-table row-count checks now use the campaign’s configured expectations, improving detection of incomplete or inconsistent results.

- **Documentation**
  - Updated command-line examples and guidance to reflect the latest Twitter LLM campaign configuration and expected output size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->