### PR TITLE
Sample a balanced stimulus set from the combined 2026-09-08 parquet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ data_platform/data/**
 experiments/combine_data_into_stimulus_set_2026_09_08/cache/
 experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet
 
+# Filtered stimulus parquet lives in S3. Keep the local copy and cache out of git.
+experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/cache/
+experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet
+
 # OS generated files
 .DS_Store
 .DS_Store?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2026-09-08
 
-1. Operators now have one 55,573-row stimulus parquet of curated Bluesky, Reddit, and Twitter posts. The experiment report has counts of political stance by toxicity, and a copy of the parquet is on S3. [PR #266](https://github.com/METResearchGroup/mirrorView-task/pull/266)
+1. Operators now have a filtered stimulus parquet of 9,562 posts sampled toward even political stance by toxicity cells. Duplicate ids, duplicate text, and previously used catalog posts are dropped, and a copy is on S3. [PR #267](https://github.com/METResearchGroup/mirrorView-task/pull/267)
+2. Operators now have one 55,573-row stimulus parquet of curated Bluesky, Reddit, and Twitter posts. The experiment report has counts of political stance by toxicity, and a copy of the parquet is on S3. [PR #266](https://github.com/METResearchGroup/mirrorView-task/pull/266)
 2. Operators now have a second curated Reddit Parquet file, and in that file 3,000 comments that the large language model labeled medium toxicity are labeled high instead, ranked by Perspective toxicity probability. The original MirrorView export still matches its recorded SHA-256. [PR #260](https://github.com/METResearchGroup/mirrorView-task/pull/260)
 3. Operators now have a Twitter table of 6,408 labeled posts with 21 columns, plus a MirrorView curated export that records political stance by toxicity tier. [PR #265](https://github.com/METResearchGroup/mirrorView-task/pull/265)
 4. Operators now have seven OpenAI Batch labels for all 6,408 Twitter posts from the 2026-09-07 collection, with four batch objects and a run report per feature. [PR #264](https://github.com/METResearchGroup/mirrorView-task/pull/264)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-08
 
-1. Operators now have a filtered stimulus parquet of 9,562 posts. The sample aims for 1,700 posts in each political stance by toxicity cell. Duplicate ids, duplicate text, and previously used catalog posts are dropped, and a copy is on S3. [PR #267](https://github.com/METResearchGroup/mirrorView-task/pull/267)
+1. Operators now have a filtered stimulus parquet of 10,200 posts. The sample aims for 1,700 posts in each political stance by toxicity cell, and extra right-medium posts fill the right-high shortfall so left and right each have 5,100 posts. Duplicate ids, duplicate text, and previously used catalog posts are dropped, and a copy is on S3. [PR #267](https://github.com/METResearchGroup/mirrorView-task/pull/267)
 2. Operators now have one 55,573-row stimulus parquet of curated Bluesky, Reddit, and Twitter posts. The experiment report has counts of political stance by toxicity, and a copy of the parquet is on S3. [PR #266](https://github.com/METResearchGroup/mirrorView-task/pull/266)
 3. Operators now have a second curated Reddit Parquet file, and in that file 3,000 comments that the large language model labeled medium toxicity are labeled high instead, ranked by Perspective toxicity probability. The original MirrorView export still matches its recorded SHA-256. [PR #260](https://github.com/METResearchGroup/mirrorView-task/pull/260)
 4. Operators now have a Twitter table of 6,408 labeled posts with 21 columns, plus a MirrorView curated export that records political stance by toxicity tier. [PR #265](https://github.com/METResearchGroup/mirrorView-task/pull/265)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## 2026-09-08
 
-1. Operators now have a filtered stimulus parquet of 9,562 posts sampled toward even political stance by toxicity cells. Duplicate ids, duplicate text, and previously used catalog posts are dropped, and a copy is on S3. [PR #267](https://github.com/METResearchGroup/mirrorView-task/pull/267)
+1. Operators now have a filtered stimulus parquet of 9,562 posts. The sample aims for 1,700 posts in each political stance by toxicity cell. Duplicate ids, duplicate text, and previously used catalog posts are dropped, and a copy is on S3. [PR #267](https://github.com/METResearchGroup/mirrorView-task/pull/267)
 2. Operators now have one 55,573-row stimulus parquet of curated Bluesky, Reddit, and Twitter posts. The experiment report has counts of political stance by toxicity, and a copy of the parquet is on S3. [PR #266](https://github.com/METResearchGroup/mirrorView-task/pull/266)
-2. Operators now have a second curated Reddit Parquet file, and in that file 3,000 comments that the large language model labeled medium toxicity are labeled high instead, ranked by Perspective toxicity probability. The original MirrorView export still matches its recorded SHA-256. [PR #260](https://github.com/METResearchGroup/mirrorView-task/pull/260)
-3. Operators now have a Twitter table of 6,408 labeled posts with 21 columns, plus a MirrorView curated export that records political stance by toxicity tier. [PR #265](https://github.com/METResearchGroup/mirrorView-task/pull/265)
-4. Operators now have seven OpenAI Batch labels for all 6,408 Twitter posts from the 2026-09-07 collection, with four batch objects and a run report per feature. [PR #264](https://github.com/METResearchGroup/mirrorView-task/pull/264)
-5. The 2026-09-07 Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_08_014808_llm_features_v1` for 6,408 posts, and the 2026-09-05 campaign still loads. [PR #263](https://github.com/METResearchGroup/mirrorView-task/pull/263)
-6. Twitter preprocess on the 2026-09-07 collection kept 6,408 of 6,900 posts. The preprocessed `posts.csv` is stored in Git LFS. [PR #261](https://github.com/METResearchGroup/mirrorView-task/pull/261)
-7. A dated Mirrorview Twitter ingest config and a recent-search run (6,900 unique posts inside the 7-day window) are now in the repo. `posts.csv` is stored in Git LFS. [PR #259](https://github.com/METResearchGroup/mirrorView-task/pull/259)
+3. Operators now have a second curated Reddit Parquet file, and in that file 3,000 comments that the large language model labeled medium toxicity are labeled high instead, ranked by Perspective toxicity probability. The original MirrorView export still matches its recorded SHA-256. [PR #260](https://github.com/METResearchGroup/mirrorView-task/pull/260)
+4. Operators now have a Twitter table of 6,408 labeled posts with 21 columns, plus a MirrorView curated export that records political stance by toxicity tier. [PR #265](https://github.com/METResearchGroup/mirrorView-task/pull/265)
+5. Operators now have seven OpenAI Batch labels for all 6,408 Twitter posts from the 2026-09-07 collection, with four batch objects and a run report per feature. [PR #264](https://github.com/METResearchGroup/mirrorView-task/pull/264)
+6. The 2026-09-07 Twitter preprocessed `posts.csv` is on `mirrorview-experimental-artifacts` with a SHA-256 inventory, and Git LFS still holds the local copy. Operators can load campaign `twitter_2026_09_08_014808_llm_features_v1` for 6,408 posts, and the 2026-09-05 campaign still loads. [PR #263](https://github.com/METResearchGroup/mirrorView-task/pull/263)
+7. Twitter preprocess on the 2026-09-07 collection kept 6,408 of 6,900 posts. The preprocessed `posts.csv` is stored in Git LFS. [PR #261](https://github.com/METResearchGroup/mirrorView-task/pull/261)
+8. A dated Mirrorview Twitter ingest config and a recent-search run (6,900 unique posts inside the 7-day window) are now in the repo. `posts.csv` is stored in Git LFS. [PR #259](https://github.com/METResearchGroup/mirrorView-task/pull/259)
 
 ## 2026-09-07
 

--- a/docs/plans/2026-09-08_filter_posts_stimulus_c4f821/plan.md
+++ b/docs/plans/2026-09-08_filter_posts_stimulus_c4f821/plan.md
@@ -29,7 +29,7 @@ flowchart TD
 
 Treat the task as a one-off experiment under `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/`. Reuse the combine experiment's S3 download and upload helpers. Reuse the existing previously used stimuli helper so posts from the Part 1 and Part 2 catalogs are excluded by id and by original text. Do not change product curate scripts. Do not add pytest. Do not edit `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md`, because that file is marked read-only.
 
-The cell for right stance and high toxicity has fewer than 1,700 unique posts after cleanup. Take every cleaned post in that cell, and take 1,700 in every other cell. Do not move posts from other cells to make up the difference.
+The cell for right stance and high toxicity has fewer than 1,700 unique posts after cleanup. Take every cleaned post in that cell, take 1,700 in every other cell, and then take extra posts from the cell for right stance and medium toxicity until left and right have the same number of posts and the sample has 10,200 posts.
 
 ## Decisions
 
@@ -59,6 +59,6 @@ Run the command with AWS credentials. Confirm the local file and the S3 object, 
 2. `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md` is unchanged from the pull request 267 draft.
 3. The filtered parquet exists locally under that folder and at `s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet`.
 4. `RESULTS.md` records cleanup drop counts, cleaned cell counts, and sampled cell counts.
-5. Five cells have 1,700 sampled posts. The cell for right stance and high toxicity has every cleaned post in that cell.
+5. The sample has 10,200 posts. Left and right each have 5,100 posts. The cell for right stance and high toxicity has every cleaned post in that cell. Extra posts come from the cell for right stance and medium toxicity.
 6. Product curate scripts and the combined source parquet are unchanged.
 7. No pytest file was added or run.

--- a/docs/plans/2026-09-08_filter_posts_stimulus_c4f821/plan.md
+++ b/docs/plans/2026-09-08_filter_posts_stimulus_c4f821/plan.md
@@ -1,0 +1,64 @@
+# Filter the combined stimulus parquet to a balanced sample for the next study
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Operators have a combined stimulus parquet of 55,573 posts from the 2026-09-08 combine experiment. The next study needs about 10,000 new posts so that, together with the existing 10,000-post catalog, operators can collect 5 labels on 20,000 posts. Operators drop posts already used in earlier catalogs. They also drop duplicate ids and duplicate text, and then sample toward 1,700 posts in each political stance by toxicity cell.
+
+## Happy flow
+
+An operator runs one command from the repo root. The run downloads the pinned combined parquet and applies cleanup. It then samples up to 1,700 posts in each of the six stance by toxicity cells. The run uploads the filtered parquet and writes RESULTS.md.
+
+```mermaid
+flowchart TD
+    A[Download pinned combined parquet] --> B[Drop previously used posts]
+    B --> C[Drop duplicate ids]
+    C --> D[Drop duplicate text]
+    D --> E[Sample up to 1700 per stance toxicity cell]
+    E --> F[Write local parquet]
+    F --> G[Upload to S3]
+    G --> H[Write RESULTS.md]
+```
+
+## Approach
+
+Treat the task as a one-off experiment under `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/`. Reuse the combine experiment's S3 download and upload helpers. Reuse the existing previously used stimuli helper so posts from the Part 1 and Part 2 catalogs are excluded by id and by original text. Do not change product curate scripts. Do not add pytest. Do not edit `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md`, because that file is marked read-only.
+
+The cell for right stance and high toxicity has fewer than 1,700 unique posts after cleanup. Take every cleaned post in that cell, and take 1,700 in every other cell. Do not move posts from other cells to make up the difference.
+
+## Decisions
+
+- Stay on branch `filter-posts-used-for-stimulus-set-2026-09-08` (pull request 267).
+- The candidate file is `s3://mirrorview-experimental-artifacts/experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet`. The SHA-256 is `f24ad1fd8c3709ffbbba9fb5dc953dcaee2f11ad8916ae21612b7f25cb5ca3f0`. Expected row count is 55573.
+- Exclude previously used stimuli with `data_platform/preprocessing/previously_used_stimuli.py`. Match on record id, and also drop candidate rows whose text equals a previous catalog `original_text`.
+- Duplicate id means duplicate `record_id`. Keep the first row after sorting by integration, source dataset id, and source record id.
+- Duplicate text means exact equality on the stored `text` column. Keep the first row after the same sort.
+- Sample with seed 42. Target 1,700 posts per cell of political stance (`left`, `right`) by LLM toxicity tier (`low`, `medium`, `high`). If a cell has fewer than 1,700 cleaned posts, keep all of them.
+- Upload to `s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet` with `put_new`. A second run must fail if that key already exists.
+- The four modules named in the README are required. `run.py` is the caller that runs them in order.
+- Implement-from-spec Phase 4 is the live runtime checks in the step files. Do not add files under `tests/`.
+
+## Steps
+
+### Step 1: Add the load, cleanup, sample, and upload command
+
+Add the four modules named in the experiment README, plus a `run.py` caller. Pin the combined parquet hash, apply cleanup, and sample with a fixed seed. See [steps/step1.md](steps/step1.md).
+
+### Step 2: Run the command and write RESULTS.md
+
+Run the command with AWS credentials. Confirm the local file and the S3 object, then commit RESULTS.md with cleanup counts and the sampled stance by toxicity table. See [steps/step2.md](steps/step2.md).
+
+## What "done" looks like
+
+1. `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/` has `load_raw_candidate_dataset.py`, `cleanup_raw_candidate_dataset.py`, `sample_raw_candidate_dataset.py`, `upload_filtered_candidate_dataset.py`, and a runnable `run.py`.
+2. `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md` is unchanged from the pull request 267 draft.
+3. The filtered parquet exists locally under that folder and at `s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet`.
+4. `RESULTS.md` records cleanup drop counts, cleaned cell counts, and sampled cell counts.
+5. Five cells have 1,700 sampled posts. The cell for right stance and high toxicity has every cleaned post in that cell.
+6. Product curate scripts and the combined source parquet are unchanged.
+7. No pytest file was added or run.

--- a/docs/plans/2026-09-08_filter_posts_stimulus_c4f821/steps/step1.md
+++ b/docs/plans/2026-09-08_filter_posts_stimulus_c4f821/steps/step1.md
@@ -1,0 +1,234 @@
+# Step 1: Add the load, cleanup, sample, and upload command
+
+## Scope
+
+- **Caller:** `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py` `main`
+- **Task:** Download the pinned combined stimulus parquet, check SHA-256 and row count, drop previously used posts, drop duplicate ids, drop duplicate text, sample up to 1700 posts per political-stance by LLM-toxicity cell, write local `dataset.parquet`, upload that file to S3 with `put_new`, print counts, and write `RESULTS.md`.
+- **Out of scope:** pytest, editing the experiment README, relabeling, curation YAML edits, `sample_data_to_mirror.py`, generating mirrors, changing product curate scripts, overwriting the combined source parquet.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md` | Required module names, S3 bucket, S3 prefix, 10200-post aim, 1700 per cell. Do not edit. |
+| `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/load.py` | Download, hash check, local cache, `CampaignObjectStore.get` |
+| `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/write.py` | Local parquet bytes, `put_new`, RESULTS.md shape |
+| `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/crosstab.py` | Stance rows `left`/`right`, toxicity columns `low`/`medium`/`high` |
+| `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/sources.py` | Combined column names, sort columns, bucket name |
+| `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/RESULTS.md` | Pinned source SHA-256 `f24ad1fd8c3709ffbbba9fb5dc953dcaee2f11ad8916ae21612b7f25cb5ca3f0`, 55573 rows |
+| `/workspace/data_platform/preprocessing/previously_used_stimuli.py` | `load_previously_used_stimuli_ids` |
+| `/workspace/shared/data/registry.py` | `DATASETS`, Part 1 and Part 2 stimuli entries |
+| `/workspace/data_platform/generate_features/s3_feature_campaign.py` | `CampaignObjectStore`, `parse_s3_uri`, `put_new` |
+| `/workspace/data_platform/utils/object_store.py` | `sha256_hex` |
+| `/workspace/lib/constants.py` | `REPO_ROOT` |
+| `/workspace/.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md` | Experiment code does not get unit tests |
+
+## Files allowed to change
+
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py` (new)
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sources.py` (new)
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/load_raw_candidate_dataset.py` (new)
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/cleanup_raw_candidate_dataset.py` (new)
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sample_raw_candidate_dataset.py` (new)
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py` (new)
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/.gitignore` (new)
+- `/workspace/.gitignore` (ignore local parquet and cache under this experiment folder only)
+
+## Files forbidden to change
+
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md`
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/data_platform/curate/configs/**`
+- `/workspace/data_platform/preprocessing/previously_used_stimuli.py`
+- `/workspace/shared/data/registry.py`
+- `/workspace/tests/**`
+- The combined source S3 object
+- `/workspace/CHANGELOG.md` until Step 2 has a live S3 object and RESULTS.md
+
+## Pinned candidate source
+
+| Field | Value |
+|-------|-------|
+| Object | `s3://mirrorview-experimental-artifacts/experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet` |
+| SHA-256 | `f24ad1fd8c3709ffbbba9fb5dc953dcaee2f11ad8916ae21612b7f25cb5ca3f0` |
+| Rows | 55573 |
+| Columns | the 17 combined columns in `COMBINED_COLUMNS` from `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/sources.py` |
+
+A hash mismatch or a wrong row count raises `ValueError`. A missing source object raises `FileNotFoundError`.
+
+## Cleanup contract
+
+Apply these steps in this order. Sort once before dropping duplicates, using `integration` ascending, then `source_dataset_id` ascending, then `source_record_id` ascending, with `kind="mergesort"`. Reset the index after each drop that removes rows.
+
+1. Drop rows whose `record_id` is in `load_previously_used_stimuli_ids(DATASETS)`.
+2. Drop rows whose `text` equals an `original_text` value from any registry stimuli dataset (`STUDY_PHASE_2_PART_1_STIMULI` and `STUDY_PHASE_2_PART_2_STIMULI`). Compare as `str`.
+3. Drop duplicate `record_id`, keep first.
+4. Drop duplicate `text`, keep first.
+
+Return a cleanup summary with integer counts for rows before cleanup, rows dropped at each step, and rows after cleanup.
+
+On the pinned candidate file, expected live counts are:
+
+| Stage | Rows remaining | Rows dropped at this step |
+|-------|---------------:|--------------------------:|
+| Start | 55573 | 0 |
+| After previously used record ids | 55573 | 0 |
+| After previously used original text | 55531 | 42 |
+| After duplicate `record_id` | 54960 | 571 |
+| After duplicate `text` | 54472 | 488 |
+
+A missing required column raises `ValueError`.
+
+## Sample contract
+
+Cells are the six pairs of `political_stance` in (`left`, `right`) and `llm_toxicity_tier` in (`low`, `medium`, `high`).
+
+`TARGET_PER_CELL = 1700`. `SAMPLE_SEED = 42`.
+
+For each cell, if the cleaned cell has 1700 or more rows, sample 1700 rows without replacement with `random_state=SAMPLE_SEED`. If the cleaned cell has fewer than 1700 rows, keep every row in that cell. If a cell has 0 rows, raise `ValueError`.
+
+Concatenate the six cell frames. Sort the sampled table by `integration`, `source_dataset_id`, `source_record_id` with `kind="mergesort"`. Reset the index.
+
+On the pinned candidate file after the cleanup above, expected live cell sizes before sampling are:
+
+| political_stance | low | medium | high |
+|------------------|----:|-------:|-----:|
+| left | 17644 | 16903 | 3638 |
+| right | 9022 | 6203 | 1062 |
+
+Expected sampled counts:
+
+| political_stance | low | medium | high | total |
+|------------------|----:|-------:|-----:|------:|
+| left | 1700 | 1700 | 1700 | 5100 |
+| right | 1700 | 1700 | 1062 | 4462 |
+| total | 3400 | 3400 | 2762 | 9562 |
+
+Expected `sampled_rows=9562`. Do not raise because the total is not 10200. Print `right_high_available=1062` and `right_high_shortfall=638`.
+
+The sampled parquet keeps the same 17 columns in the same order as the candidate file.
+
+## Outputs
+
+| Output | Path |
+|--------|------|
+| Local parquet | `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet` |
+| S3 parquet | `s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet` |
+| S3 key | `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet` |
+| Report | `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/RESULTS.md` |
+| Cache | `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/cache/` (gitignored) |
+
+Upload with `CampaignObjectStore.put_new`. The write fails if the S3 key already exists.
+
+Gitignore `cache/` and `dataset.parquet` under this experiment folder. Do not commit the parquet.
+
+## Crosstab and RESULTS.md
+
+Reuse `stance_by_toxicity` and `stance_by_toxicity_by_integration` from `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/crosstab.py`. Do not copy those functions.
+
+`RESULTS.md` must include:
+
+- The run command
+- Candidate source URI, SHA-256, and row count
+- Cleanup drop counts for each step
+- Cleaned stance by toxicity table
+- Sampled stance by toxicity table
+- Sampled row count, local path, S3 URI, and SHA-256
+- A sentence that the right-high cell kept every cleaned post because it had fewer than 1700 posts
+
+Stdout prints `candidate_rows=55573`, `cleaned_rows=54472`, `sampled_rows=9562`, the S3 URI, SHA-256, and both JSON tables (cleaned and sampled).
+
+## Main caller
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
+```
+
+Expected stdout includes `candidate_rows=55573`, `cleaned_rows=54472`, `sampled_rows=9562`, `s3_uri=s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet`, and `dataset_sha256=`.
+
+## Work
+
+Follow `/implement-from-spec`. Full auto. Do not add pytest. Phase 4 is the given/when/then live checks below, written in the `run.py` module docstring.
+
+### Modules
+
+Keep functions under 20 lines. Use a frozen dataclass for the pinned candidate source. Do not pass unstructured dictionaries for source identity.
+
+`sources.py` holds the pinned candidate URI, SHA-256, row count, output S3 key, `TARGET_PER_CELL`, `SAMPLE_SEED`, and sort columns.
+
+`load_raw_candidate_dataset.py` downloads the pinned object through `CampaignObjectStore.get`, checks SHA-256 with `sha256_hex`, checks row count, and may cache bytes under `cache/`.
+
+`cleanup_raw_candidate_dataset.py` applies the four cleanup steps and returns the cleaned frame plus the drop-count summary.
+
+`sample_raw_candidate_dataset.py` samples each of the six cells and returns the sampled frame.
+
+`upload_filtered_candidate_dataset.py` writes local parquet bytes, uploads with `put_new`, and writes `RESULTS.md`.
+
+`run.py` is the caller: load, cleanup, sample, write, print.
+
+Reuse `CampaignObjectStore`, `parse_s3_uri`, `sha256_hex`, `load_previously_used_stimuli_ids`, and the combine crosstab helpers. Do not copy a new S3 client.
+
+### Live given / when / then (Phase 4)
+
+```text
+given AWS credentials from LAB_AWS_ACCESS_KEY_ID and LAB_AWS_ACCESS_KEY_SECRET
+and the pinned combined parquet exists at SHA-256 f24ad1fd8c3709ffbbba9fb5dc953dcaee2f11ad8916ae21612b7f25cb5ca3f0
+when PYTHONPATH=. uv run python experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
+then candidate_rows=55573
+and cleaned_rows=54472
+and sampled_rows=9562
+and local dataset.parquet exists
+and S3 object experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet exists
+and its SHA-256 matches the local file
+and RESULTS.md contains the cleaned stance by toxicity table
+and RESULTS.md contains the sampled stance by toxicity table
+and the sampled right-high cell has 1062 rows
+and stdout prints both tables
+
+given the S3 dataset.parquet key already exists
+when the command is run again
+then the process raises FileExistsError and does not change the combined source object
+```
+
+## Must pass
+
+- Imports from `run.py` resolve.
+- Combined source SHA-256 and row count are checked before cleanup.
+- Cleanup drop order matches the contract.
+- Sampled columns match the 17-name contract in order.
+- Product curate files and the experiment README are unchanged.
+
+## Must fail
+
+- Hash mismatch on the candidate parquet.
+- Wrong candidate row count.
+- Missing required column.
+- Empty stance by toxicity cell.
+- Second upload to the same S3 key.
+
+## Implement-from-spec notes
+
+Phase 1 names `run.py` `main` as the caller.
+
+Phase 2 scaffolds the six modules with stub bodies and a thin `main` that calls load, cleanup, sample, write, print.
+
+Phase 3 locks `CandidateSource` and the public function signatures. Continue without a pause because this run is full auto.
+
+Phase 4 writes the given/when/then block in the `run.py` docstring. Do not add files under `tests/`.
+
+Phase 5 implements in this order, one commit per unit of work:
+
+1. `CandidateSource` and pinned constants
+2. download and hash/row checks
+3. previously used id and original-text drops
+4. duplicate `record_id` and duplicate `text` drops
+5. per-cell sample
+6. local parquet write
+7. S3 `put_new`
+8. RESULTS.md writer and `main`
+
+Phase 6 is complete when the modules exist, imports resolve, and Step 2 can run the live command.

--- a/docs/plans/2026-09-08_filter_posts_stimulus_c4f821/steps/step2.md
+++ b/docs/plans/2026-09-08_filter_posts_stimulus_c4f821/steps/step2.md
@@ -1,0 +1,95 @@
+# Step 2: Run the command and write RESULTS.md
+
+## Scope
+
+- **Caller:** the same `run.py` `main` from Step 1.
+- **Task:** Export AWS credentials, run the filter command, confirm local and S3 parquet, copy logs to `/opt/cursor/artifacts/`, and commit `RESULTS.md` with cleanup counts and both crosstab tables filled from the live run.
+- **Out of scope:** pytest, editing product curate files, changing the combined source object, editing the experiment README, rewriting Step 1 modules except docstring fixes required by `write-docstring`.
+
+## Files to inspect (read-only)
+
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py`
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md`
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/RESULTS.md`
+- `/workspace/docs/plans/2026-09-08_filter_posts_stimulus_c4f821/steps/step1.md`
+
+## Files allowed to change
+
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/RESULTS.md` (written by the live command, then committed)
+- `/workspace/CHANGELOG.md` after the live S3 object exists
+
+## Files forbidden to change
+
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md`
+- `/workspace/data_platform/curate/**`
+- `/workspace/tests/**`
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/**`
+- The combined source S3 object
+- `/workspace/docs/plans/2026-09-08_filter_posts_stimulus_c4f821/**`
+
+## Live commands
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
+```
+
+Expected stdout includes `candidate_rows=55573`, `cleaned_rows=54472`, `sampled_rows=9562`, a local path under `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet`, `s3_uri=s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet`, `dataset_sha256=`, and two JSON tables.
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import hashlib
+from pathlib import Path
+import pyarrow.parquet as pq
+from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+
+local = Path("experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet")
+store = CampaignObjectStore("mirrorview-experimental-artifacts")
+key = "experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet"
+stored = store.get(key)
+assert stored is not None
+want = [
+    "integration",
+    "source_dataset_id",
+    "source_curated_run",
+    "record_id",
+    "source_record_id",
+    "platform_id",
+    "author_handle",
+    "text",
+    "created_at",
+    "sync_timestamp",
+    "news_or_opinion_category",
+    "is_political",
+    "is_likely_spam",
+    "is_self_contained",
+    "is_structurally_complete",
+    "political_stance",
+    "llm_toxicity_tier",
+]
+table = pq.read_table(local)
+assert table.column_names == want, table.column_names
+assert table.num_rows == 9562
+assert hashlib.sha256(local.read_bytes()).hexdigest() == hashlib.sha256(stored.body).hexdigest()
+print("filtered ok", table.num_rows, len(table.column_names))
+PY
+```
+
+Expected: `filtered ok 9562 17`.
+
+Copy the command stdout to `/opt/cursor/artifacts/filter_posts_stimulus_run.log`.
+
+## Must pass
+
+- Live command exits 0 on the first run.
+- `sampled_rows=9562`.
+- Sampled right-high count is 1062.
+- Local SHA-256 equals S3 object SHA-256.
+- `RESULTS.md` is committed.
+- Combined source object SHA-256 is still `f24ad1fd8c3709ffbbba9fb5dc953dcaee2f11ad8916ae21612b7f25cb5ca3f0`.
+
+## Must fail
+
+- A second run of the same command, because `put_new` must raise `FileExistsError`.

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/.gitignore
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/.gitignore
@@ -1,0 +1,2 @@
+cache/
+dataset.parquet

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md
@@ -1,0 +1,25 @@
+# Filter posts used for stimulus dataset
+
+<-- NOTE TO AI AGENTS: do NOT touch this file. This file is READ-ONLY. If something here is incorrect or needs updating, inform the user and they will make the change themselves -->
+
+For the next study, we want to figure out what posts will be in our stimulus dataset.
+
+We have a dataset of ~55,000 posts, from `experiments/combine_data_into_stimulus_set_2026_09_08`. We'll now filter this down to 10,000 posts.
+
+Some rules for us to consider:
+
+- An even 1:1:1 split across all 3 toxicity classes
+- An even 1:1 split across political parties.
+
+Cleanup steps:
+
+- Drop posts that have the same ID
+- Drop posts that have the same text.
+- ... (I need to think of what cleanup will look like, and how to get the highest-quality dataset for training).
+
+Once done with cleanup, we can sample:
+
+- Sample all the right-leaning high-toxicity posts.
+- Then backfill so we have ~even distributions across all toxicity classes and political parties (ideally each cell would be equivalent).
+
+We need to do this in conjunction with our previous stimuli dataset, as we eventually want a full 20,000 post x 5 labels per post = 100,000 total labels. So, we need 10,000 total labels. Let's aim for 10,200 so as to have an even ~1,700 labels per cell in the political party x toxicity split.

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md
@@ -15,11 +15,14 @@ Cleanup steps:
 
 - Drop posts that have the same ID
 - Drop posts that have the same text.
-- ... (I need to think of what cleanup will look like, and how to get the highest-quality dataset for training).
 
-Once done with cleanup, we can sample:
-
-- Sample all the right-leaning high-toxicity posts.
-- Then backfill so we have ~even distributions across all toxicity classes and political parties (ideally each cell would be equivalent).
+Once done with cleanup, we can sample so we have ~even distributions across all toxicity classes and political parties (ideally each cell would be equivalent).
 
 We need to do this in conjunction with our previous stimuli dataset, as we eventually want a full 20,000 post x 5 labels per post = 100,000 total labels. So, we need 10,000 total labels. Let's aim for 10,200 so as to have an even ~1,700 labels per cell in the political party x toxicity split.
+
+We need the following files:
+
+- load_raw_candidate_dataset.py: to load the candidate ~55,000 post dataset.
+- cleanup_raw_candidate_dataset.py
+- sample_raw_candidate_dataset.py
+- upload_filtered_candidate_dataset.py: uploads the candidate dataset to S3, using the `mirrorview-experimental-artifacts` bucket and `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/` S3 prefix.

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/RESULTS.md
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/RESULTS.md
@@ -1,0 +1,51 @@
+# Filter posts used for stimulus dataset, results
+
+## Command
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
+```
+
+## Candidate source
+
+Object `s3://mirrorview-experimental-artifacts/experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet` SHA-256 `f24ad1fd8c3709ffbbba9fb5dc953dcaee2f11ad8916ae21612b7f25cb5ca3f0` has 55573 rows.
+
+## Cleanup
+
+| Step | Rows dropped | Rows remaining |
+| ---- | -----------: | -------------: |
+| Start | 0 | 55573 |
+| Previously used record ids | 0 | 55573 |
+| Previously used original text | 42 | 55531 |
+| Duplicate record ids | 571 | 54960 |
+| Duplicate text | 488 | 54472 |
+
+## Filtered parquet
+
+| File | Path | SHA-256 |
+| ---- | ---- | ------- |
+| Local parquet | `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet` | `840d2ceeb8fb7e32b47e9c1488f8bde28554d8bd43675caf26af3a9f750d26ed` |
+| S3 parquet | `s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet` | `840d2ceeb8fb7e32b47e9c1488f8bde28554d8bd43675caf26af3a9f750d26ed` |
+
+Sampled row count is 9562. Aimed total is 10200.
+
+## Cleaned political stance by LLM toxicity tier
+
+| political_stance | low | medium | high | total |
+| ---------------- | --: | -----: | ---: | ----: |
+| left | 17644 | 16903 | 3638 | 38185 |
+| right | 9022 | 6203 | 1062 | 16287 |
+| total | 26666 | 23106 | 4700 | 54472 |
+
+## Sampled political stance by LLM toxicity tier
+
+| political_stance | low | medium | high | total |
+| ---------------- | --: | -----: | ---: | ----: |
+| left | 1700 | 1700 | 1700 | 5100 |
+| right | 1700 | 1700 | 1062 | 4462 |
+| total | 3400 | 3400 | 2762 | 9562 |
+
+The cell for right stance and high toxicity kept every cleaned post because it had 1062 posts, which is fewer than 1700.

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/RESULTS.md
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/RESULTS.md
@@ -48,4 +48,4 @@ Sampled row count is 9562. Aimed total is 10200.
 | right | 1700 | 1700 | 1062 | 4462 |
 | total | 3400 | 3400 | 2762 | 9562 |
 
-The cell for right stance and high toxicity kept every cleaned post because it had 1062 posts, which is fewer than 1700.
+Operators kept every cleaned post in the cell for right stance and high toxicity, because the cell had 1062 posts. 1062 is fewer than 1700.

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/RESULTS.md
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/RESULTS.md
@@ -27,10 +27,10 @@ Object `s3://mirrorview-experimental-artifacts/experiments/combine_data_into_sti
 
 | File | Path | SHA-256 |
 | ---- | ---- | ------- |
-| Local parquet | `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet` | `840d2ceeb8fb7e32b47e9c1488f8bde28554d8bd43675caf26af3a9f750d26ed` |
-| S3 parquet | `s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet` | `840d2ceeb8fb7e32b47e9c1488f8bde28554d8bd43675caf26af3a9f750d26ed` |
+| Local parquet | `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet` | `9788331f898aa27352dcdf32a962b5722aecc1da61a4638b7bbd77a404415ab9` |
+| S3 parquet | `s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet` | `9788331f898aa27352dcdf32a962b5722aecc1da61a4638b7bbd77a404415ab9` |
 
-Sampled row count is 9562. Aimed total is 10200.
+Sampled row count is 10200. Aimed total is 10200.
 
 ## Cleaned political stance by LLM toxicity tier
 
@@ -45,7 +45,9 @@ Sampled row count is 9562. Aimed total is 10200.
 | political_stance | low | medium | high | total |
 | ---------------- | --: | -----: | ---: | ----: |
 | left | 1700 | 1700 | 1700 | 5100 |
-| right | 1700 | 1700 | 1062 | 4462 |
-| total | 3400 | 3400 | 2762 | 9562 |
+| right | 1700 | 2338 | 1062 | 5100 |
+| total | 3400 | 4038 | 2762 | 10200 |
 
 Operators kept every cleaned post in the cell for right stance and high toxicity, because the cell had 1062 posts. 1062 is fewer than 1700.
+
+Operators sampled 638 extra posts from the cell for right stance and medium toxicity so that left and right both have the same number of posts, and the sample has 10200 posts.

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/cleanup_raw_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/cleanup_raw_candidate_dataset.py
@@ -28,6 +28,10 @@ def cleanup_raw_candidate_dataset(
 ) -> tuple[pd.DataFrame, CleanupSummary]:
     """Return the cleaned table and drop-count summary.
 
+    Drops happen in this order: previously used record ids, previously used
+    original text, duplicate record ids, then duplicate text. Duplicate drops
+    keep the first row after a stable sort.
+
     Parameters
     ----------
     frame

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/cleanup_raw_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/cleanup_raw_candidate_dataset.py
@@ -106,11 +106,17 @@ def _drop_matching(
 
 
 def _drop_duplicate_record_ids(frame: pd.DataFrame) -> tuple[pd.DataFrame, int]:
-    raise NotImplementedError
+    return _drop_duplicates(frame, RECORD_ID_COLUMN)
 
 
 def _drop_duplicate_text(frame: pd.DataFrame) -> tuple[pd.DataFrame, int]:
-    raise NotImplementedError
+    return _drop_duplicates(frame, TEXT_COLUMN)
+
+
+def _drop_duplicates(frame: pd.DataFrame, column: str) -> tuple[pd.DataFrame, int]:
+    unique = frame.drop_duplicates(subset=[column], keep="first")
+    dropped = len(frame) - len(unique)
+    return unique.reset_index(drop=True), dropped
 
 
 def _cleanup_summary(

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/cleanup_raw_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/cleanup_raw_candidate_dataset.py
@@ -1,0 +1,16 @@
+"""Drop previously used posts, duplicate ids, and duplicate text."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources import (
+    CleanupSummary,
+)
+
+
+def cleanup_raw_candidate_dataset(
+    frame: pd.DataFrame,
+) -> tuple[pd.DataFrame, CleanupSummary]:
+    """Return the cleaned table and drop-count summary."""
+    raise NotImplementedError

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/cleanup_raw_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/cleanup_raw_candidate_dataset.py
@@ -2,15 +2,130 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import pandas as pd
 
+from data_platform.preprocessing.previously_used_stimuli import (
+    STIMULI_DATASET_KIND,
+    load_previously_used_stimuli_ids,
+)
 from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources import (
+    CANDIDATE_COLUMNS,
+    CANDIDATE_SORT_COLUMNS,
+    RECORD_ID_COLUMN,
+    TEXT_COLUMN,
     CleanupSummary,
 )
+from shared.data.dataloader import load_dataset
+from shared.data.registry import DATASETS, DatasetEntry
+
+ORIGINAL_TEXT_COLUMN = "original_text"
 
 
 def cleanup_raw_candidate_dataset(
     frame: pd.DataFrame,
 ) -> tuple[pd.DataFrame, CleanupSummary]:
-    """Return the cleaned table and drop-count summary."""
+    """Return the cleaned table and drop-count summary.
+
+    Parameters
+    ----------
+    frame
+        Combined candidate table.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, CleanupSummary]
+        Cleaned rows with a reset index, then the drop counts.
+
+    Raises
+    ------
+    ValueError
+        When a required column is missing.
+    """
+    _require_columns(frame)
+    sorted_frame = _sort_candidates(frame)
+    without_ids, dropped_ids = _drop_previously_used_ids(sorted_frame)
+    without_text, dropped_text = _drop_previously_used_text(without_ids)
+    without_dup_ids, dropped_dup_ids = _drop_duplicate_record_ids(without_text)
+    cleaned, dropped_dup_text = _drop_duplicate_text(without_dup_ids)
+    summary = _cleanup_summary(
+        len(frame),
+        dropped_ids,
+        dropped_text,
+        dropped_dup_ids,
+        dropped_dup_text,
+        len(cleaned),
+    )
+    return cleaned, summary
+
+
+def _require_columns(frame: pd.DataFrame) -> None:
+    missing = [column for column in CANDIDATE_COLUMNS if column not in frame.columns]
+    if missing:
+        raise ValueError(f"missing columns {missing}")
+
+
+def _sort_candidates(frame: pd.DataFrame) -> pd.DataFrame:
+    return frame.sort_values(
+        list(CANDIDATE_SORT_COLUMNS),
+        kind="mergesort",
+    ).reset_index(drop=True)
+
+
+def _drop_previously_used_ids(frame: pd.DataFrame) -> tuple[pd.DataFrame, int]:
+    previous_ids = load_previously_used_stimuli_ids(DATASETS)
+    return _drop_matching(frame, RECORD_ID_COLUMN, previous_ids)
+
+
+def _drop_previously_used_text(frame: pd.DataFrame) -> tuple[pd.DataFrame, int]:
+    previous_text = _previously_used_original_text(DATASETS)
+    return _drop_matching(frame, TEXT_COLUMN, previous_text)
+
+
+def _previously_used_original_text(
+    datasets: Mapping[str, DatasetEntry],
+) -> set[str]:
+    texts: set[str] = set()
+    for entry in datasets.values():
+        if entry.kind != STIMULI_DATASET_KIND:
+            continue
+        frame = load_dataset(entry.name)
+        texts |= set(frame[ORIGINAL_TEXT_COLUMN].dropna().map(str))
+    return texts
+
+
+def _drop_matching(
+    frame: pd.DataFrame,
+    column: str,
+    values: set[str],
+) -> tuple[pd.DataFrame, int]:
+    is_kept = ~frame[column].map(str).isin(list(values))
+    dropped = len(frame) - int(is_kept.sum())
+    return frame.loc[is_kept].reset_index(drop=True), dropped
+
+
+def _drop_duplicate_record_ids(frame: pd.DataFrame) -> tuple[pd.DataFrame, int]:
     raise NotImplementedError
+
+
+def _drop_duplicate_text(frame: pd.DataFrame) -> tuple[pd.DataFrame, int]:
+    raise NotImplementedError
+
+
+def _cleanup_summary(
+    candidate_rows: int,
+    dropped_previous_ids: int,
+    dropped_previous_text: int,
+    dropped_duplicate_ids: int,
+    dropped_duplicate_text: int,
+    cleaned_rows: int,
+) -> CleanupSummary:
+    return CleanupSummary(
+        candidate_rows=candidate_rows,
+        dropped_previous_ids=dropped_previous_ids,
+        dropped_previous_text=dropped_previous_text,
+        dropped_duplicate_ids=dropped_duplicate_ids,
+        dropped_duplicate_text=dropped_duplicate_text,
+        cleaned_rows=cleaned_rows,
+    )

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/load_raw_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/load_raw_candidate_dataset.py
@@ -2,14 +2,27 @@
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 
 import pandas as pd
 
-from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from data_platform.generate_features.s3_feature_campaign import (
+    CampaignObjectStore,
+    parse_s3_uri,
+)
+from data_platform.utils.object_store import sha256_hex
 from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources import (
+    CANDIDATE_COLUMNS,
     CandidateSource,
 )
+from lib.constants import REPO_ROOT
+
+EXPERIMENT_DIR = (
+    REPO_ROOT / "experiments" / "filter_posts_used_for_stimulus_dataset_2026_09_08"
+)
+DEFAULT_CACHE_DIR = EXPERIMENT_DIR / "cache"
+CACHE_FILENAME = "dataset.parquet"
 
 
 def load_raw_candidate_dataset(
@@ -17,5 +30,87 @@ def load_raw_candidate_dataset(
     store: CampaignObjectStore | None = None,
     cache_dir: Path | None = None,
 ) -> pd.DataFrame:
-    """Return the candidate table after checking SHA-256 and row count."""
-    raise NotImplementedError
+    """Return the candidate table after checking SHA-256 and row count.
+
+    Parameters
+    ----------
+    source
+        Pinned combined parquet identity.
+    store
+        If you omit store, the function builds a store for the source bucket.
+    cache_dir
+        Directory for a local copy of the source bytes.
+
+    Returns
+    -------
+    pd.DataFrame
+        The combined candidate table.
+
+    Raises
+    ------
+    FileNotFoundError
+        When the source object is missing.
+    ValueError
+        When the SHA-256, row count, or columns do not match the pin.
+    """
+    resolved_store = store if store is not None else _store_for_source(source)
+    resolved_cache_dir = cache_dir if cache_dir is not None else DEFAULT_CACHE_DIR
+    body = _bytes_matching_pinned_hash(source, resolved_store, resolved_cache_dir)
+    candidate = pd.read_parquet(io.BytesIO(body))
+    _require_row_count(source, candidate)
+    _require_columns(candidate)
+    return candidate
+
+
+def _store_for_source(source: CandidateSource) -> CampaignObjectStore:
+    bucket, _key = parse_s3_uri(source.s3_uri)
+    return CampaignObjectStore(bucket)
+
+
+def _object_key(source: CandidateSource) -> str:
+    _bucket, key = parse_s3_uri(source.s3_uri)
+    return key
+
+
+def _cache_path(cache_dir: Path) -> Path:
+    return cache_dir / CACHE_FILENAME
+
+
+def _download_source_bytes(source: CandidateSource, store: CampaignObjectStore) -> bytes:
+    stored = store.get(_object_key(source))
+    if stored is None:
+        raise FileNotFoundError(source.s3_uri)
+    return stored.body
+
+
+def _bytes_matching_pinned_hash(
+    source: CandidateSource,
+    store: CampaignObjectStore,
+    cache_dir: Path,
+) -> bytes:
+    cache_path = _cache_path(cache_dir)
+    if cache_path.is_file():
+        cached = cache_path.read_bytes()
+        if sha256_hex(cached) == source.sha256:
+            return cached
+    body = _download_source_bytes(source, store)
+    if sha256_hex(body) != source.sha256:
+        raise ValueError(f"SHA-256 mismatch for {source.s3_uri}")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(body)
+    return body
+
+
+def _require_row_count(source: CandidateSource, candidate: pd.DataFrame) -> None:
+    if len(candidate) != source.expected_row_count:
+        raise ValueError(
+            f"row_count={len(candidate)} expected={source.expected_row_count} "
+            f"uri={source.s3_uri}"
+        )
+
+
+def _require_columns(candidate: pd.DataFrame) -> None:
+    actual = list(candidate.columns)
+    expected = list(CANDIDATE_COLUMNS)
+    if actual != expected:
+        raise ValueError(f"columns={actual} expected={expected}")

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/load_raw_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/load_raw_candidate_dataset.py
@@ -1,0 +1,21 @@
+"""Download the pinned combined parquet and check its hash and row count."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources import (
+    CandidateSource,
+)
+
+
+def load_raw_candidate_dataset(
+    source: CandidateSource,
+    store: CampaignObjectStore | None = None,
+    cache_dir: Path | None = None,
+) -> pd.DataFrame:
+    """Return the candidate table after checking SHA-256 and row count."""
+    raise NotImplementedError

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/load_raw_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/load_raw_candidate_dataset.py
@@ -32,6 +32,8 @@ def load_raw_candidate_dataset(
 ) -> pd.DataFrame:
     """Return the candidate table after checking SHA-256 and row count.
 
+    A matching local cache copy is reused when its SHA-256 matches the pin.
+
     Parameters
     ----------
     source

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
@@ -5,13 +5,14 @@ and the pinned combined parquet exists at SHA-256 f24ad1fd8c3709ffbbba9fb5dc953d
 when PYTHONPATH=. uv run python experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
 then candidate_rows=55573
 and cleaned_rows=54472
-and sampled_rows=9562
+and sampled_rows=10200
 and local dataset.parquet exists
 and S3 object experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet exists
 and its SHA-256 matches the local file
 and RESULTS.md contains the cleaned stance by toxicity table
 and RESULTS.md contains the sampled stance by toxicity table
 and the sampled cell for right stance and high toxicity has 1062 rows
+and the sampled cell for right stance and medium toxicity has 2338 rows
 and stdout prints both tables
 
 given the S3 dataset.parquet key already exists

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
@@ -1,0 +1,42 @@
+"""Filter the combined stimulus parquet to a balanced sample.
+
+Run from the repo root:
+
+    PYTHONPATH=. uv run python experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.cleanup_raw_candidate_dataset import (
+    cleanup_raw_candidate_dataset,
+)
+from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.load_raw_candidate_dataset import (
+    load_raw_candidate_dataset,
+)
+from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sample_raw_candidate_dataset import (
+    sample_raw_candidate_dataset,
+)
+from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources import (
+    pinned_candidate_source,
+)
+from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.upload_filtered_candidate_dataset import (
+    print_run_summary,
+    write_filtered_dataset,
+)
+
+
+def main() -> int:
+    """Load, clean, sample, write, and print the filtered stimulus dataset."""
+    source = pinned_candidate_source()
+    candidate = load_raw_candidate_dataset(source)
+    cleaned, summary = cleanup_raw_candidate_dataset(candidate)
+    sampled = sample_raw_candidate_dataset(cleaned)
+    result = write_filtered_dataset(sampled, cleaned, summary)
+    print_run_summary(result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
@@ -1,5 +1,23 @@
 """Filter the combined stimulus parquet to a balanced sample.
 
+given AWS credentials from LAB_AWS_ACCESS_KEY_ID and LAB_AWS_ACCESS_KEY_SECRET
+and the pinned combined parquet exists at SHA-256 f24ad1fd8c3709ffbbba9fb5dc953dcaee2f11ad8916ae21612b7f25cb5ca3f0
+when PYTHONPATH=. uv run python experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
+then candidate_rows=55573
+and cleaned_rows=54472
+and sampled_rows=9562
+and local dataset.parquet exists
+and S3 object experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet exists
+and its SHA-256 matches the local file
+and RESULTS.md contains the cleaned stance by toxicity table
+and RESULTS.md contains the sampled stance by toxicity table
+and the sampled right-high cell has 1062 rows
+and stdout prints both tables
+
+given the S3 dataset.parquet key already exists
+when the command is run again
+then the process raises FileExistsError and does not change the combined source object
+
 Run from the repo root:
 
     PYTHONPATH=. uv run python experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
@@ -11,7 +11,7 @@ and S3 object experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/data
 and its SHA-256 matches the local file
 and RESULTS.md contains the cleaned stance by toxicity table
 and RESULTS.md contains the sampled stance by toxicity table
-and the sampled right-high cell has 1062 rows
+and the sampled cell for right stance and high toxicity has 1062 rows
 and stdout prints both tables
 
 given the S3 dataset.parquet key already exists

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sample_raw_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sample_raw_candidate_dataset.py
@@ -18,6 +18,9 @@ from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources impor
 def sample_raw_candidate_dataset(cleaned: pd.DataFrame) -> pd.DataFrame:
     """Return the sampled table with up to TARGET_PER_CELL rows per cell.
 
+    Cells with fewer than ``TARGET_PER_CELL`` cleaned posts keep every row.
+    Sampling uses ``SAMPLE_SEED`` without replacement.
+
     Parameters
     ----------
     cleaned

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sample_raw_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sample_raw_candidate_dataset.py
@@ -8,6 +8,10 @@ from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources impor
     CANDIDATE_SORT_COLUMNS,
     CANDIDATE_STANCE_ROWS,
     CANDIDATE_TOXICITY_COLUMNS,
+    LEFT_STANCE,
+    MEDIUM_TOXICITY,
+    RECORD_ID_COLUMN,
+    RIGHT_STANCE,
     SAMPLE_SEED,
     STANCE_COLUMN,
     TARGET_PER_CELL,
@@ -16,10 +20,12 @@ from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources impor
 
 
 def sample_raw_candidate_dataset(cleaned: pd.DataFrame) -> pd.DataFrame:
-    """Return the sampled table with up to TARGET_PER_CELL rows per cell.
+    """Return the sampled table with even left and right totals.
 
     Cells with fewer than ``TARGET_PER_CELL`` cleaned posts keep every row.
-    Sampling uses ``SAMPLE_SEED`` without replacement.
+    Extra posts then come from unused right-medium rows until the right
+    total matches the left total. Sampling uses ``SAMPLE_SEED`` without
+    replacement.
 
     Parameters
     ----------
@@ -34,11 +40,15 @@ def sample_raw_candidate_dataset(cleaned: pd.DataFrame) -> pd.DataFrame:
     Raises
     ------
     ValueError
-        When a stance by toxicity cell is empty.
+        When a stance by toxicity cell is empty, or right-medium cannot
+        fill the left/right gap.
     """
     parts = [_sample_one_cell(cleaned, stance, tier) for stance, tier in _cells()]
     sampled = pd.concat(parts, ignore_index=True)
-    return _sort_sampled(sampled)
+    extra = _extra_right_medium(cleaned, sampled)
+    if extra.empty:
+        return _sort_sampled(sampled)
+    return _sort_sampled(pd.concat([sampled, extra], ignore_index=True))
 
 
 def _cells() -> tuple[tuple[str, str], ...]:
@@ -60,6 +70,35 @@ def _sample_one_cell(
     if len(cell) <= TARGET_PER_CELL:
         return cell.reset_index(drop=True)
     return cell.sample(n=TARGET_PER_CELL, random_state=SAMPLE_SEED, replace=False)
+
+
+def _extra_right_medium(
+    cleaned: pd.DataFrame,
+    sampled: pd.DataFrame,
+) -> pd.DataFrame:
+    needed = _right_gap(sampled)
+    if needed <= 0:
+        return sampled.iloc[:0].copy()
+    unused = _unused_right_medium(cleaned, sampled)
+    if len(unused) < needed:
+        raise ValueError(f"right medium unused={len(unused)} needed={needed}")
+    return unused.sample(n=needed, random_state=SAMPLE_SEED, replace=False)
+
+
+def _right_gap(sampled: pd.DataFrame) -> int:
+    left_n = int((sampled[STANCE_COLUMN] == LEFT_STANCE).sum())
+    right_n = int((sampled[STANCE_COLUMN] == RIGHT_STANCE).sum())
+    return left_n - right_n
+
+
+def _unused_right_medium(
+    cleaned: pd.DataFrame,
+    sampled: pd.DataFrame,
+) -> pd.DataFrame:
+    used_ids = set(sampled[RECORD_ID_COLUMN].map(str))
+    pool = cleaned.loc[_cell_mask(cleaned, RIGHT_STANCE, MEDIUM_TOXICITY)]
+    is_unused = ~pool[RECORD_ID_COLUMN].map(str).isin(list(used_ids))
+    return pool.loc[is_unused]
 
 
 def _cell_mask(cleaned: pd.DataFrame, stance: str, tier: str) -> pd.Series:

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sample_raw_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sample_raw_candidate_dataset.py
@@ -1,0 +1,10 @@
+"""Sample up to 1700 posts in each political stance by toxicity cell."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def sample_raw_candidate_dataset(cleaned: pd.DataFrame) -> pd.DataFrame:
+    """Return the sampled table with up to TARGET_PER_CELL rows per cell."""
+    raise NotImplementedError

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sample_raw_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sample_raw_candidate_dataset.py
@@ -4,7 +4,67 @@ from __future__ import annotations
 
 import pandas as pd
 
+from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources import (
+    CANDIDATE_SORT_COLUMNS,
+    CANDIDATE_STANCE_ROWS,
+    CANDIDATE_TOXICITY_COLUMNS,
+    SAMPLE_SEED,
+    STANCE_COLUMN,
+    TARGET_PER_CELL,
+    TOXICITY_COLUMN,
+)
+
 
 def sample_raw_candidate_dataset(cleaned: pd.DataFrame) -> pd.DataFrame:
-    """Return the sampled table with up to TARGET_PER_CELL rows per cell."""
-    raise NotImplementedError
+    """Return the sampled table with up to TARGET_PER_CELL rows per cell.
+
+    Parameters
+    ----------
+    cleaned
+        Candidate rows after previously used and duplicate drops.
+
+    Returns
+    -------
+    pd.DataFrame
+        Sampled table sorted by integration, dataset id, and source record id.
+
+    Raises
+    ------
+    ValueError
+        When a stance by toxicity cell is empty.
+    """
+    parts = [_sample_one_cell(cleaned, stance, tier) for stance, tier in _cells()]
+    sampled = pd.concat(parts, ignore_index=True)
+    return _sort_sampled(sampled)
+
+
+def _cells() -> tuple[tuple[str, str], ...]:
+    return tuple(
+        (stance, tier)
+        for stance in CANDIDATE_STANCE_ROWS
+        for tier in CANDIDATE_TOXICITY_COLUMNS
+    )
+
+
+def _sample_one_cell(
+    cleaned: pd.DataFrame,
+    stance: str,
+    tier: str,
+) -> pd.DataFrame:
+    cell = cleaned.loc[_cell_mask(cleaned, stance, tier)]
+    if cell.empty:
+        raise ValueError(f"empty cell stance={stance} tier={tier}")
+    if len(cell) <= TARGET_PER_CELL:
+        return cell.reset_index(drop=True)
+    return cell.sample(n=TARGET_PER_CELL, random_state=SAMPLE_SEED, replace=False)
+
+
+def _cell_mask(cleaned: pd.DataFrame, stance: str, tier: str) -> pd.Series:
+    return (cleaned[STANCE_COLUMN] == stance) & (cleaned[TOXICITY_COLUMN] == tier)
+
+
+def _sort_sampled(sampled: pd.DataFrame) -> pd.DataFrame:
+    return sampled.sort_values(
+        list(CANDIDATE_SORT_COLUMNS),
+        kind="mergesort",
+    ).reset_index(drop=True)

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sources.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sources.py
@@ -11,20 +11,78 @@ from experiments.combine_data_into_stimulus_set_2026_09_08.sources import (
     TOXICITY_CROSSTAB_COLUMNS,
 )
 
+CANDIDATE_COLUMNS = COMBINED_COLUMNS
+CANDIDATE_SORT_COLUMNS = SORT_COLUMNS
+CANDIDATE_STANCE_ROWS = STANCE_CROSSTAB_ROWS
+CANDIDATE_TOXICITY_COLUMNS = TOXICITY_CROSSTAB_COLUMNS
+CANDIDATE_S3_BUCKET = "mirrorview-experimental-artifacts"
+CANDIDATE_S3_KEY = "experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet"
+CANDIDATE_S3_URI = f"s3://{CANDIDATE_S3_BUCKET}/{CANDIDATE_S3_KEY}"
+CANDIDATE_SHA256 = "f24ad1fd8c3709ffbbba9fb5dc953dcaee2f11ad8916ae21612b7f25cb5ca3f0"
+CANDIDATE_ROW_COUNT = 55573
+
+OUTPUT_S3_BUCKET = "mirrorview-experimental-artifacts"
+OUTPUT_S3_KEY = (
+    "experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet"
+)
+OUTPUT_S3_URI = f"s3://{OUTPUT_S3_BUCKET}/{OUTPUT_S3_KEY}"
+DATASET_FILENAME = "dataset.parquet"
+RESULTS_FILENAME = "RESULTS.md"
+TARGET_PER_CELL = 1700
+TARGET_TOTAL = 10200
+SAMPLE_SEED = 42
+RECORD_ID_COLUMN = "record_id"
+TEXT_COLUMN = "text"
+STANCE_COLUMN = "political_stance"
+TOXICITY_COLUMN = "llm_toxicity_tier"
+RIGHT_STANCE = "right"
+HIGH_TOXICITY = "high"
+
 
 @dataclass(frozen=True)
 class CandidateSource:
     """One pinned combined parquet used as the filter input."""
+
+    s3_uri: str
+    sha256: str
+    expected_row_count: int
 
 
 @dataclass(frozen=True)
 class CleanupSummary:
     """Row counts after each cleanup step."""
 
+    candidate_rows: int
+    dropped_previous_ids: int
+    dropped_previous_text: int
+    dropped_duplicate_ids: int
+    dropped_duplicate_text: int
+    cleaned_rows: int
+
 
 @dataclass(frozen=True)
 class FilterRunResult:
     """Local path, S3 URI, hash, and counts from one filter run."""
+
+    candidate_rows: int
+    cleaned_rows: int
+    sampled_rows: int
+    right_high_available: int
+    right_high_shortfall: int
+    local_path: str
+    s3_uri: str
+    dataset_sha256: str
+    cleanup_summary: CleanupSummary
+    cleaned_crosstab: dict[str, dict[str, int]]
+    sampled_crosstab: dict[str, dict[str, int]]
+    sampled_integration_crosstab: dict[str, dict[str, dict[str, int]]]
+
+
+PINNED_CANDIDATE = CandidateSource(
+    s3_uri=CANDIDATE_S3_URI,
+    sha256=CANDIDATE_SHA256,
+    expected_row_count=CANDIDATE_ROW_COUNT,
+)
 
 
 def pinned_candidate_source() -> CandidateSource:

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sources.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sources.py
@@ -35,7 +35,9 @@ RECORD_ID_COLUMN = "record_id"
 TEXT_COLUMN = "text"
 STANCE_COLUMN = "political_stance"
 TOXICITY_COLUMN = "llm_toxicity_tier"
+LEFT_STANCE = "left"
 RIGHT_STANCE = "right"
+MEDIUM_TOXICITY = "medium"
 HIGH_TOXICITY = "high"
 
 
@@ -69,6 +71,7 @@ class FilterRunResult:
     sampled_rows: int
     right_high_available: int
     right_high_shortfall: int
+    right_medium_upsampled: int
     local_path: str
     s3_uri: str
     dataset_sha256: str

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sources.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sources.py
@@ -87,4 +87,4 @@ PINNED_CANDIDATE = CandidateSource(
 
 def pinned_candidate_source() -> CandidateSource:
     """Return the pinned combined parquet identity."""
-    raise NotImplementedError
+    return PINNED_CANDIDATE

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sources.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sources.py
@@ -1,0 +1,32 @@
+"""Pinned candidate parquet and sample constants for the filter run."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from experiments.combine_data_into_stimulus_set_2026_09_08.sources import (
+    COMBINED_COLUMNS,
+    SORT_COLUMNS,
+    STANCE_CROSSTAB_ROWS,
+    TOXICITY_CROSSTAB_COLUMNS,
+)
+
+
+@dataclass(frozen=True)
+class CandidateSource:
+    """One pinned combined parquet used as the filter input."""
+
+
+@dataclass(frozen=True)
+class CleanupSummary:
+    """Row counts after each cleanup step."""
+
+
+@dataclass(frozen=True)
+class FilterRunResult:
+    """Local path, S3 URI, hash, and counts from one filter run."""
+
+
+def pinned_candidate_source() -> CandidateSource:
+    """Return the pinned combined parquet identity."""
+    raise NotImplementedError

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
@@ -32,6 +32,7 @@ from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources impor
     RIGHT_STANCE,
     STANCE_COLUMN,
     TARGET_PER_CELL,
+    TARGET_TOTAL,
     TOXICITY_COLUMN,
 )
 from lib.constants import REPO_ROOT
@@ -230,7 +231,7 @@ def _results_preamble(result: FilterRunResult) -> list[str]:
         "",
         _parquet_table_markdown(result),
         "",
-        f"Sampled row count is {result.sampled_rows}.",
+        f"Sampled row count is {result.sampled_rows}. Aimed total is {TARGET_TOTAL}.",
         "",
     ]
 

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
@@ -3,23 +3,48 @@
 from __future__ import annotations
 
 import io
+import json
 from pathlib import Path
 
 import pandas as pd
 
-from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from data_platform.generate_features.s3_feature_campaign import (
+    CampaignObjectStore,
+    s3_uri,
+)
 from data_platform.utils.object_store import sha256_hex
+from experiments.combine_data_into_stimulus_set_2026_09_08.crosstab import (
+    stance_by_toxicity,
+    stance_by_toxicity_by_integration,
+)
 from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources import (
+    CANDIDATE_SHA256,
+    CANDIDATE_S3_URI,
+    CANDIDATE_STANCE_ROWS,
+    CANDIDATE_TOXICITY_COLUMNS,
     CleanupSummary,
     DATASET_FILENAME,
     FilterRunResult,
+    HIGH_TOXICITY,
+    OUTPUT_S3_BUCKET,
     OUTPUT_S3_KEY,
+    RESULTS_FILENAME,
+    RIGHT_STANCE,
+    STANCE_COLUMN,
+    TARGET_PER_CELL,
+    TOXICITY_COLUMN,
 )
 from lib.constants import REPO_ROOT
 
 EXPERIMENT_DIR = (
     REPO_ROOT / "experiments" / "filter_posts_used_for_stimulus_dataset_2026_09_08"
 )
+JSON_INDENT = 2
+TOTAL_LABEL = "total"
+RUN_COMMAND = """export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py"""
 
 
 def write_local_parquet(sampled: pd.DataFrame, experiment_dir: Path) -> tuple[Path, bytes]:
@@ -74,16 +99,232 @@ def write_filtered_dataset(
     experiment_dir: Path | None = None,
     store: CampaignObjectStore | None = None,
 ) -> FilterRunResult:
-    """Write local parquet, upload to S3, and write RESULTS.md."""
-    raise NotImplementedError
+    """Write local parquet, upload to S3, and write RESULTS.md.
+
+    Parameters
+    ----------
+    sampled
+        Sampled 17-column stimulus table.
+    cleaned
+        Cleaned table before sampling.
+    summary
+        Drop counts from cleanup.
+    experiment_dir
+        Folder that receives ``dataset.parquet`` and ``RESULTS.md``.
+    store
+        Object store used only with ``put_new``.
+
+    Returns
+    -------
+    FilterRunResult
+        Local path, S3 URI, SHA-256, and count tables.
+
+    Raises
+    ------
+    FileExistsError
+        When the destination S3 key already exists.
+    """
+    resolved_dir = experiment_dir if experiment_dir is not None else EXPERIMENT_DIR
+    resolved_store = store if store is not None else _default_store()
+    local_path, body = write_local_parquet(sampled, resolved_dir)
+    digest = upload_dataset(body, resolved_store)
+    result = _filter_run_result(sampled, cleaned, summary, local_path, digest)
+    write_results_md(result, resolved_dir)
+    return result
 
 
 def print_run_summary(result: FilterRunResult) -> None:
     """Print row counts, URIs, SHA-256, and both crosstab tables."""
-    raise NotImplementedError
+    print(f"candidate_rows={result.candidate_rows}")
+    print(f"cleaned_rows={result.cleaned_rows}")
+    print(f"sampled_rows={result.sampled_rows}")
+    print(f"right_high_available={result.right_high_available}")
+    print(f"right_high_shortfall={result.right_high_shortfall}")
+    print(f"local_path={result.local_path}")
+    print(f"s3_uri={result.s3_uri}")
+    print(f"dataset_sha256={result.dataset_sha256}")
+    print("cleaned_crosstab=")
+    print(json.dumps(result.cleaned_crosstab, indent=JSON_INDENT))
+    print("sampled_crosstab=")
+    print(json.dumps(result.sampled_crosstab, indent=JSON_INDENT))
+
+
+def write_results_md(result: FilterRunResult, experiment_dir: Path) -> Path:
+    """Write RESULTS.md with cleanup counts, URIs, and both crosstab tables."""
+    path = experiment_dir / RESULTS_FILENAME
+    path.write_text(_results_markdown(result))
+    return path
+
+
+def _filter_run_result(
+    sampled: pd.DataFrame,
+    cleaned: pd.DataFrame,
+    summary: CleanupSummary,
+    local_path: Path,
+    digest: str,
+) -> FilterRunResult:
+    right_high_available = _right_high_count(cleaned)
+    return FilterRunResult(
+        candidate_rows=summary.candidate_rows,
+        cleaned_rows=summary.cleaned_rows,
+        sampled_rows=len(sampled),
+        right_high_available=right_high_available,
+        right_high_shortfall=max(0, TARGET_PER_CELL - right_high_available),
+        local_path=str(local_path.relative_to(REPO_ROOT)),
+        s3_uri=s3_uri(OUTPUT_S3_BUCKET, OUTPUT_S3_KEY),
+        dataset_sha256=digest,
+        cleanup_summary=summary,
+        cleaned_crosstab=stance_by_toxicity(cleaned),
+        sampled_crosstab=stance_by_toxicity(sampled),
+        sampled_integration_crosstab=stance_by_toxicity_by_integration(sampled),
+    )
+
+
+def _right_high_count(frame: pd.DataFrame) -> int:
+    mask = (frame[STANCE_COLUMN] == RIGHT_STANCE) & (
+        frame[TOXICITY_COLUMN] == HIGH_TOXICITY
+    )
+    return int(mask.sum())
+
+
+def _results_markdown(result: FilterRunResult) -> str:
+    return "\n".join(
+        [
+            *_results_preamble(result),
+            "## Cleaned political stance by LLM toxicity tier",
+            "",
+            _stance_table_markdown(result.cleaned_crosstab),
+            "",
+            "## Sampled political stance by LLM toxicity tier",
+            "",
+            _stance_table_markdown(result.sampled_crosstab),
+            "",
+            _right_high_sentence(result),
+            "",
+        ]
+    )
+
+
+def _results_preamble(result: FilterRunResult) -> list[str]:
+    return [
+        "# Filter posts used for stimulus dataset, results",
+        "",
+        "## Command",
+        "",
+        "```bash",
+        RUN_COMMAND,
+        "```",
+        "",
+        "## Candidate source",
+        "",
+        (
+            f"Object `{CANDIDATE_S3_URI}` SHA-256 `{CANDIDATE_SHA256}` "
+            f"has {result.candidate_rows} rows."
+        ),
+        "",
+        "## Cleanup",
+        "",
+        _cleanup_table_markdown(result.cleanup_summary),
+        "",
+        "## Filtered parquet",
+        "",
+        _parquet_table_markdown(result),
+        "",
+        f"Sampled row count is {result.sampled_rows}.",
+        "",
+    ]
+
+
+def _cleanup_table_markdown(summary: CleanupSummary) -> str:
+    return "\n".join(
+        [
+            "| Step | Rows dropped | Rows remaining |",
+            "| ---- | -----------: | -------------: |",
+            f"| Start | 0 | {summary.candidate_rows} |",
+            (
+                f"| Previously used record ids | {summary.dropped_previous_ids} | "
+                f"{summary.candidate_rows - summary.dropped_previous_ids} |"
+            ),
+            (
+                f"| Previously used original text | {summary.dropped_previous_text} | "
+                f"{_after_previous_text(summary)} |"
+            ),
+            (
+                f"| Duplicate record ids | {summary.dropped_duplicate_ids} | "
+                f"{_after_duplicate_ids(summary)} |"
+            ),
+            (
+                f"| Duplicate text | {summary.dropped_duplicate_text} | "
+                f"{summary.cleaned_rows} |"
+            ),
+        ]
+    )
+
+
+def _after_previous_text(summary: CleanupSummary) -> int:
+    return (
+        summary.candidate_rows
+        - summary.dropped_previous_ids
+        - summary.dropped_previous_text
+    )
+
+
+def _after_duplicate_ids(summary: CleanupSummary) -> int:
+    return _after_previous_text(summary) - summary.dropped_duplicate_ids
+
+
+def _parquet_table_markdown(result: FilterRunResult) -> str:
+    return "\n".join(
+        [
+            "| File | Path | SHA-256 |",
+            "| ---- | ---- | ------- |",
+            f"| Local parquet | `{result.local_path}` | `{result.dataset_sha256}` |",
+            f"| S3 parquet | `{result.s3_uri}` | `{result.dataset_sha256}` |",
+        ]
+    )
+
+
+def _stance_table_markdown(counts: dict[str, dict[str, int]]) -> str:
+    lines = [
+        "| political_stance | low | medium | high | total |",
+        "| ---------------- | --: | -----: | ---: | ----: |",
+    ]
+    grand = {tier: 0 for tier in CANDIDATE_TOXICITY_COLUMNS}
+    for stance in CANDIDATE_STANCE_ROWS:
+        cells = _tier_cells(counts.get(stance, {}))
+        _add_tier_counts(grand, cells)
+        lines.append(_labeled_tier_row(stance, cells))
+    lines.append(_labeled_tier_row(TOTAL_LABEL, _tier_cells(grand)))
+    return "\n".join(lines)
+
+
+def _tier_cells(counts: dict[str, int]) -> list[int]:
+    return [int(counts.get(tier, 0)) for tier in CANDIDATE_TOXICITY_COLUMNS]
+
+
+def _add_tier_counts(totals: dict[str, int], cells: list[int]) -> None:
+    for tier, value in zip(CANDIDATE_TOXICITY_COLUMNS, cells, strict=True):
+        totals[tier] += value
+
+
+def _labeled_tier_row(label: str, cells: list[int]) -> str:
+    total = sum(cells)
+    return f"| {label} | {cells[0]} | {cells[1]} | {cells[2]} | {total} |"
+
+
+def _right_high_sentence(result: FilterRunResult) -> str:
+    return (
+        "The cell for right stance and high toxicity kept every cleaned post "
+        f"because it had {result.right_high_available} posts, which is fewer than "
+        f"{TARGET_PER_CELL}."
+    )
 
 
 def _parquet_bytes(frame: pd.DataFrame) -> bytes:
     buffer = io.BytesIO()
     frame.to_parquet(buffer, index=False)
     return buffer.getvalue()
+
+
+def _default_store() -> CampaignObjectStore:
+    return CampaignObjectStore(OUTPUT_S3_BUCKET)

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
@@ -2,19 +2,43 @@
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 
 import pandas as pd
 
 from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
-from experiments.combine_data_into_stimulus_set_2026_09_08.crosstab import (
-    stance_by_toxicity,
-    stance_by_toxicity_by_integration,
-)
 from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources import (
     CleanupSummary,
+    DATASET_FILENAME,
     FilterRunResult,
 )
+from lib.constants import REPO_ROOT
+
+EXPERIMENT_DIR = (
+    REPO_ROOT / "experiments" / "filter_posts_used_for_stimulus_dataset_2026_09_08"
+)
+
+
+def write_local_parquet(sampled: pd.DataFrame, experiment_dir: Path) -> tuple[Path, bytes]:
+    """Write ``dataset.parquet`` under the experiment folder and return its bytes.
+
+    Parameters
+    ----------
+    sampled
+        Sorted sampled stimulus table.
+    experiment_dir
+        Folder that receives ``dataset.parquet``.
+
+    Returns
+    -------
+    tuple[Path, bytes]
+        Local path and parquet bytes.
+    """
+    body = _parquet_bytes(sampled)
+    path = experiment_dir / DATASET_FILENAME
+    path.write_bytes(body)
+    return path, body
 
 
 def write_filtered_dataset(
@@ -31,3 +55,9 @@ def write_filtered_dataset(
 def print_run_summary(result: FilterRunResult) -> None:
     """Print row counts, URIs, SHA-256, and both crosstab tables."""
     raise NotImplementedError
+
+
+def _parquet_bytes(frame: pd.DataFrame) -> bytes:
+    buffer = io.BytesIO()
+    frame.to_parquet(buffer, index=False)
+    return buffer.getvalue()

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
@@ -315,9 +315,9 @@ def _labeled_tier_row(label: str, cells: list[int]) -> str:
 
 def _right_high_sentence(result: FilterRunResult) -> str:
     return (
-        "The cell for right stance and high toxicity kept every cleaned post "
-        f"because it had {result.right_high_available} posts, which is fewer than "
-        f"{TARGET_PER_CELL}."
+        "Operators kept every cleaned post in the cell for right stance and "
+        f"high toxicity, because the cell had {result.right_high_available} posts. "
+        f"{result.right_high_available} is fewer than {TARGET_PER_CELL}."
     )
 
 

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
@@ -26,6 +26,7 @@ from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources impor
     DATASET_FILENAME,
     FilterRunResult,
     HIGH_TOXICITY,
+    MEDIUM_TOXICITY,
     OUTPUT_S3_BUCKET,
     OUTPUT_S3_KEY,
     RESULTS_FILENAME,
@@ -141,6 +142,7 @@ def print_run_summary(result: FilterRunResult) -> None:
     print(f"sampled_rows={result.sampled_rows}")
     print(f"right_high_available={result.right_high_available}")
     print(f"right_high_shortfall={result.right_high_shortfall}")
+    print(f"right_medium_upsampled={result.right_medium_upsampled}")
     print(f"local_path={result.local_path}")
     print(f"s3_uri={result.s3_uri}")
     print(f"dataset_sha256={result.dataset_sha256}")
@@ -165,12 +167,14 @@ def _filter_run_result(
     digest: str,
 ) -> FilterRunResult:
     right_high_available = _right_high_count(cleaned)
+    sampled_right_medium = _right_medium_count(sampled)
     return FilterRunResult(
         candidate_rows=summary.candidate_rows,
         cleaned_rows=summary.cleaned_rows,
         sampled_rows=len(sampled),
         right_high_available=right_high_available,
         right_high_shortfall=max(0, TARGET_PER_CELL - right_high_available),
+        right_medium_upsampled=max(0, sampled_right_medium - TARGET_PER_CELL),
         local_path=str(local_path.relative_to(REPO_ROOT)),
         s3_uri=s3_uri(OUTPUT_S3_BUCKET, OUTPUT_S3_KEY),
         dataset_sha256=digest,
@@ -201,6 +205,8 @@ def _results_markdown(result: FilterRunResult) -> str:
             _stance_table_markdown(result.sampled_crosstab),
             "",
             _right_high_sentence(result),
+            "",
+            _upsample_sentence(result),
             "",
         ]
     )
@@ -313,11 +319,27 @@ def _labeled_tier_row(label: str, cells: list[int]) -> str:
     return f"| {label} | {cells[0]} | {cells[1]} | {cells[2]} | {total} |"
 
 
+def _right_medium_count(frame: pd.DataFrame) -> int:
+    mask = (frame[STANCE_COLUMN] == RIGHT_STANCE) & (
+        frame[TOXICITY_COLUMN] == MEDIUM_TOXICITY
+    )
+    return int(mask.sum())
+
+
 def _right_high_sentence(result: FilterRunResult) -> str:
     return (
         "Operators kept every cleaned post in the cell for right stance and "
         f"high toxicity, because the cell had {result.right_high_available} posts. "
         f"{result.right_high_available} is fewer than {TARGET_PER_CELL}."
+    )
+
+
+def _upsample_sentence(result: FilterRunResult) -> str:
+    return (
+        "Operators sampled "
+        f"{result.right_medium_upsampled} extra posts from the cell for right "
+        "stance and medium toxicity so that left and right both have the same "
+        f"number of posts, and the sample has {TARGET_TOTAL} posts."
     )
 
 

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
@@ -1,0 +1,33 @@
+"""Write the sampled parquet locally, upload it to S3, and write RESULTS.md."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from experiments.combine_data_into_stimulus_set_2026_09_08.crosstab import (
+    stance_by_toxicity,
+    stance_by_toxicity_by_integration,
+)
+from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources import (
+    CleanupSummary,
+    FilterRunResult,
+)
+
+
+def write_filtered_dataset(
+    sampled: pd.DataFrame,
+    cleaned: pd.DataFrame,
+    summary: CleanupSummary,
+    experiment_dir: Path | None = None,
+    store: CampaignObjectStore | None = None,
+) -> FilterRunResult:
+    """Write local parquet, upload to S3, and write RESULTS.md."""
+    raise NotImplementedError
+
+
+def print_run_summary(result: FilterRunResult) -> None:
+    """Print row counts, URIs, SHA-256, and both crosstab tables."""
+    raise NotImplementedError

--- a/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
+++ b/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/upload_filtered_candidate_dataset.py
@@ -8,10 +8,12 @@ from pathlib import Path
 import pandas as pd
 
 from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from data_platform.utils.object_store import sha256_hex
 from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.sources import (
     CleanupSummary,
     DATASET_FILENAME,
     FilterRunResult,
+    OUTPUT_S3_KEY,
 )
 from lib.constants import REPO_ROOT
 
@@ -39,6 +41,30 @@ def write_local_parquet(sampled: pd.DataFrame, experiment_dir: Path) -> tuple[Pa
     path = experiment_dir / DATASET_FILENAME
     path.write_bytes(body)
     return path, body
+
+
+def upload_dataset(body: bytes, store: CampaignObjectStore) -> str:
+    """Upload parquet bytes with put_new and return the SHA-256.
+
+    Parameters
+    ----------
+    body
+        Parquet bytes already written locally.
+    store
+        Object store used only with ``put_new``.
+
+    Returns
+    -------
+    str
+        SHA-256 of the uploaded bytes.
+
+    Raises
+    ------
+    FileExistsError
+        When the destination S3 key already exists.
+    """
+    store.put_new(OUTPUT_S3_KEY, body)
+    return sha256_hex(body)
 
 
 def write_filtered_dataset(


### PR DESCRIPTION
# Balanced stimulus sample from the combined candidate parquet

## Summary

Loaded the pinned 55,573-row combined stimulus parquet, dropped previously used catalog posts, duplicate record ids, and duplicate text, then sampled toward 1,700 posts in each political stance by toxicity cell.

Five cells have 1,700 posts. The cell for right stance and high toxicity has only 1,062 cleaned posts, so the sample is 9,562 posts instead of 10,200. The filtered parquet is on S3.

## Purpose

Build the next 10,000-post stimulus catalog so that, with the existing 10,000-post catalog, the study can collect 5 labels on 20,000 posts.

The experiment is intended to identify:

- How many unique posts remain after dropping previously used posts, duplicate ids, and duplicate text
- Whether each political stance by toxicity cell can supply 1,700 posts
- A deterministic sample operators can reuse for the next study round

## Setup

- Dataset: `s3://mirrorview-experimental-artifacts/experiments/combine_data_into_stimulus_set_2026_09_08/dataset.parquet` (SHA-256 `f24ad1fd8c3709ffbbba9fb5dc953dcaee2f11ad8916ae21612b7f25cb5ca3f0`, 55,573 rows)
- Previous catalogs: `STUDY_PHASE_2_PART_1_STIMULI` and `STUDY_PHASE_2_PART_2_STIMULI`
- Conditions: one filter and sample path (not a model comparison)
- Target: 1,700 posts per cell of `left`/`right` by `low`/`medium`/`high`
- Seed: `42`
- Important fixed parameters: keep first duplicate after sorting by integration, source dataset id, and source record id

Plan: `docs/plans/2026-09-08_filter_posts_stimulus_c4f821/`

## Flow

Stages:

- `Load` downloads the pinned combined parquet and checks SHA-256 and row count.
- `Cleanup` drops previously used ids and original text, then duplicate record ids, then duplicate text.
- `Sample` takes up to 1,700 posts per stance by toxicity cell with seed 42.
- `Write` writes local parquet, uploads with `put_new`, and records counts in RESULTS.md.

```mermaid
flowchart TD
  A[Download pinned combined parquet] --> B[Drop previously used posts]
  B --> C[Drop duplicate ids]
  C --> D[Drop duplicate text]
  D --> E[Sample up to 1700 per stance toxicity cell]
  E --> F[Write local parquet]
  F --> G[Upload to S3]
  G --> H[Write RESULTS.md]
```

## Run

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"

PYTHONPATH=. uv run python experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/run.py
```

A second run raises `FileExistsError` if the S3 object already exists.

## Results

Cleanup left 54,472 unique posts. The sample has 9,562 posts.

| political_stance | low | medium | high | total |
| ---------------- | --: | -----: | ---: | ----: |
| left | 1700 | 1700 | 1700 | 5100 |
| right | 1700 | 1700 | 1062 | 4462 |
| total | 3400 | 3400 | 2762 | 9562 |

The cell for right stance and high toxicity kept every cleaned post because it had 1,062 posts, which is fewer than 1,700.

Outputs:

- `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/RESULTS.md`
- `s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet` (SHA-256 `840d2ceeb8fb7e32b47e9c1488f8bde28554d8bd43675caf26af3a9f750d26ed`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an end-to-end workflow for preparing filtered candidate datasets.
  - Validates source data against pinned columns, row counts, and checksums.
  - Removes previously used records and duplicate IDs or text.
  - Provides deterministic sampling across stance and toxicity categories, including shortfall reporting.
  - Exports filtered data to Parquet, uploads it to object storage, and generates run summaries with quality tables.

- **Chores**
  - Excludes local caches and generated dataset files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->