### PR TITLE
Combine curated Bluesky, Reddit, and Twitter posts into one stimulus parquet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,10 @@ data_platform/data/**
 !experiments/reddit_curated_perspective_v2_2026_09_08/outputs/
 !experiments/reddit_curated_perspective_v2_2026_09_08/outputs/**
 
+# Combined stimulus parquet lives in S3. Keep the local copy and cache out of git.
+experiments/combine_data_into_stimulus_set_2026_09_08/cache/
+experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet
+
 # OS generated files
 .DS_Store
 .DS_Store?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-08
 
-1. Operators now have one 55,573-row stimulus parquet that concatenates curated Bluesky, Reddit, and Twitter posts, with political-stance-by-toxicity counts in the experiment report and a copy on S3. [PR #266](https://github.com/METResearchGroup/mirrorView-task/pull/266)
+1. Operators now have one 55,573-row stimulus parquet of curated Bluesky, Reddit, and Twitter posts. The experiment report has counts of political stance by toxicity, and a copy of the parquet is on S3. [PR #266](https://github.com/METResearchGroup/mirrorView-task/pull/266)
 2. Operators now have a second curated Reddit Parquet file, and in that file 3,000 comments that the large language model labeled medium toxicity are labeled high instead, ranked by Perspective toxicity probability. The original MirrorView export still matches its recorded SHA-256. [PR #260](https://github.com/METResearchGroup/mirrorView-task/pull/260)
 3. Operators now have a Twitter table of 6,408 labeled posts with 21 columns, plus a MirrorView curated export that records political stance by toxicity tier. [PR #265](https://github.com/METResearchGroup/mirrorView-task/pull/265)
 4. Operators now have seven OpenAI Batch labels for all 6,408 Twitter posts from the 2026-09-07 collection, with four batch objects and a run report per feature. [PR #264](https://github.com/METResearchGroup/mirrorView-task/pull/264)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## 2026-09-08
 
-1. Operators now have a second curated Reddit Parquet file, and in that file 3,000 comments that the large language model labeled medium toxicity are labeled high instead, ranked by Perspective toxicity probability. The original MirrorView export still matches its recorded SHA-256. [PR #260](https://github.com/METResearchGroup/mirrorView-task/pull/260)
-2. Operators now have a Twitter table of 6,408 labeled posts with 21 columns, plus a MirrorView curated export that records political stance by toxicity tier. [PR #265](https://github.com/METResearchGroup/mirrorView-task/pull/265)
-3. Operators now have seven OpenAI Batch labels for all 6,408 Twitter posts from the 2026-09-07 collection, with four batch objects and a run report per feature. [PR #264](https://github.com/METResearchGroup/mirrorView-task/pull/264)
-4. The 2026-09-07 Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_08_014808_llm_features_v1` for 6,408 posts, and the 2026-09-05 campaign still loads. [PR #263](https://github.com/METResearchGroup/mirrorView-task/pull/263)
-5. Twitter preprocess on the 2026-09-07 collection kept 6,408 of 6,900 posts. The preprocessed `posts.csv` is stored in Git LFS. [PR #261](https://github.com/METResearchGroup/mirrorView-task/pull/261)
-6. A dated Mirrorview Twitter ingest config and a recent-search run (6,900 unique posts inside the 7-day window) are now in the repo. `posts.csv` is stored in Git LFS. [PR #259](https://github.com/METResearchGroup/mirrorView-task/pull/259)
+1. Operators now have one 55,573-row stimulus parquet that concatenates curated Bluesky, Reddit, and Twitter posts, with political-stance-by-toxicity counts in the experiment report and a copy on S3. [PR #266](https://github.com/METResearchGroup/mirrorView-task/pull/266)
+2. Operators now have a second curated Reddit Parquet file, and in that file 3,000 comments that the large language model labeled medium toxicity are labeled high instead, ranked by Perspective toxicity probability. The original MirrorView export still matches its recorded SHA-256. [PR #260](https://github.com/METResearchGroup/mirrorView-task/pull/260)
+3. Operators now have a Twitter table of 6,408 labeled posts with 21 columns, plus a MirrorView curated export that records political stance by toxicity tier. [PR #265](https://github.com/METResearchGroup/mirrorView-task/pull/265)
+4. Operators now have seven OpenAI Batch labels for all 6,408 Twitter posts from the 2026-09-07 collection, with four batch objects and a run report per feature. [PR #264](https://github.com/METResearchGroup/mirrorView-task/pull/264)
+5. The 2026-09-07 Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_08_014808_llm_features_v1` for 6,408 posts, and the 2026-09-05 campaign still loads. [PR #263](https://github.com/METResearchGroup/mirrorView-task/pull/263)
+6. Twitter preprocess on the 2026-09-07 collection kept 6,408 of 6,900 posts. The preprocessed `posts.csv` is stored in Git LFS. [PR #261](https://github.com/METResearchGroup/mirrorView-task/pull/261)
+7. A dated Mirrorview Twitter ingest config and a recent-search run (6,900 unique posts inside the 7-day window) are now in the repo. `posts.csv` is stored in Git LFS. [PR #259](https://github.com/METResearchGroup/mirrorView-task/pull/259)
 
 ## 2026-09-07
 

--- a/docs/plans/2026-09-08_combine_data_into_stimulus_set_9e4b12/plan.md
+++ b/docs/plans/2026-09-08_combine_data_into_stimulus_set_9e4b12/plan.md
@@ -1,0 +1,51 @@
+# Combine curated Bluesky, Reddit, and Twitter posts into one stimulus parquet
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Operators have four MirrorView curated exports from the recent labeling PRs. The experiment downloads those four files, concatenates them into one parquet, writes that file locally and to S3, and reports post counts by political stance and toxicity, first overall and then split by Bluesky, Reddit, and Twitter.
+
+## Happy flow
+
+An operator runs one command from the repo root. The script downloads the four pinned curated parquet files from S3, checks each file's SHA-256 and row count, writes one combined parquet locally and to S3, and prints two count tables. The same tables are written to RESULTS.md.
+
+```mermaid
+flowchart TD
+    A[Download four curated parquet files] --> B[Check SHA-256 and row counts]
+    B --> C[Add platform and source columns]
+    C --> D[Concatenate all rows]
+    D --> E[Write local dataset.parquet]
+    E --> F[Upload dataset.parquet to S3]
+    F --> G[Count stance by toxicity overall]
+    G --> H[Count stance by toxicity by platform]
+    H --> I[Write RESULTS.md]
+```
+
+## Approach
+
+Treat the four curated exports as the inputs. Do not re-run labeling, curation filters, or the older sampler. Keep every curated row. Use the Reddit second file that moved 3000 medium comments to high. Add a platform column so the two Twitter collections sit in one Twitter group in the three-platform table.
+
+## Steps
+
+### Step 1: Add the combine script
+
+Add a command under `experiments/combine_data_into_stimulus_set_2026_09_08/` that downloads the four pinned curated files, checks hashes and row counts, concatenates a shared column set, writes the local parquet, and uploads it to S3. The step file is [steps/step1.md](steps/step1.md).
+
+### Step 2: Run the command and write RESULTS.md
+
+Run the command with AWS credentials. Confirm the local file and the S3 object, then commit RESULTS.md with the overall stance by toxicity table and the table that splits those counts by Bluesky, Reddit, and Twitter. The step file is [steps/step2.md](steps/step2.md).
+
+## What "done" looks like
+
+1. The experiment folder exists at `experiments/combine_data_into_stimulus_set_2026_09_08/`.
+2. `dataset.parquet` exists locally under that folder and at `s3://mirrorview-experimental-artifacts/experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet`.
+3. Combined row count equals 9756 + 1457 + 1299 + 43061, which is 55573.
+4. `RESULTS.md` has the overall stance by toxicity table and the three-platform table.
+5. Stdout prints the same two tables.
+6. Product curate scripts and MirrorView filter YAML files are unchanged.
+7. No pytest files were added, because this is experiment code.

--- a/docs/plans/2026-09-08_combine_data_into_stimulus_set_9e4b12/steps/step1.md
+++ b/docs/plans/2026-09-08_combine_data_into_stimulus_set_9e4b12/steps/step1.md
@@ -1,0 +1,206 @@
+# Step 1: Add the combine script
+
+## Scope
+
+- **Caller:** `experiments/combine_data_into_stimulus_set_2026_09_08/run.py` `main`
+- **Task:** Download four pinned curated parquet files from S3, check each file's SHA-256 and row count, normalize to a shared column set, concatenate, write local `dataset.parquet`, upload that file to S3 with `put_new`, print two crosstab tables, and write `RESULTS.md`.
+- **Out of scope:** pytest, relabeling, curation YAML edits, `sample_data_to_mirror.py`, generating mirrors, changing product curate scripts, overwriting the four source objects.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/wide_run_report.md` | Bluesky curated URI, hash, 9756 rows, stance by toxicity |
+| `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md` | Twitter collection 1 curated URI, hash, 1457 rows |
+| `/workspace/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/reports/wide_run_report.md` | Twitter collection 2 curated URI, hash, 1299 rows |
+| `/workspace/docs/plans/2026-09-07_generate_reddit_llm_features_c7a14e/reports/wide_run_report.md` | Original Reddit curated URI and 43061 rows |
+| `/workspace/experiments/reddit_curated_perspective_v2_2026_09_08/RESULTS.md` | Reddit second file URI, hash, v2 stance by toxicity |
+| `/workspace/experiments/reddit_curated_perspective_v2_2026_09_08/load_curated.py` | Download, hash check, `CampaignObjectStore.get` |
+| `/workspace/data_platform/generate_features/s3_feature_campaign.py` | `CampaignObjectStore`, `parse_s3_uri`, `put_new` |
+| `/workspace/data_platform/utils/object_store.py` | `sha256_hex`, `DEFAULT_S3_BUCKET`, `DEFAULT_S3_REGION` |
+| `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py` | Stance rows `left`/`right`, toxicity columns `low`/`medium`/`high` |
+| `/workspace/lib/constants.py` | `REPO_ROOT` |
+| `/workspace/.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md` | Experiment code does not get unit tests |
+
+## Files allowed to change
+
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/run.py` (new)
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/sources.py` (new)
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/load.py` (new)
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/normalize.py` (new)
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/crosstab.py` (new)
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/write.py` (new)
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/README.md` (new)
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/.gitignore` (new)
+- `/workspace/.gitignore` (ignore local parquet and cache under this experiment folder only)
+
+## Files forbidden to change
+
+- `/workspace/data_platform/curate/consolidate_bluesky_llm_campaign.py`
+- `/workspace/data_platform/curate/consolidate_reddit_llm_campaign.py`
+- `/workspace/data_platform/curate/consolidate_twitter_llm_campaign.py`
+- `/workspace/data_platform/curate/configs/**`
+- `/workspace/experiments/scaled_mirrors_generation_2026_06_02/**`
+- `/workspace/experiments/reddit_curated_perspective_v2_2026_09_08/**`
+- `/workspace/tests/**`
+- The four source S3 objects listed below
+- `/workspace/CHANGELOG.md` until Step 2 has a live S3 object and RESULTS.md
+
+## Pinned sources
+
+Use these four objects. Reddit uses the second file `mirrorview_v2.parquet`, not the original `mirrorview.parquet`.
+
+| Platform | Dataset id | Curated run | Object | SHA-256 | Rows |
+|----------|------------|-------------|--------|---------|-----:|
+| bluesky | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` | `2026_09_06-23:25:06` | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/curated/2026_09_06-23:25:06/mirrorview.parquet` | `35e3f05111a16c27b95538894cda18db6d7295c8aad6be4fb7cb83ecafb1b3bc` | 9756 |
+| twitter | `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` | `2026_09_07-06:58:09` | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/curated/2026_09_07-06:58:09/mirrorview.parquet` | `7639e54554869371fdb6397a1c2a497b32711679290322b999fb68ee173f39c9` | 1457 |
+| twitter | `twitter_5901767a-e609-46fc-9a17-742516b548f2` | `2026_09_08-05:34:19` | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/curated/2026_09_08-05:34:19/mirrorview.parquet` | `c2178c27165c26dd960bd470e3ee98791e7c98638a346eca0f0fafa1c065c8e2` | 1299 |
+| reddit | `reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079` | `2026_09_07-21:47:32` | `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/curated/2026_09_07-21:47:32/mirrorview_v2.parquet` | `e1d9b1494fd2ef030dc8fdc1f71980b55d972e4a01da23923fa6f61a693a3936` | 43061 |
+
+Combined expected row count: 55573.
+
+## Shared column contract
+
+The combined parquet has these columns in this order:
+
+1. `integration`
+2. `source_dataset_id`
+3. `source_curated_run`
+4. `record_id`
+5. `source_record_id`
+6. `platform_id`
+7. `author_handle`
+8. `text`
+9. `created_at`
+10. `sync_timestamp`
+11. `news_or_opinion_category`
+12. `is_political`
+13. `is_likely_spam`
+14. `is_self_contained`
+15. `is_structurally_complete`
+16. `political_stance`
+17. `llm_toxicity_tier`
+
+`platform_id` comes from `uri` on Bluesky, `tweet_id` on Twitter, and `comment_fullname` on Reddit.
+
+`text` is the existing standardized `text` column on every source. Do not use Reddit `body`.
+
+`integration` values are `bluesky`, `reddit`, and `twitter`.
+
+Sort the combined table by `integration` ascending, then `source_dataset_id` ascending, then `source_record_id` ascending. Do not drop rows. Do not dedupe across the two Twitter collections. If a tweet id appears in both Twitter files, keep both rows.
+
+A missing required column, a hash mismatch, or a wrong source row count raises `ValueError`. A missing source object raises `FileNotFoundError`.
+
+## Outputs
+
+| Output | Path |
+|--------|------|
+| Local parquet | `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet` |
+| S3 parquet | `s3://mirrorview-experimental-artifacts/experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet` |
+| S3 key | `experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet` |
+| Report | `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/RESULTS.md` |
+| Cache | `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/cache/` (gitignored) |
+
+Upload with `CampaignObjectStore.put_new`. The write fails if the S3 key already exists. Record SHA-256 of the parquet bytes as object metadata the same way `put_new` already does.
+
+Gitignore `cache/` and `dataset.parquet` under this experiment folder. Do not commit the parquet.
+
+## Crosstab contract
+
+Stance rows are `left` and `right`. Toxicity columns are `low`, `medium`, and `high`. Missing cells count as 0.
+
+Table 1 is overall `political_stance` by `llm_toxicity_tier` across all 55573 rows, with row totals and a total row.
+
+Table 2 is the same counts split by `integration`. One markdown table with columns `integration`, `political_stance`, `low`, `medium`, `high`, `total`. Platform order is `bluesky`, `reddit`, `twitter`. The two Twitter collections are one `twitter` group. Include a total row per platform and a grand total row.
+
+Stdout prints both tables as JSON, plus `combined_rows=55573` and the local and S3 URIs and SHA-256.
+
+## Main caller
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/combine_data_into_stimulus_set_2026_09_08/run.py
+```
+
+Expected stdout includes `combined_rows=55573`, `local_path=`, `s3_uri=s3://mirrorview-experimental-artifacts/experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet`, `dataset_sha256=`, and the two JSON tables.
+
+## Work
+
+Follow `/implement-from-spec`. Full auto. Do not add pytest. Phase 4 is the given/when/then live checks below, written in the `run.py` module docstring.
+
+### Modules
+
+Keep functions under 20 lines. Use a frozen dataclass for each pinned source. Do not pass unstructured dictionaries for source identity.
+
+`sources.py` holds `CuratedSource` and the four pinned records.
+
+`load.py` downloads one source through `CampaignObjectStore.get`, checks SHA-256 with `sha256_hex`, checks row count, and may cache bytes under `cache/`.
+
+`normalize.py` maps one source frame onto the 17 shared columns.
+
+`crosstab.py` builds the two count tables.
+
+`write.py` writes local parquet bytes, uploads with `put_new`, and writes `RESULTS.md`.
+
+`run.py` is the caller: load all four, normalize, concatenate, sort, write, print.
+
+Reuse `CampaignObjectStore`, `parse_s3_uri`, and `sha256_hex`. Do not copy a new S3 client.
+
+### Live given / when / then (Phase 4)
+
+```text
+given AWS credentials from LAB_AWS_ACCESS_KEY_ID and LAB_AWS_ACCESS_KEY_SECRET
+and the four pinned curated objects exist at the hashes above
+when PYTHONPATH=. uv run python experiments/combine_data_into_stimulus_set_2026_09_08/run.py
+then combined_rows=55573
+and local dataset.parquet exists
+and S3 object experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet exists
+and its SHA-256 matches the local file
+and RESULTS.md contains the overall stance by toxicity table
+and RESULTS.md contains the three-platform stance by toxicity table
+and stdout prints both tables
+
+given the S3 dataset.parquet key already exists
+when the command is run again
+then the process raises FileExistsError and does not change the four source objects
+```
+
+## Must pass
+
+- Imports from `run.py` resolve.
+- Combined row count is 55573 after a live run in Step 2.
+- Combined columns match the 17-name contract in order.
+- Reddit source is `mirrorview_v2.parquet`.
+- Product curate files are unchanged.
+
+## Must fail
+
+- Hash mismatch on any source.
+- Wrong source row count.
+- Missing required column on a source.
+- Second upload to the same S3 key.
+
+## Implement-from-spec notes
+
+Phase 1 names `run.py` `main` as the caller.
+
+Phase 2 scaffolds the six modules with stub bodies and a thin `main` that calls load, normalize, concatenate, write, print.
+
+Phase 3 locks `CuratedSource` and the public function signatures. Continue without a pause because this run is full auto.
+
+Phase 4 writes the given/when/then block in the `run.py` docstring. Do not add files under `tests/`.
+
+Phase 5 implements in this order, one commit per unit of work:
+
+1. `CuratedSource` and `PINNED_SOURCES`
+2. download and hash/row checks
+3. normalize to 17 columns
+4. concatenate and sort
+5. crosstab builders
+6. local parquet write
+7. S3 `put_new`
+8. RESULTS.md writer and `main`
+
+Phase 6 is complete when the modules exist, imports resolve, and Step 2 can run the live command.

--- a/docs/plans/2026-09-08_combine_data_into_stimulus_set_9e4b12/steps/step2.md
+++ b/docs/plans/2026-09-08_combine_data_into_stimulus_set_9e4b12/steps/step2.md
@@ -1,0 +1,134 @@
+# Step 2: Run the command and write RESULTS.md
+
+## Scope
+
+- **Caller:** the same `run.py` `main` from Step 1.
+- **Task:** Export AWS credentials, run the combine command, confirm local and S3 parquet, copy logs to `/opt/cursor/artifacts/`, and commit `RESULTS.md` with the two crosstab tables filled from the live run.
+- **Out of scope:** pytest, editing product curate files, changing pinned source objects, rewriting Step 1 modules except docstring fixes required by `write-docstring`.
+
+## Files to inspect (read-only)
+
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/run.py`
+- `/workspace/experiments/reddit_curated_perspective_v2_2026_09_08/RESULTS.md`
+- `/workspace/docs/plans/2026-09-05_generate_bluesky_llm_features_4d8a7c/reports/wide_run_report.md`
+- `/workspace/docs/plans/2026-09-07_generate_twitter_llm_features_e3c91a/reports/wide_run_report.md`
+- `/workspace/docs/plans/2026-09-08_join_twitter_llm_curate_19e01b/reports/wide_run_report.md`
+- `/workspace/experiments/reddit_curated_perspective_v2_2026_09_08/RESULTS.md`
+
+## Files allowed to change
+
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/RESULTS.md` (written by the live command, then committed)
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/README.md` (command and expected stdout only, if Step 1 left placeholders)
+
+## Files forbidden to change
+
+- `/workspace/data_platform/curate/**`
+- `/workspace/data_platform/curate/configs/**`
+- `/workspace/tests/**`
+- `/workspace/experiments/reddit_curated_perspective_v2_2026_09_08/**`
+- The four source S3 objects
+- `/workspace/docs/plans/2026-09-08_combine_data_into_stimulus_set_9e4b12/**`
+
+## Live commands
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/combine_data_into_stimulus_set_2026_09_08/run.py
+```
+
+Expected stdout includes `combined_rows=55573`, a local path under `experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet`, `s3_uri=s3://mirrorview-experimental-artifacts/experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet`, `dataset_sha256=`, and two JSON tables.
+
+```bash
+aws s3 cp s3://mirrorview-experimental-artifacts/experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet /tmp/combine_stimulus_dataset.parquet
+PYTHONPATH=. uv run python - <<'PY'
+import hashlib
+from pathlib import Path
+import pyarrow.parquet as pq
+
+local = Path("experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet")
+downloaded = Path("/tmp/combine_stimulus_dataset.parquet")
+want = [
+    "integration",
+    "source_dataset_id",
+    "source_curated_run",
+    "record_id",
+    "source_record_id",
+    "platform_id",
+    "author_handle",
+    "text",
+    "created_at",
+    "sync_timestamp",
+    "news_or_opinion_category",
+    "is_political",
+    "is_likely_spam",
+    "is_self_contained",
+    "is_structurally_complete",
+    "political_stance",
+    "llm_toxicity_tier",
+]
+table = pq.read_table(downloaded)
+assert table.column_names == want, table.column_names
+assert table.num_rows == 55573
+assert hashlib.sha256(local.read_bytes()).hexdigest() == hashlib.sha256(downloaded.read_bytes()).hexdigest()
+print("combined ok", table.num_rows, len(table.column_names))
+PY
+```
+
+Expected: `combined ok 55573 17`.
+
+Also list the prefix:
+
+```bash
+aws s3 ls s3://mirrorview-experimental-artifacts/experiments/combine_data_into_stimulus_set_2026_09_08/
+```
+
+Expected listing includes `dataset.parquet`.
+
+Copy command stdout, the parquet assertion, and the S3 listing to `/opt/cursor/artifacts/`.
+
+## RESULTS.md
+
+`RESULTS.md` must include:
+
+- The four source URIs, SHA-256 values, and row counts
+- Combined row count 55573
+- Combined parquet local path, S3 URI, and SHA-256
+- Overall political stance by LLM toxicity tier table (`left`/`right` by `low`/`medium`/`high`, with totals)
+- The three-platform table with `integration`, `political_stance`, `low`, `medium`, `high`, `total`
+- The exact rerun command
+
+Twitter rows from both collections must sit in the Twitter group of the three-platform table. Bluesky counts in that table must match the Bluesky wide-run report (9756 rows). Reddit counts must match the v2 report (43061 rows, with 3000 medium comments moved to high). Twitter counts must equal 1457 + 1299 = 2756.
+
+Sanity check against source reports before committing RESULTS.md:
+
+| Platform | left low | left medium | left high | right low | right medium | right high | total |
+|----------|---------:|------------:|----------:|----------:|-------------:|-----------:|------:|
+| bluesky | 3563 | 4179 | 585 | 529 | 755 | 145 | 9756 |
+| reddit v2 | 13423 | 12632 | 3056 | 7998 | 5095 | 857 | 43061 |
+| twitter 1 | 563 | 142 | 12 | 392 | 279 | 69 | 1457 |
+| twitter 2 | 512 | 118 | 9 | 342 | 245 | 73 | 1299 |
+
+Twitter combined: left 1075 / 260 / 21, right 734 / 524 / 142, total 2756.
+
+Overall: left 18061 / 17071 / 3662, right 9261 / 6374 / 1144, total 55573.
+
+If a live cell disagrees with this table, stop. Do not invent numbers.
+
+## Must pass
+
+- Live command exits 0 on the first run.
+- `combined ok 55573 17`.
+- S3 object exists and matches local SHA-256.
+- RESULTS.md tables match the sanity-check totals above.
+- Source S3 objects are unchanged.
+
+## Must fail
+
+- A second run that tries to `put_new` the same S3 key (expected `FileExistsError`). Do not treat that as a product bug.
+- Any change to product curate scripts.
+
+## Implement-from-spec notes
+
+This step is a live run, not new product logic. Do not add pytest. After a green run, commit RESULTS.md. Apply `write-docstring` only if Step 1 docstrings are incomplete, as a separate commit.

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/.gitignore
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/.gitignore
@@ -1,0 +1,2 @@
+cache/
+dataset.parquet

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/README.md
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/README.md
@@ -1,6 +1,6 @@
 # Combine curated data into a stimulus set
 
-Download the four pinned MirrorView curated parquet files (Bluesky, two Twitter collections, and Reddit v2). Concatenate them into one table. Write `dataset.parquet` locally and to S3. Print counts of posts by political stance and toxicity, overall and by platform.
+Download the four pinned MirrorView curated parquet files (Bluesky, two Twitter collections, and Reddit v2), and concatenate them into one table. Write `dataset.parquet` locally and to S3, and print counts of posts by political stance and toxicity, both overall and by platform.
 
 ## Run
 
@@ -10,4 +10,4 @@ export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 PYTHONPATH=. uv run python experiments/combine_data_into_stimulus_set_2026_09_08/run.py
 ```
 
-Expected stdout includes `combined_rows=55573` and the S3 URI for `dataset.parquet`. The write fails if that S3 object already exists.
+Expected stdout includes `combined_rows=55573` and the S3 URI for `dataset.parquet`. The S3 upload fails if that object already exists.

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/README.md
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/README.md
@@ -1,0 +1,13 @@
+# Combine curated data into a stimulus set
+
+Download the four pinned MirrorView curated parquet files (Bluesky, two Twitter collections, and Reddit v2). Concatenate them into one table. Write `dataset.parquet` locally and to S3. Print counts of posts by political stance and toxicity, overall and by platform.
+
+## Run
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+PYTHONPATH=. uv run python experiments/combine_data_into_stimulus_set_2026_09_08/run.py
+```
+
+Expected stdout includes `combined_rows=55573` and the S3 URI for `dataset.parquet`. The write fails if that S3 object already exists.

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/RESULTS.md
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/RESULTS.md
@@ -1,0 +1,51 @@
+# Combine curated data into a stimulus set, results
+
+## Command
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/combine_data_into_stimulus_set_2026_09_08/run.py
+```
+
+## Sources
+
+| Platform | Dataset id | Curated run | Object | SHA-256 | Rows |
+| -------- | ---------- | ----------- | ------ | ------- | ---: |
+| bluesky | `bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73` | `2026_09_06-23:25:06` | `s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73/curated/2026_09_06-23:25:06/mirrorview.parquet` | `35e3f05111a16c27b95538894cda18db6d7295c8aad6be4fb7cb83ecafb1b3bc` | 9756 |
+| twitter | `twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547` | `2026_09_07-06:58:09` | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547/curated/2026_09_07-06:58:09/mirrorview.parquet` | `7639e54554869371fdb6397a1c2a497b32711679290322b999fb68ee173f39c9` | 1457 |
+| twitter | `twitter_5901767a-e609-46fc-9a17-742516b548f2` | `2026_09_08-05:34:19` | `s3://mirrorview-experimental-artifacts/data_platform/data/twitter/twitter_5901767a-e609-46fc-9a17-742516b548f2/curated/2026_09_08-05:34:19/mirrorview.parquet` | `c2178c27165c26dd960bd470e3ee98791e7c98638a346eca0f0fafa1c065c8e2` | 1299 |
+| reddit | `reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079` | `2026_09_07-21:47:32` | `s3://mirrorview-experimental-artifacts/data_platform/data/reddit/reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079/curated/2026_09_07-21:47:32/mirrorview_v2.parquet` | `e1d9b1494fd2ef030dc8fdc1f71980b55d972e4a01da23923fa6f61a693a3936` | 43061 |
+
+Combined row count is 55573. Expected row count is 55573.
+
+## Combined parquet
+
+| File | Path | SHA-256 |
+| ---- | ---- | ------- |
+| Local parquet | `experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet` | `f24ad1fd8c3709ffbbba9fb5dc953dcaee2f11ad8916ae21612b7f25cb5ca3f0` |
+| S3 parquet | `s3://mirrorview-experimental-artifacts/experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet` | `f24ad1fd8c3709ffbbba9fb5dc953dcaee2f11ad8916ae21612b7f25cb5ca3f0` |
+
+## Overall political stance by LLM toxicity tier
+
+| political_stance | low | medium | high | total |
+| ---------------- | --: | -----: | ---: | ----: |
+| left | 18061 | 17071 | 3662 | 38794 |
+| right | 9261 | 6374 | 1144 | 16779 |
+| total | 27322 | 23445 | 4806 | 55573 |
+
+## Political stance by LLM toxicity tier, by platform
+
+| integration | political_stance | low | medium | high | total |
+| ----------- | ---------------- | --: | -----: | ---: | ----: |
+| bluesky | left | 3563 | 4179 | 585 | 8327 |
+| bluesky | right | 529 | 755 | 145 | 1429 |
+| bluesky | total | 4092 | 4934 | 730 | 9756 |
+| reddit | left | 13423 | 12632 | 3056 | 29111 |
+| reddit | right | 7998 | 5095 | 857 | 13950 |
+| reddit | total | 21421 | 17727 | 3913 | 43061 |
+| twitter | left | 1075 | 260 | 21 | 1356 |
+| twitter | right | 734 | 524 | 142 | 1400 |
+| twitter | total | 1809 | 784 | 163 | 2756 |
+| total | total | 27322 | 23445 | 4806 | 55573 |

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/RESULTS.md
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/RESULTS.md
@@ -49,3 +49,10 @@ Combined row count is 55573. Expected row count is 55573.
 | twitter | right | 734 | 524 | 142 | 1400 |
 | twitter | total | 1809 | 784 | 163 | 2756 |
 | total | total | 27322 | 23445 | 4806 | 55573 |
+
+## Twitter posts that appear in both collections
+
+574 Twitter posts appear in both curated collections, so they contribute 1,148 of the 2,756 Twitter rows. Unique Twitter posts are 2,182. The combine keeps both rows, and it does not drop or merge them.
+
+25 of those 574 posts have different labels across the two collections: 12 differ on political stance, 16 differ on LLM toxicity tier, and 3 differ on both. A later stimulus catalog that keys rows by `record_id` or tweet id alone would treat those posts as duplicates.
+

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/crosstab.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/crosstab.py
@@ -1,0 +1,15 @@
+"""Count political stance by LLM toxicity tier, overall and by platform."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def stance_by_toxicity(frame: pd.DataFrame) -> dict:
+    """Return left/right counts by low, medium, and high toxicity."""
+    raise NotImplementedError
+
+
+def stance_by_toxicity_by_integration(frame: pd.DataFrame) -> dict:
+    """Return stance by toxicity counts grouped by platform."""
+    raise NotImplementedError

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/crosstab.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/crosstab.py
@@ -5,11 +5,36 @@ from __future__ import annotations
 import pandas as pd
 
 
-def stance_by_toxicity(frame: pd.DataFrame) -> dict:
-    """Return left/right counts by low, medium, and high toxicity."""
+def stance_by_toxicity(frame: pd.DataFrame) -> dict[str, dict[str, int]]:
+    """Return left/right counts by low, medium, and high toxicity.
+
+    Parameters
+    ----------
+    frame
+        Combined table with ``political_stance`` and ``llm_toxicity_tier``.
+
+    Returns
+    -------
+    dict[str, dict[str, int]]
+        Counts keyed by stance, then by toxicity tier. Missing cells are 0.
+    """
     raise NotImplementedError
 
 
-def stance_by_toxicity_by_integration(frame: pd.DataFrame) -> dict:
-    """Return stance by toxicity counts grouped by platform."""
+def stance_by_toxicity_by_integration(
+    frame: pd.DataFrame,
+) -> dict[str, dict[str, dict[str, int]]]:
+    """Return stance by toxicity counts grouped by platform.
+
+    Parameters
+    ----------
+    frame
+        Combined table with ``integration``, ``political_stance``, and
+        ``llm_toxicity_tier``.
+
+    Returns
+    -------
+    dict[str, dict[str, dict[str, int]]]
+        Counts keyed by platform, then stance, then toxicity tier.
+    """
     raise NotImplementedError

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/crosstab.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/crosstab.py
@@ -4,6 +4,16 @@ from __future__ import annotations
 
 import pandas as pd
 
+from experiments.combine_data_into_stimulus_set_2026_09_08.sources import (
+    INTEGRATION_CROSSTAB_ORDER,
+    STANCE_CROSSTAB_ROWS,
+    TOXICITY_CROSSTAB_COLUMNS,
+)
+
+INTEGRATION_COLUMN = "integration"
+STANCE_COLUMN = "political_stance"
+TOXICITY_COLUMN = "llm_toxicity_tier"
+
 
 def stance_by_toxicity(frame: pd.DataFrame) -> dict[str, dict[str, int]]:
     """Return left/right counts by low, medium, and high toxicity.
@@ -18,7 +28,8 @@ def stance_by_toxicity(frame: pd.DataFrame) -> dict[str, dict[str, int]]:
     dict[str, dict[str, int]]
         Counts keyed by stance, then by toxicity tier. Missing cells are 0.
     """
-    raise NotImplementedError
+    grouped = frame.groupby([STANCE_COLUMN, TOXICITY_COLUMN], dropna=False).size()
+    return _fill_stance_counts(grouped)
 
 
 def stance_by_toxicity_by_integration(
@@ -37,4 +48,37 @@ def stance_by_toxicity_by_integration(
     dict[str, dict[str, dict[str, int]]]
         Counts keyed by platform, then stance, then toxicity tier.
     """
-    raise NotImplementedError
+    grouped = frame.groupby(
+        [INTEGRATION_COLUMN, STANCE_COLUMN, TOXICITY_COLUMN],
+        dropna=False,
+    ).size()
+    return _fill_integration_counts(grouped)
+
+
+def _empty_stance_counts() -> dict[str, dict[str, int]]:
+    return {
+        stance: {tier: 0 for tier in TOXICITY_CROSSTAB_COLUMNS}
+        for stance in STANCE_CROSSTAB_ROWS
+    }
+
+
+def _fill_stance_counts(grouped: pd.Series) -> dict[str, dict[str, int]]:
+    counts = _empty_stance_counts()
+    for (stance, tier), row_count in grouped.items():
+        counts.setdefault(str(stance), {})
+        counts[str(stance)][str(tier)] = int(row_count)
+    return counts
+
+
+def _fill_integration_counts(
+    grouped: pd.Series,
+) -> dict[str, dict[str, dict[str, int]]]:
+    counts = {
+        integration: _empty_stance_counts() for integration in INTEGRATION_CROSSTAB_ORDER
+    }
+    for (integration, stance, tier), row_count in grouped.items():
+        platform = str(integration)
+        counts.setdefault(platform, _empty_stance_counts())
+        counts[platform].setdefault(str(stance), {})
+        counts[platform][str(stance)][str(tier)] = int(row_count)
+    return counts

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/load.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/load.py
@@ -1,0 +1,10 @@
+"""Download a pinned curated parquet and check its hash and row count."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def load_curated_source(source) -> pd.DataFrame:
+    """Return one curated table after checking SHA-256 and row count."""
+    raise NotImplementedError

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/load.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/load.py
@@ -2,9 +2,41 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
 
+from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from experiments.combine_data_into_stimulus_set_2026_09_08.sources import CuratedSource
 
-def load_curated_source(source) -> pd.DataFrame:
-    """Return one curated table after checking SHA-256 and row count."""
+
+def load_curated_source(
+    source: CuratedSource,
+    store: CampaignObjectStore | None = None,
+    cache_dir: Path | None = None,
+) -> pd.DataFrame:
+    """Return one curated table after checking SHA-256 and row count.
+
+    Parameters
+    ----------
+    source
+        Pinned curated parquet identity.
+    store
+        Object store used to download the source. None builds a store for the
+        source bucket.
+    cache_dir
+        Directory for a local copy of the source bytes.
+
+    Returns
+    -------
+    pd.DataFrame
+        The curated table.
+
+    Raises
+    ------
+    FileNotFoundError
+        When the source object is missing.
+    ValueError
+        When the SHA-256 or row count does not match the pin.
+    """
     raise NotImplementedError

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/load.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/load.py
@@ -2,12 +2,23 @@
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 
 import pandas as pd
 
-from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from data_platform.generate_features.s3_feature_campaign import (
+    CampaignObjectStore,
+    parse_s3_uri,
+)
+from data_platform.utils.object_store import sha256_hex
 from experiments.combine_data_into_stimulus_set_2026_09_08.sources import CuratedSource
+from lib.constants import REPO_ROOT
+
+EXPERIMENT_DIR = (
+    REPO_ROOT / "experiments" / "combine_data_into_stimulus_set_2026_09_08"
+)
+DEFAULT_CACHE_DIR = EXPERIMENT_DIR / "cache"
 
 
 def load_curated_source(
@@ -39,4 +50,56 @@ def load_curated_source(
     ValueError
         When the SHA-256 or row count does not match the pin.
     """
-    raise NotImplementedError
+    resolved_store = store if store is not None else _store_for_source(source)
+    resolved_cache_dir = cache_dir if cache_dir is not None else DEFAULT_CACHE_DIR
+    body = _bytes_matching_pinned_hash(source, resolved_store, resolved_cache_dir)
+    curated = pd.read_parquet(io.BytesIO(body))
+    _require_row_count(source, curated)
+    return curated
+
+
+def _store_for_source(source: CuratedSource) -> CampaignObjectStore:
+    bucket, _key = parse_s3_uri(source.s3_uri)
+    return CampaignObjectStore(bucket)
+
+
+def _object_key(source: CuratedSource) -> str:
+    _bucket, key = parse_s3_uri(source.s3_uri)
+    return key
+
+
+def _cache_path(source: CuratedSource, cache_dir: Path) -> Path:
+    return cache_dir / f"{source.dataset_id}.parquet"
+
+
+def _download_source_bytes(source: CuratedSource, store: CampaignObjectStore) -> bytes:
+    stored = store.get(_object_key(source))
+    if stored is None:
+        raise FileNotFoundError(source.s3_uri)
+    return stored.body
+
+
+def _bytes_matching_pinned_hash(
+    source: CuratedSource,
+    store: CampaignObjectStore,
+    cache_dir: Path,
+) -> bytes:
+    cache_path = _cache_path(source, cache_dir)
+    if cache_path.is_file():
+        cached = cache_path.read_bytes()
+        if sha256_hex(cached) == source.sha256:
+            return cached
+    body = _download_source_bytes(source, store)
+    if sha256_hex(body) != source.sha256:
+        raise ValueError(f"SHA-256 mismatch for {source.s3_uri}")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(body)
+    return body
+
+
+def _require_row_count(source: CuratedSource, curated: pd.DataFrame) -> None:
+    if len(curated) != source.expected_row_count:
+        raise ValueError(
+            f"row_count={len(curated)} expected={source.expected_row_count} "
+            f"uri={source.s3_uri}"
+        )

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/load.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/load.py
@@ -33,8 +33,7 @@ def load_curated_source(
     source
         Pinned curated parquet identity.
     store
-        Object store used to download the source. None builds a store for the
-        source bucket.
+        If you omit store, the function builds a store for the source bucket.
     cache_dir
         Directory for a local copy of the source bytes.
 

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/normalize.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/normalize.py
@@ -4,7 +4,27 @@ from __future__ import annotations
 
 import pandas as pd
 
+from experiments.combine_data_into_stimulus_set_2026_09_08.sources import CuratedSource
 
-def normalize_curated_frame(frame: pd.DataFrame, source) -> pd.DataFrame:
-    """Return one source table with the shared 17-column schema."""
+
+def normalize_curated_frame(frame: pd.DataFrame, source: CuratedSource) -> pd.DataFrame:
+    """Return one source table with the shared 17-column schema.
+
+    Parameters
+    ----------
+    frame
+        Curated export as downloaded.
+    source
+        Pinned identity used to fill platform and source columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        Table with the shared combine columns in contract order.
+
+    Raises
+    ------
+    ValueError
+        When a required column is missing.
+    """
     raise NotImplementedError

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/normalize.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/normalize.py
@@ -24,7 +24,15 @@ PASSTHROUGH_COLUMNS = (
     "political_stance",
     "llm_toxicity_tier",
 )
-STRING_ID_COLUMNS = ("record_id", "source_record_id")
+BOOLEAN_COLUMNS = (
+    "is_political",
+    "is_likely_spam",
+    "is_self_contained",
+    "is_structurally_complete",
+)
+STRING_PASSTHROUGH_COLUMNS = tuple(
+    column for column in PASSTHROUGH_COLUMNS if column not in BOOLEAN_COLUMNS
+)
 INTEGRATION_COLUMN = "integration"
 SOURCE_DATASET_ID_COLUMN = "source_dataset_id"
 SOURCE_CURATED_RUN_COLUMN = "source_curated_run"
@@ -53,7 +61,7 @@ def normalize_curated_frame(frame: pd.DataFrame, source: CuratedSource) -> pd.Da
     """
     _require_source_columns(frame, source)
     identity = _source_identity_frame(frame, source)
-    passthrough = _string_id_passthrough(frame)
+    passthrough = _string_passthrough(frame)
     normalized = pd.concat([identity, passthrough], axis=1)
     return normalized.loc[:, list(COMBINED_COLUMNS)]
 
@@ -65,9 +73,9 @@ def _require_source_columns(frame: pd.DataFrame, source: CuratedSource) -> None:
         raise ValueError(f"missing columns {missing} uri={source.s3_uri}")
 
 
-def _string_id_passthrough(frame: pd.DataFrame) -> pd.DataFrame:
+def _string_passthrough(frame: pd.DataFrame) -> pd.DataFrame:
     passthrough = frame.loc[:, list(PASSTHROUGH_COLUMNS)].copy()
-    for column in STRING_ID_COLUMNS:
+    for column in STRING_PASSTHROUGH_COLUMNS:
         passthrough[column] = passthrough[column].astype(str)
     return passthrough
 

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/normalize.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/normalize.py
@@ -24,6 +24,7 @@ PASSTHROUGH_COLUMNS = (
     "political_stance",
     "llm_toxicity_tier",
 )
+STRING_ID_COLUMNS = ("record_id", "source_record_id")
 INTEGRATION_COLUMN = "integration"
 SOURCE_DATASET_ID_COLUMN = "source_dataset_id"
 SOURCE_CURATED_RUN_COLUMN = "source_curated_run"
@@ -52,7 +53,7 @@ def normalize_curated_frame(frame: pd.DataFrame, source: CuratedSource) -> pd.Da
     """
     _require_source_columns(frame, source)
     identity = _source_identity_frame(frame, source)
-    passthrough = frame.loc[:, list(PASSTHROUGH_COLUMNS)]
+    passthrough = _string_id_passthrough(frame)
     normalized = pd.concat([identity, passthrough], axis=1)
     return normalized.loc[:, list(COMBINED_COLUMNS)]
 
@@ -64,13 +65,20 @@ def _require_source_columns(frame: pd.DataFrame, source: CuratedSource) -> None:
         raise ValueError(f"missing columns {missing} uri={source.s3_uri}")
 
 
+def _string_id_passthrough(frame: pd.DataFrame) -> pd.DataFrame:
+    passthrough = frame.loc[:, list(PASSTHROUGH_COLUMNS)].copy()
+    for column in STRING_ID_COLUMNS:
+        passthrough[column] = passthrough[column].astype(str)
+    return passthrough
+
+
 def _source_identity_frame(frame: pd.DataFrame, source: CuratedSource) -> pd.DataFrame:
     return pd.DataFrame(
         {
             INTEGRATION_COLUMN: source.integration.value,
             SOURCE_DATASET_ID_COLUMN: source.dataset_id,
             SOURCE_CURATED_RUN_COLUMN: source.curated_run,
-            PLATFORM_ID_COLUMN: frame[source.platform_id_column].to_numpy(),
+            PLATFORM_ID_COLUMN: frame[source.platform_id_column].astype(str).to_numpy(),
         },
         index=frame.index,
     )

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/normalize.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/normalize.py
@@ -4,7 +4,30 @@ from __future__ import annotations
 
 import pandas as pd
 
-from experiments.combine_data_into_stimulus_set_2026_09_08.sources import CuratedSource
+from experiments.combine_data_into_stimulus_set_2026_09_08.sources import (
+    COMBINED_COLUMNS,
+    CuratedSource,
+)
+
+PASSTHROUGH_COLUMNS = (
+    "record_id",
+    "source_record_id",
+    "author_handle",
+    "text",
+    "created_at",
+    "sync_timestamp",
+    "news_or_opinion_category",
+    "is_political",
+    "is_likely_spam",
+    "is_self_contained",
+    "is_structurally_complete",
+    "political_stance",
+    "llm_toxicity_tier",
+)
+INTEGRATION_COLUMN = "integration"
+SOURCE_DATASET_ID_COLUMN = "source_dataset_id"
+SOURCE_CURATED_RUN_COLUMN = "source_curated_run"
+PLATFORM_ID_COLUMN = "platform_id"
 
 
 def normalize_curated_frame(frame: pd.DataFrame, source: CuratedSource) -> pd.DataFrame:
@@ -27,4 +50,27 @@ def normalize_curated_frame(frame: pd.DataFrame, source: CuratedSource) -> pd.Da
     ValueError
         When a required column is missing.
     """
-    raise NotImplementedError
+    _require_source_columns(frame, source)
+    identity = _source_identity_frame(frame, source)
+    passthrough = frame.loc[:, list(PASSTHROUGH_COLUMNS)]
+    normalized = pd.concat([identity, passthrough], axis=1)
+    return normalized.loc[:, list(COMBINED_COLUMNS)]
+
+
+def _require_source_columns(frame: pd.DataFrame, source: CuratedSource) -> None:
+    required = (*PASSTHROUGH_COLUMNS, source.platform_id_column)
+    missing = [column for column in required if column not in frame.columns]
+    if missing:
+        raise ValueError(f"missing columns {missing} uri={source.s3_uri}")
+
+
+def _source_identity_frame(frame: pd.DataFrame, source: CuratedSource) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            INTEGRATION_COLUMN: source.integration.value,
+            SOURCE_DATASET_ID_COLUMN: source.dataset_id,
+            SOURCE_CURATED_RUN_COLUMN: source.curated_run,
+            PLATFORM_ID_COLUMN: frame[source.platform_id_column].to_numpy(),
+        },
+        index=frame.index,
+    )

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/normalize.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/normalize.py
@@ -1,0 +1,10 @@
+"""Map one curated export onto the shared stimulus columns."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def normalize_curated_frame(frame: pd.DataFrame, source) -> pd.DataFrame:
+    """Return one source table with the shared 17-column schema."""
+    raise NotImplementedError

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/run.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/run.py
@@ -1,0 +1,62 @@
+"""Combine four pinned curated parquet files into one stimulus dataset.
+
+given AWS credentials from LAB_AWS_ACCESS_KEY_ID and LAB_AWS_ACCESS_KEY_SECRET
+and the four pinned curated objects exist at the hashes in sources.py
+when PYTHONPATH=. uv run python experiments/combine_data_into_stimulus_set_2026_09_08/run.py
+then combined_rows=55573
+and local dataset.parquet exists
+and S3 object experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet exists
+and its SHA-256 matches the local file
+and RESULTS.md contains the overall stance by toxicity table
+and RESULTS.md contains the three-platform stance by toxicity table
+and stdout prints both tables
+
+given the S3 dataset.parquet key already exists
+when the command is run again
+then the process raises FileExistsError and does not change the four source objects
+
+Run from the repo root:
+
+    PYTHONPATH=. uv run python experiments/combine_data_into_stimulus_set_2026_09_08/run.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+from experiments.combine_data_into_stimulus_set_2026_09_08.crosstab import (
+    stance_by_toxicity,
+    stance_by_toxicity_by_integration,
+)
+from experiments.combine_data_into_stimulus_set_2026_09_08.load import load_curated_source
+from experiments.combine_data_into_stimulus_set_2026_09_08.normalize import (
+    normalize_curated_frame,
+)
+from experiments.combine_data_into_stimulus_set_2026_09_08.sources import pinned_sources
+from experiments.combine_data_into_stimulus_set_2026_09_08.write import (
+    print_run_summary,
+    write_combined_dataset,
+)
+
+
+def concatenate_curated_frames(frames: list) -> object:
+    """Concatenate normalized source tables and sort them."""
+    raise NotImplementedError
+
+
+def main() -> int:
+    """Load, combine, write, and print the stimulus dataset."""
+    sources = pinned_sources()
+    frames = [
+        normalize_curated_frame(load_curated_source(source), source) for source in sources
+    ]
+    combined = concatenate_curated_frames(frames)
+    overall = stance_by_toxicity(combined)
+    by_integration = stance_by_toxicity_by_integration(combined)
+    result = write_combined_dataset(combined, overall, by_integration)
+    print_run_summary(result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/run.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/run.py
@@ -32,7 +32,11 @@ from experiments.combine_data_into_stimulus_set_2026_09_08.load import load_cura
 from experiments.combine_data_into_stimulus_set_2026_09_08.normalize import (
     normalize_curated_frame,
 )
-from experiments.combine_data_into_stimulus_set_2026_09_08.sources import pinned_sources
+from experiments.combine_data_into_stimulus_set_2026_09_08.sources import (
+    COMBINED_ROW_COUNT,
+    SORT_COLUMNS,
+    pinned_sources,
+)
 from experiments.combine_data_into_stimulus_set_2026_09_08.write import (
     print_run_summary,
     write_combined_dataset,
@@ -52,8 +56,20 @@ def concatenate_curated_frames(frames: list[pd.DataFrame]) -> pd.DataFrame:
     -------
     pd.DataFrame
         Combined table sorted by integration, dataset id, and source record id.
+
+    Raises
+    ------
+    ValueError
+        When the combined row count is not 55573.
     """
-    raise NotImplementedError
+    combined = pd.concat(frames, ignore_index=True)
+    sorted_combined = combined.sort_values(
+        list(SORT_COLUMNS),
+        kind="mergesort",
+    ).reset_index(drop=True)
+    if len(sorted_combined) != COMBINED_ROW_COUNT:
+        raise ValueError(f"combined_rows={len(sorted_combined)}")
+    return sorted_combined
 
 
 def main() -> int:

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/run.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/run.py
@@ -37,10 +37,22 @@ from experiments.combine_data_into_stimulus_set_2026_09_08.write import (
     print_run_summary,
     write_combined_dataset,
 )
+import pandas as pd
 
 
-def concatenate_curated_frames(frames: list) -> object:
-    """Concatenate normalized source tables and sort them."""
+def concatenate_curated_frames(frames: list[pd.DataFrame]) -> pd.DataFrame:
+    """Concatenate normalized source tables and sort them.
+
+    Parameters
+    ----------
+    frames
+        Normalized tables in pinned-source order.
+
+    Returns
+    -------
+    pd.DataFrame
+        Combined table sorted by integration, dataset id, and source record id.
+    """
     raise NotImplementedError
 
 

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/sources.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/sources.py
@@ -2,7 +2,157 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
 
-def pinned_sources() -> tuple:
+
+class Integration(str, Enum):
+    """Platform that produced a curated export."""
+
+    BLUESKY = "bluesky"
+    REDDIT = "reddit"
+    TWITTER = "twitter"
+
+
+@dataclass(frozen=True)
+class CuratedSource:
+    """One pinned curated parquet object used as a combine input."""
+
+    integration: Integration
+    dataset_id: str
+    curated_run: str
+    s3_uri: str
+    sha256: str
+    expected_row_count: int
+    platform_id_column: str
+
+
+@dataclass(frozen=True)
+class CombineRunResult:
+    """Local path, S3 URI, hash, and counts from one combine run."""
+
+    combined_rows: int
+    local_path: str
+    s3_uri: str
+    dataset_sha256: str
+    overall_crosstab: dict[str, dict[str, int]]
+    integration_crosstab: dict[str, dict[str, dict[str, int]]]
+
+
+BLUESKY_DATASET_ID = "bluesky_7e2c4a91-3b5f-4d8e-a6c1-0f9b8d2e5a73"
+BLUESKY_CURATED_RUN = "2026_09_06-23:25:06"
+BLUESKY_S3_URI = (
+    "s3://mirrorview-experimental-artifacts/data_platform/data/bluesky/"
+    f"{BLUESKY_DATASET_ID}/curated/{BLUESKY_CURATED_RUN}/mirrorview.parquet"
+)
+BLUESKY_SHA256 = "35e3f05111a16c27b95538894cda18db6d7295c8aad6be4fb7cb83ecafb1b3bc"
+BLUESKY_ROW_COUNT = 9756
+BLUESKY_PLATFORM_ID_COLUMN = "uri"
+
+TWITTER_DATASET_ID_RUN_1 = "twitter_fba4ddb2-fcf7-4a13-a7cc-0d98db44b547"
+TWITTER_CURATED_RUN_1 = "2026_09_07-06:58:09"
+TWITTER_S3_URI_RUN_1 = (
+    "s3://mirrorview-experimental-artifacts/data_platform/data/twitter/"
+    f"{TWITTER_DATASET_ID_RUN_1}/curated/{TWITTER_CURATED_RUN_1}/mirrorview.parquet"
+)
+TWITTER_SHA256_RUN_1 = "7639e54554869371fdb6397a1c2a497b32711679290322b999fb68ee173f39c9"
+TWITTER_ROW_COUNT_RUN_1 = 1457
+
+TWITTER_DATASET_ID_RUN_2 = "twitter_5901767a-e609-46fc-9a17-742516b548f2"
+TWITTER_CURATED_RUN_2 = "2026_09_08-05:34:19"
+TWITTER_S3_URI_RUN_2 = (
+    "s3://mirrorview-experimental-artifacts/data_platform/data/twitter/"
+    f"{TWITTER_DATASET_ID_RUN_2}/curated/{TWITTER_CURATED_RUN_2}/mirrorview.parquet"
+)
+TWITTER_SHA256_RUN_2 = "c2178c27165c26dd960bd470e3ee98791e7c98638a346eca0f0fafa1c065c8e2"
+TWITTER_ROW_COUNT_RUN_2 = 1299
+TWITTER_PLATFORM_ID_COLUMN = "tweet_id"
+
+REDDIT_DATASET_ID = "reddit_3d8a2c41-9b17-4e6f-a5d0-8c1b2e4f6079"
+REDDIT_CURATED_RUN = "2026_09_07-21:47:32"
+REDDIT_S3_URI = (
+    "s3://mirrorview-experimental-artifacts/data_platform/data/reddit/"
+    f"{REDDIT_DATASET_ID}/curated/{REDDIT_CURATED_RUN}/mirrorview_v2.parquet"
+)
+REDDIT_SHA256 = "e1d9b1494fd2ef030dc8fdc1f71980b55d972e4a01da23923fa6f61a693a3936"
+REDDIT_ROW_COUNT = 43061
+REDDIT_PLATFORM_ID_COLUMN = "comment_fullname"
+
+COMBINED_ROW_COUNT = 55573
+COMBINED_COLUMNS = (
+    "integration",
+    "source_dataset_id",
+    "source_curated_run",
+    "record_id",
+    "source_record_id",
+    "platform_id",
+    "author_handle",
+    "text",
+    "created_at",
+    "sync_timestamp",
+    "news_or_opinion_category",
+    "is_political",
+    "is_likely_spam",
+    "is_self_contained",
+    "is_structurally_complete",
+    "political_stance",
+    "llm_toxicity_tier",
+)
+SORT_COLUMNS = ("integration", "source_dataset_id", "source_record_id")
+STANCE_CROSSTAB_ROWS = ("left", "right")
+TOXICITY_CROSSTAB_COLUMNS = ("low", "medium", "high")
+INTEGRATION_CROSSTAB_ORDER = (
+    Integration.BLUESKY.value,
+    Integration.REDDIT.value,
+    Integration.TWITTER.value,
+)
+
+OUTPUT_S3_BUCKET = "mirrorview-experimental-artifacts"
+OUTPUT_S3_KEY = "experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet"
+OUTPUT_S3_URI = f"s3://{OUTPUT_S3_BUCKET}/{OUTPUT_S3_KEY}"
+DATASET_FILENAME = "dataset.parquet"
+RESULTS_FILENAME = "RESULTS.md"
+
+PINNED_SOURCES = (
+    CuratedSource(
+        integration=Integration.BLUESKY,
+        dataset_id=BLUESKY_DATASET_ID,
+        curated_run=BLUESKY_CURATED_RUN,
+        s3_uri=BLUESKY_S3_URI,
+        sha256=BLUESKY_SHA256,
+        expected_row_count=BLUESKY_ROW_COUNT,
+        platform_id_column=BLUESKY_PLATFORM_ID_COLUMN,
+    ),
+    CuratedSource(
+        integration=Integration.TWITTER,
+        dataset_id=TWITTER_DATASET_ID_RUN_1,
+        curated_run=TWITTER_CURATED_RUN_1,
+        s3_uri=TWITTER_S3_URI_RUN_1,
+        sha256=TWITTER_SHA256_RUN_1,
+        expected_row_count=TWITTER_ROW_COUNT_RUN_1,
+        platform_id_column=TWITTER_PLATFORM_ID_COLUMN,
+    ),
+    CuratedSource(
+        integration=Integration.TWITTER,
+        dataset_id=TWITTER_DATASET_ID_RUN_2,
+        curated_run=TWITTER_CURATED_RUN_2,
+        s3_uri=TWITTER_S3_URI_RUN_2,
+        sha256=TWITTER_SHA256_RUN_2,
+        expected_row_count=TWITTER_ROW_COUNT_RUN_2,
+        platform_id_column=TWITTER_PLATFORM_ID_COLUMN,
+    ),
+    CuratedSource(
+        integration=Integration.REDDIT,
+        dataset_id=REDDIT_DATASET_ID,
+        curated_run=REDDIT_CURATED_RUN,
+        s3_uri=REDDIT_S3_URI,
+        sha256=REDDIT_SHA256,
+        expected_row_count=REDDIT_ROW_COUNT,
+        platform_id_column=REDDIT_PLATFORM_ID_COLUMN,
+    ),
+)
+
+
+def pinned_sources() -> tuple[CuratedSource, ...]:
     """Return the four pinned curated sources in combine order."""
     raise NotImplementedError

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/sources.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/sources.py
@@ -155,4 +155,4 @@ PINNED_SOURCES = (
 
 def pinned_sources() -> tuple[CuratedSource, ...]:
     """Return the four pinned curated sources in combine order."""
-    raise NotImplementedError
+    return PINNED_SOURCES

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/sources.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/sources.py
@@ -1,0 +1,8 @@
+"""Pinned MirrorView curated parquet sources for the stimulus combine run."""
+
+from __future__ import annotations
+
+
+def pinned_sources() -> tuple:
+    """Return the four pinned curated sources in combine order."""
+    raise NotImplementedError

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/write.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/write.py
@@ -2,12 +2,43 @@
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 
 import pandas as pd
 
 from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
-from experiments.combine_data_into_stimulus_set_2026_09_08.sources import CombineRunResult
+from experiments.combine_data_into_stimulus_set_2026_09_08.sources import (
+    CombineRunResult,
+    DATASET_FILENAME,
+    OUTPUT_S3_BUCKET,
+)
+from lib.constants import REPO_ROOT
+
+EXPERIMENT_DIR = (
+    REPO_ROOT / "experiments" / "combine_data_into_stimulus_set_2026_09_08"
+)
+
+
+def write_local_parquet(combined: pd.DataFrame, experiment_dir: Path) -> tuple[Path, bytes]:
+    """Write ``dataset.parquet`` under the experiment folder and return its bytes.
+
+    Parameters
+    ----------
+    combined
+        Sorted 17-column stimulus table.
+    experiment_dir
+        Folder that receives ``dataset.parquet``.
+
+    Returns
+    -------
+    tuple[Path, bytes]
+        Local path and parquet bytes.
+    """
+    body = _parquet_bytes(combined)
+    path = experiment_dir / DATASET_FILENAME
+    path.write_bytes(body)
+    return path, body
 
 
 def write_combined_dataset(
@@ -48,3 +79,13 @@ def write_combined_dataset(
 def print_run_summary(result: CombineRunResult) -> None:
     """Print combined row count, URIs, SHA-256, and both crosstab tables."""
     raise NotImplementedError
+
+
+def _parquet_bytes(frame: pd.DataFrame) -> bytes:
+    buffer = io.BytesIO()
+    frame.to_parquet(buffer, index=False)
+    return buffer.getvalue()
+
+
+def _default_store() -> CampaignObjectStore:
+    return CampaignObjectStore(OUTPUT_S3_BUCKET)

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/write.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/write.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import json
 from pathlib import Path
 
 import pandas as pd
@@ -13,16 +14,28 @@ from data_platform.generate_features.s3_feature_campaign import (
 )
 from data_platform.utils.object_store import sha256_hex
 from experiments.combine_data_into_stimulus_set_2026_09_08.sources import (
+    COMBINED_ROW_COUNT,
     CombineRunResult,
     DATASET_FILENAME,
+    INTEGRATION_CROSSTAB_ORDER,
     OUTPUT_S3_BUCKET,
     OUTPUT_S3_KEY,
+    PINNED_SOURCES,
+    RESULTS_FILENAME,
+    STANCE_CROSSTAB_ROWS,
+    TOXICITY_CROSSTAB_COLUMNS,
 )
 from lib.constants import REPO_ROOT
 
 EXPERIMENT_DIR = (
     REPO_ROOT / "experiments" / "combine_data_into_stimulus_set_2026_09_08"
 )
+JSON_INDENT = 2
+TOTAL_LABEL = "total"
+RUN_COMMAND = """export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/combine_data_into_stimulus_set_2026_09_08/run.py"""
 
 
 def write_local_parquet(combined: pd.DataFrame, experiment_dir: Path) -> tuple[Path, bytes]:
@@ -102,12 +115,184 @@ def write_combined_dataset(
     FileExistsError
         When the destination S3 key already exists.
     """
-    raise NotImplementedError
+    resolved_dir = experiment_dir if experiment_dir is not None else EXPERIMENT_DIR
+    resolved_store = store if store is not None else _default_store()
+    local_path, body = write_local_parquet(combined, resolved_dir)
+    digest = upload_dataset(body, resolved_store)
+    result = _combine_run_result(
+        combined, local_path, digest, overall_crosstab, integration_crosstab
+    )
+    write_results_md(result, resolved_dir)
+    return result
 
 
 def print_run_summary(result: CombineRunResult) -> None:
     """Print combined row count, URIs, SHA-256, and both crosstab tables."""
-    raise NotImplementedError
+    print(f"combined_rows={result.combined_rows}")
+    print(f"local_path={result.local_path}")
+    print(f"s3_uri={result.s3_uri}")
+    print(f"dataset_sha256={result.dataset_sha256}")
+    print("overall_crosstab=")
+    print(json.dumps(result.overall_crosstab, indent=JSON_INDENT))
+    print("integration_crosstab=")
+    print(json.dumps(result.integration_crosstab, indent=JSON_INDENT))
+
+
+def write_results_md(result: CombineRunResult, experiment_dir: Path) -> Path:
+    """Write RESULTS.md with source pins, URIs, and both crosstab tables."""
+    path = experiment_dir / RESULTS_FILENAME
+    path.write_text(_results_markdown(result))
+    return path
+
+
+def _combine_run_result(
+    combined: pd.DataFrame,
+    local_path: Path,
+    digest: str,
+    overall_crosstab: dict[str, dict[str, int]],
+    integration_crosstab: dict[str, dict[str, dict[str, int]]],
+) -> CombineRunResult:
+    return CombineRunResult(
+        combined_rows=len(combined),
+        local_path=str(local_path),
+        s3_uri=s3_uri(OUTPUT_S3_BUCKET, OUTPUT_S3_KEY),
+        dataset_sha256=digest,
+        overall_crosstab=overall_crosstab,
+        integration_crosstab=integration_crosstab,
+    )
+
+
+def _results_markdown(result: CombineRunResult) -> str:
+    return "\n".join(
+        [
+            *_results_preamble(result),
+            "## Overall political stance by LLM toxicity tier",
+            "",
+            _stance_table_markdown(result.overall_crosstab),
+            "",
+            "## Political stance by LLM toxicity tier, by platform",
+            "",
+            _integration_table_markdown(result.integration_crosstab),
+            "",
+        ]
+    )
+
+
+def _results_preamble(result: CombineRunResult) -> list[str]:
+    return [
+        "# Combine curated data into a stimulus set, results",
+        "",
+        "## Command",
+        "",
+        "```bash",
+        RUN_COMMAND,
+        "```",
+        "",
+        "## Sources",
+        "",
+        _sources_table_markdown(),
+        "",
+        (
+            f"Combined row count is {result.combined_rows}. "
+            f"Expected row count is {COMBINED_ROW_COUNT}."
+        ),
+        "",
+        "## Combined parquet",
+        "",
+        _parquet_table_markdown(result),
+        "",
+    ]
+
+
+def _sources_table_markdown() -> str:
+    lines = [
+        "| Platform | Dataset id | Curated run | Object | SHA-256 | Rows |",
+        "| -------- | ---------- | ----------- | ------ | ------- | ---: |",
+    ]
+    for source in PINNED_SOURCES:
+        lines.append(
+            f"| {source.integration.value} | `{source.dataset_id}` | "
+            f"`{source.curated_run}` | `{source.s3_uri}` | `{source.sha256}` | "
+            f"{source.expected_row_count} |"
+        )
+    return "\n".join(lines)
+
+
+def _parquet_table_markdown(result: CombineRunResult) -> str:
+    return "\n".join(
+        [
+            "| File | Path | SHA-256 |",
+            "| ---- | ---- | ------- |",
+            f"| Local parquet | `{result.local_path}` | `{result.dataset_sha256}` |",
+            f"| S3 parquet | `{result.s3_uri}` | `{result.dataset_sha256}` |",
+        ]
+    )
+
+
+def _stance_table_markdown(counts: dict[str, dict[str, int]]) -> str:
+    lines = [
+        "| political_stance | low | medium | high | total |",
+        "| ---------------- | --: | -----: | ---: | ----: |",
+    ]
+    grand = {tier: 0 for tier in TOXICITY_CROSSTAB_COLUMNS}
+    for stance in STANCE_CROSSTAB_ROWS:
+        cells = _tier_cells(counts.get(stance, {}))
+        _add_tier_counts(grand, cells)
+        lines.append(_labeled_tier_row(stance, cells))
+    lines.append(_labeled_tier_row(TOTAL_LABEL, _tier_cells(grand)))
+    return "\n".join(lines)
+
+
+def _integration_table_markdown(
+    counts: dict[str, dict[str, dict[str, int]]],
+) -> str:
+    lines = [
+        "| integration | political_stance | low | medium | high | total |",
+        "| ----------- | ---------------- | --: | -----: | ---: | ----: |",
+    ]
+    grand = {tier: 0 for tier in TOXICITY_CROSSTAB_COLUMNS}
+    for integration in INTEGRATION_CROSSTAB_ORDER:
+        platform_counts = counts.get(integration, {})
+        platform_total = {tier: 0 for tier in TOXICITY_CROSSTAB_COLUMNS}
+        lines.extend(_platform_stance_rows(integration, platform_counts, platform_total))
+        lines.append(_integration_row(integration, TOTAL_LABEL, _tier_cells(platform_total)))
+        _add_tier_counts(grand, _tier_cells(platform_total))
+    lines.append(_integration_row(TOTAL_LABEL, TOTAL_LABEL, _tier_cells(grand)))
+    return "\n".join(lines)
+
+
+def _platform_stance_rows(
+    integration: str,
+    platform_counts: dict[str, dict[str, int]],
+    platform_total: dict[str, int],
+) -> list[str]:
+    rows: list[str] = []
+    for stance in STANCE_CROSSTAB_ROWS:
+        cells = _tier_cells(platform_counts.get(stance, {}))
+        _add_tier_counts(platform_total, cells)
+        rows.append(_integration_row(integration, stance, cells))
+    return rows
+
+
+def _tier_cells(counts: dict[str, int]) -> list[int]:
+    return [int(counts.get(tier, 0)) for tier in TOXICITY_CROSSTAB_COLUMNS]
+
+
+def _add_tier_counts(totals: dict[str, int], cells: list[int]) -> None:
+    for tier, value in zip(TOXICITY_CROSSTAB_COLUMNS, cells, strict=True):
+        totals[tier] += value
+
+
+def _labeled_tier_row(label: str, cells: list[int]) -> str:
+    total = sum(cells)
+    return f"| {label} | {cells[0]} | {cells[1]} | {cells[2]} | {total} |"
+
+
+def _integration_row(integration: str, stance: str, cells: list[int]) -> str:
+    total = sum(cells)
+    return (
+        f"| {integration} | {stance} | {cells[0]} | {cells[1]} | {cells[2]} | {total} |"
+    )
 
 
 def _parquet_bytes(frame: pd.DataFrame) -> bytes:

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/write.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/write.py
@@ -2,18 +2,49 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
+
+from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from experiments.combine_data_into_stimulus_set_2026_09_08.sources import CombineRunResult
 
 
 def write_combined_dataset(
     combined: pd.DataFrame,
-    overall_crosstab: dict,
-    integration_crosstab: dict,
-) -> object:
-    """Write local parquet, upload to S3, and write RESULTS.md."""
+    overall_crosstab: dict[str, dict[str, int]],
+    integration_crosstab: dict[str, dict[str, dict[str, int]]],
+    experiment_dir: Path | None = None,
+    store: CampaignObjectStore | None = None,
+) -> CombineRunResult:
+    """Write local parquet, upload to S3, and write RESULTS.md.
+
+    Parameters
+    ----------
+    combined
+        Sorted 17-column stimulus table.
+    overall_crosstab
+        Stance by toxicity counts across all rows.
+    integration_crosstab
+        Stance by toxicity counts keyed by platform.
+    experiment_dir
+        Folder that receives ``dataset.parquet`` and ``RESULTS.md``.
+    store
+        Object store used only with ``put_new``.
+
+    Returns
+    -------
+    CombineRunResult
+        Local path, S3 URI, SHA-256, and the two count tables.
+
+    Raises
+    ------
+    FileExistsError
+        When the destination S3 key already exists.
+    """
     raise NotImplementedError
 
 
-def print_run_summary(result: object) -> None:
+def print_run_summary(result: CombineRunResult) -> None:
     """Print combined row count, URIs, SHA-256, and both crosstab tables."""
     raise NotImplementedError

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/write.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/write.py
@@ -154,7 +154,7 @@ def _combine_run_result(
 ) -> CombineRunResult:
     return CombineRunResult(
         combined_rows=len(combined),
-        local_path=str(local_path),
+        local_path=str(local_path.relative_to(REPO_ROOT)),
         s3_uri=s3_uri(OUTPUT_S3_BUCKET, OUTPUT_S3_KEY),
         dataset_sha256=digest,
         overall_crosstab=overall_crosstab,

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/write.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/write.py
@@ -1,0 +1,19 @@
+"""Write the combined parquet locally, upload it to S3, and write RESULTS.md."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def write_combined_dataset(
+    combined: pd.DataFrame,
+    overall_crosstab: dict,
+    integration_crosstab: dict,
+) -> object:
+    """Write local parquet, upload to S3, and write RESULTS.md."""
+    raise NotImplementedError
+
+
+def print_run_summary(result: object) -> None:
+    """Print combined row count, URIs, SHA-256, and both crosstab tables."""
+    raise NotImplementedError

--- a/experiments/combine_data_into_stimulus_set_2026_09_08/write.py
+++ b/experiments/combine_data_into_stimulus_set_2026_09_08/write.py
@@ -7,11 +7,16 @@ from pathlib import Path
 
 import pandas as pd
 
-from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from data_platform.generate_features.s3_feature_campaign import (
+    CampaignObjectStore,
+    s3_uri,
+)
+from data_platform.utils.object_store import sha256_hex
 from experiments.combine_data_into_stimulus_set_2026_09_08.sources import (
     CombineRunResult,
     DATASET_FILENAME,
     OUTPUT_S3_BUCKET,
+    OUTPUT_S3_KEY,
 )
 from lib.constants import REPO_ROOT
 
@@ -39,6 +44,30 @@ def write_local_parquet(combined: pd.DataFrame, experiment_dir: Path) -> tuple[P
     path = experiment_dir / DATASET_FILENAME
     path.write_bytes(body)
     return path, body
+
+
+def upload_dataset(body: bytes, store: CampaignObjectStore) -> str:
+    """Upload parquet bytes with put_new and return the SHA-256.
+
+    Parameters
+    ----------
+    body
+        Parquet bytes already written locally.
+    store
+        Object store used only with ``put_new``.
+
+    Returns
+    -------
+    str
+        SHA-256 of the uploaded bytes.
+
+    Raises
+    ------
+    FileExistsError
+        When the destination S3 key already exists.
+    """
+    store.put_new(OUTPUT_S3_KEY, body)
+    return sha256_hex(body)
 
 
 def write_combined_dataset(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Combine curated posts into one stimulus parquet

## Summary

Concatenates four pinned MirrorView curated exports into one stimulus table: Bluesky (9,756 rows), two Twitter collections (1,457 and 1,299), and Reddit v2 (43,061).

The live run wrote 55,573 rows. Local and S3 parquet files match SHA-256 `f24ad1fd8c3709ffbbba9fb5dc953dcaee2f11ad8916ae21612b7f25cb5ca3f0`. Left posts outnumber right posts (38,794 vs 16,779). High-toxicity posts are 4,806 of 55,573.

574 Twitter posts appear in both collections, so unique Twitter posts are 2,182, not 2,756. 25 of those overlapping posts disagree on stance or toxicity. Both rows are kept.

## Purpose

Put the recent curated Bluesky, Reddit, and Twitter exports in one parquet so operators can inspect the stimulus pool by toxicity and political stance, overall and by platform.

## Setup

- Bluesky curated: 9,756 rows from the 200,000-post campaign
- Twitter collection 1: 1,457 rows
- Twitter collection 2: 1,299 rows
- Reddit v2: 43,061 rows (3,000 medium comments relabeled high)
- Combined rows: 55,573
- No sampling and no cross-source dedupe
- Two Twitter collections are one Twitter group in the platform table

## Flow

Stages:

- `Download` — load four pinned curated parquet files from S3 and check SHA-256 and row count.
- `Normalize` — map each file onto 17 shared columns and add platform identity.
- `Concatenate` — keep every curated row and sort by platform, dataset, and source id.
- `Write` — save `dataset.parquet` locally and to S3, then write stance-by-toxicity tables.

```mermaid
flowchart TD
  A[Download four curated parquet files] --> B[Check SHA-256 and row counts]
  B --> C[Add platform and source columns]
  C --> D[Concatenate all rows]
  D --> E[Write local dataset.parquet]
  E --> F[Upload dataset.parquet to S3]
  F --> G[Count stance by toxicity overall]
  G --> H[Count stance by toxicity by platform]
  H --> I[Write RESULTS.md]
```

## Run

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
PYTHONPATH=. uv run python experiments/combine_data_into_stimulus_set_2026_09_08/run.py
```

The S3 upload fails if that object already exists.

## Results

Overall political stance by LLM toxicity tier:

| political_stance | low | medium | high | total |
| ---------------- | --: | -----: | ---: | ----: |
| left | 18061 | 17071 | 3662 | 38794 |
| right | 9261 | 6374 | 1144 | 16779 |
| total | 27322 | 23445 | 4806 | 55573 |

By platform:

| integration | political_stance | low | medium | high | total |
| ----------- | ---------------- | --: | -----: | ---: | ----: |
| bluesky | left | 3563 | 4179 | 585 | 8327 |
| bluesky | right | 529 | 755 | 145 | 1429 |
| bluesky | total | 4092 | 4934 | 730 | 9756 |
| reddit | left | 13423 | 12632 | 3056 | 29111 |
| reddit | right | 7998 | 5095 | 857 | 13950 |
| reddit | total | 21421 | 17727 | 3913 | 43061 |
| twitter | left | 1075 | 260 | 21 | 1356 |
| twitter | right | 734 | 524 | 142 | 1400 |
| twitter | total | 1809 | 784 | 163 | 2756 |
| total | total | 27322 | 23445 | 4806 | 55573 |

These counts match the source campaign reports (Bluesky wide-run report, both Twitter wide-run reports, and Reddit v2 RESULTS.md).

Outputs:

- `experiments/combine_data_into_stimulus_set_2026_09_08/RESULTS.md`
- `s3://mirrorview-experimental-artifacts/experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet`

Plan: `docs/plans/2026-09-08_combine_data_into_stimulus_set_9e4b12/`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9bc9ee6-acb7-4fc6-9653-0a1f0bc74eb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9bc9ee6-acb7-4fc6-9653-0a1f0bc74eb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reproducible workflow for combining four curated datasets from Bluesky, Reddit, and Twitter into a unified stimulus dataset.
  - Added validation for source integrity, expected row counts, required fields, and final dataset size.
  - Added local caching and cloud storage for the combined dataset.
  - Added summary outputs with dataset checksums and political stance by toxicity tier, including per-platform breakdowns.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->