### PR TITLE
Plan: remaining labels per stimulus post

### DIFF
--- a/docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/plan.md
+++ b/docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/plan.md
@@ -1,0 +1,66 @@
+# Calculate remaining labels per stimulus post for the old catalog and the new sample
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Operators need 5 labels on every stimulus post for the next study round. The old catalog already has some labels from study phase 2 part 2. The new sample from pull request 267 has no labels yet. Operators write one table of remaining labels per post, and they drop posts that already have 5 or more labels. They upload that table to S3 and record totals in `RESULTS.md`.
+
+## Happy flow
+
+An operator runs one command from the repo root. The command loads the old catalog, the old results, and the new sample parquet. It computes remaining labels and writes a local CSV. It then uploads that CSV to S3 and writes `RESULTS.md`.
+
+```mermaid
+flowchart TD
+    A[Load old catalog and results] --> C[Count remaining old labels]
+    B[Download new sample parquet] --> D[Give each new post 5 remaining labels]
+    C --> E[Concatenate old and new rows]
+    D --> E
+    E --> F[Drop remaining count of 0 or less]
+    F --> G[Write local CSV]
+    G --> H[Upload CSV to S3]
+    H --> I[Write RESULTS.md]
+```
+
+## Approach
+
+Treat the work as a one-off experiment under `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/`. Load the old catalog and results through the shared data loader. Download the new sample from the filter experiment's parquet, and check that file's SHA-256 and row count. Put the number of required labels per post in `constants.py`. Do not add pytest. Do not change the old catalog, the results file, the new sample parquet, or product scripts.
+
+## Decisions
+
+- Create the experiment at `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/`. Put the number of required labels per post in `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/constants.py` and set it to 5.
+- Old catalog is `shared/data/raw/study_phase_2_part_2/stimuli/flips.csv`, loaded as `STUDY_PHASE_2_PART_2_STIMULI`. The post id column is `post_primary_key`. The file has 10,000 unique ids.
+- Old results are `shared/data/raw/study_phase_2_part_2/results/full.csv`, loaded as `STUDY_PHASE_2_PART_2_RESULTS_FULL`. Count how many times each catalog id appears in the `post_id` column. Empty `post_id` cells do not match. Do not filter by trial type, because a trial-type filter does not change the remaining counts for catalog ids.
+- Remaining labels for an old post equal 5 minus that appearance count. Posts whose remaining count is 0 or less are dropped. On the current files, 8,889 old posts remain, and they need 27,528 labels. 1,111 old posts already have 5 or more labels and are dropped.
+- New sample is `s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet`. The SHA-256 is `9788331f898aa27352dcdf32a962b5722aecc1da61a4638b7bbd77a404415ab9`. Expected row count is 10,200. The post id column is `record_id`. Every new post needs 5 labels, so the new batch needs 51,000 labels.
+- Do not include study phase 2 part 1. Do not look up ids from the new sample in the old results file.
+- If the same id appears in both batches, fail the run. The filter run dropped 0 previously used record ids, so no overlap is expected.
+- Output columns are `id`, `number_of_times_to_label`, and `batch`. `batch` is `old` or `new`. Sort by `batch` with `old` first, then by `id`, so the CSV is stable.
+- Upload to `s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/required_label_count_per_stimulus_post.csv`. A second run must fail if the S3 key already exists.
+- `run.py` is the caller. Load the old files through `shared/data/dataloader.py`. Reuse the download, cache, and hash check in `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/load_raw_candidate_dataset.py` for the new parquet, with this experiment's own SHA-256 and row count.
+- Confirm the counts with the live command in Step 2. Do not add files under `tests/`. Do not add an experiment README in this work.
+
+## Steps
+
+### Step 1: Add the load, count, and upload command
+
+Add the experiment modules and a `run.py` caller. Load both batches, compute remaining labels, write the local CSV, and upload it.
+
+### Step 2: Run the command and write RESULTS.md
+
+Run the command with AWS credentials. Confirm the local file and the S3 object, then commit `RESULTS.md` with the total remaining labels and the same total split by old and new.
+
+## What "done" looks like
+
+1. `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/` has `constants.py`, a runnable `run.py`, and the load, count, and write modules.
+2. `constants.py` sets required labels per post to 5.
+3. The CSV exists locally under that folder and at `s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/required_label_count_per_stimulus_post.csv`.
+4. The CSV has three columns, `id`, `number_of_times_to_label`, and `batch`, and every `number_of_times_to_label` value is greater than 0.
+5. `RESULTS.md` records total remaining labels, remaining labels for the old batch, and remaining labels for the new batch.
+6. On the current files, remaining labels total 78,528 overall, 27,528 old, and 51,000 new. The table has 19,089 rows, 8,889 old and 10,200 new.
+7. The old catalog, the old results file, the new sample parquet, and product scripts are unchanged.
+8. No pytest file was added or run.

--- a/docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/plan.md
+++ b/docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/plan.md
@@ -8,15 +8,15 @@
 
 ## Overview
 
-Operators need 5 labels on every stimulus post for the next study round. The old catalog already has some labels from study phase 2 part 2. The new sample from pull request 267 has no labels yet. Operators write one table of remaining labels per post, and they drop posts that already have 5 or more labels. They upload that table to S3 and record totals in `RESULTS.md`.
+Operators need 5 labels on every stimulus post for the next study round. The old catalog already has some labels from study phase 2 part 2. A label counts once per unique rater, and the rater is the Prolific account. The new sample from pull request 267 has no labels yet. Operators write one table of remaining labels per post, and they drop posts that already have 5 or more unique raters. They upload that table to S3 and record totals in `RESULTS.md`.
 
 ## Happy flow
 
-An operator runs one command from the repo root. The command loads the old catalog, the old results, and the new sample parquet. It computes remaining labels and writes a local CSV. It then uploads that CSV to S3 and writes `RESULTS.md`.
+An operator runs one command from the repo root. The command loads the old catalog, the old results, and the new sample parquet. It counts unique raters on each old post and computes remaining labels. It writes a local CSV. It then uploads that CSV to S3 and writes `RESULTS.md`.
 
 ```mermaid
 flowchart TD
-    A[Load old catalog and results] --> C[Count remaining old labels]
+    A[Load old catalog and results] --> C[Count unique raters per old post]
     B[Download new sample parquet] --> D[Give each new post 5 remaining labels]
     C --> E[Concatenate old and new rows]
     D --> E
@@ -28,39 +28,39 @@ flowchart TD
 
 ## Approach
 
-Treat the work as a one-off experiment under `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/`. Load the old catalog and results through the shared data loader. Download the new sample from the filter experiment's parquet, and check that file's SHA-256 and row count. Put the number of required labels per post in `constants.py`. Do not add pytest. Do not change the old catalog, the results file, the new sample parquet, or product scripts.
+Treat the work as a one-off experiment under `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/`. Load the old catalog and results through the shared data loader. Download the new sample from the filter experiment's parquet, and check that file's SHA-256 and row count. Put the number of required labels per post in `constants.py`. Write a `README.md` in the experiment folder. Do not add pytest. Do not change the old catalog, the results file, the new sample parquet, or product scripts.
 
 ## Decisions
 
 - Create the experiment at `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/`. Put the number of required labels per post in `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/constants.py` and set it to 5.
 - Old catalog is `shared/data/raw/study_phase_2_part_2/stimuli/flips.csv`, loaded as `STUDY_PHASE_2_PART_2_STIMULI`. The post id column is `post_primary_key`. The file has 10,000 unique ids.
-- Old results are `shared/data/raw/study_phase_2_part_2/results/full.csv`, loaded as `STUDY_PHASE_2_PART_2_RESULTS_FULL`. Count how many times each catalog id appears in the `post_id` column. Empty `post_id` cells do not match. Do not filter by trial type, because a trial-type filter does not change the remaining counts for catalog ids.
-- Remaining labels for an old post equal 5 minus that appearance count. Posts whose remaining count is 0 or less are dropped. On the current files, 8,889 old posts remain, and they need 27,528 labels. 1,111 old posts already have 5 or more labels and are dropped.
+- Old results are `shared/data/raw/study_phase_2_part_2/results/full.csv`, loaded as `STUDY_PHASE_2_PART_2_RESULTS_FULL`. The rater is `prolific_id`. For each catalog id, count unique `prolific_id` values on rows whose `post_id` equals that catalog id. Empty `post_id` or empty `prolific_id` cells do not count. Two study sessions by the same Prolific account count as one rater.
+- Remaining labels for an old post equal 5 minus that unique rater count. Posts whose remaining count is 0 or less are dropped. On the current files, 8,899 old posts remain, and they need 27,557 labels. 1,101 old posts already have 5 or more unique raters and are dropped.
 - New sample is `s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet`. The SHA-256 is `9788331f898aa27352dcdf32a962b5722aecc1da61a4638b7bbd77a404415ab9`. Expected row count is 10,200. The post id column is `record_id`. Every new post needs 5 labels, so the new batch needs 51,000 labels.
 - Do not include study phase 2 part 1. Do not look up ids from the new sample in the old results file.
 - If the same id appears in both batches, fail the run. The filter run dropped 0 previously used record ids, so no overlap is expected.
 - Output columns are `id`, `number_of_times_to_label`, and `batch`. `batch` is `old` or `new`. Sort by `batch` with `old` first, then by `id`, so the CSV is stable.
 - Upload to `s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/required_label_count_per_stimulus_post.csv`. A second run must fail if the S3 key already exists.
 - `run.py` is the caller. Load the old files through `shared/data/dataloader.py`. Reuse the download, cache, and hash check in `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/load_raw_candidate_dataset.py` for the new parquet, with this experiment's own SHA-256 and row count.
-- Confirm the counts with the live command in Step 2. Do not add files under `tests/`. Do not add an experiment README in this work.
+- Write `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/README.md` in Step 1. Confirm the counts with the live command in Step 2. Do not add files under `tests/`.
 
 ## Steps
 
 ### Step 1: Add the load, count, and upload command
 
-Add the experiment modules and a `run.py` caller. Load both batches, compute remaining labels, write the local CSV, and upload it.
+Add the experiment README, modules, and a `run.py` caller. Load both batches, count unique raters on old posts, write the local CSV, and upload it. See [steps/step1.md](steps/step1.md).
 
 ### Step 2: Run the command and write RESULTS.md
 
-Run the command with AWS credentials. Confirm the local file and the S3 object, then commit `RESULTS.md` with the total remaining labels and the same total split by old and new.
+Run the command with AWS credentials. Confirm the local file and the S3 object, then commit `RESULTS.md` with the total remaining labels and the same total split by old and new. See [steps/step2.md](steps/step2.md).
 
 ## What "done" looks like
 
-1. `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/` has `constants.py`, a runnable `run.py`, and the load, count, and write modules.
+1. `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/` has `README.md`, `constants.py`, a runnable `run.py`, and the load, count, and write modules.
 2. `constants.py` sets required labels per post to 5.
 3. The CSV exists locally under that folder and at `s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/required_label_count_per_stimulus_post.csv`.
 4. The CSV has three columns, `id`, `number_of_times_to_label`, and `batch`, and every `number_of_times_to_label` value is greater than 0.
 5. `RESULTS.md` records total remaining labels, remaining labels for the old batch, and remaining labels for the new batch.
-6. On the current files, remaining labels total 78,528 overall, 27,528 old, and 51,000 new. The table has 19,089 rows, 8,889 old and 10,200 new.
+6. On the current files, remaining labels total 78,557 overall, 27,557 old, and 51,000 new. The table has 19,099 rows, 8,899 old and 10,200 new.
 7. The old catalog, the old results file, the new sample parquet, and product scripts are unchanged.
 8. No pytest file was added or run.

--- a/docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/steps/step1.md
+++ b/docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/steps/step1.md
@@ -1,0 +1,260 @@
+# Step 1: Add the load, count, and upload command
+
+## Scope
+
+- **Caller:** `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/run.py` `main`
+- **Task:** Load the old catalog and old results, download the pinned 10,200-row new sample parquet, count unique `prolific_id` raters per old post, give every new post 5 remaining labels, drop remaining counts of 0 or less, write local `required_label_count_per_stimulus_post.csv`, upload that file to S3, print totals, write `RESULTS.md`, and add `README.md`.
+- **Out of scope:** pytest, study phase 2 part 1, generating mirrors, changing product scripts, overwriting the new sample parquet, looking up new-sample ids in the old results file.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/plan.md` | Confirmed decisions, unique rater rule, expected totals |
+| `/workspace/shared/data/registry.py` | `STUDY_PHASE_2_PART_2_STIMULI`, `STUDY_PHASE_2_PART_2_RESULTS_FULL` |
+| `/workspace/shared/data/dataloader.py` | `load_dataset` |
+| `/workspace/shared/data/raw/study_phase_2_part_2/stimuli/flips.csv` | Old catalog. Id column `post_primary_key`. 10,000 unique ids |
+| `/workspace/shared/data/raw/study_phase_2_part_2/results/full.csv` | Old results. Id column `post_id`. Rater column `prolific_id` |
+| `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/RESULTS.md` | Pinned new sample SHA-256 `9788331f898aa27352dcdf32a962b5722aecc1da61a4638b7bbd77a404415ab9`, 10,200 rows |
+| `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/load_raw_candidate_dataset.py` | Download, hash check, local cache, `CampaignObjectStore.get` |
+| `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/sources.py` | `CandidateSource`, combined column names |
+| `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/write.py` | Local bytes, `put_new`, `RESULTS.md` shape |
+| `/workspace/data_platform/generate_features/s3_feature_campaign.py` | `CampaignObjectStore`, `parse_s3_uri`, `put_new` |
+| `/workspace/data_platform/utils/object_store.py` | `sha256_hex` |
+| `/workspace/lib/constants.py` | `REPO_ROOT` |
+| `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/README.md` | Run-command README shape |
+| `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md` | Agent read-only banner and required-file list |
+| `/workspace/.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md` | Experiment code does not get unit tests |
+
+## Files allowed to change
+
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/README.md` (new)
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/constants.py` (new)
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/load.py` (new)
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/calculate.py` (new)
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/write.py` (new)
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/run.py` (new)
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/.gitignore` (new)
+- `/workspace/.gitignore` (ignore local cache under this experiment folder only)
+
+## Files forbidden to change
+
+- `/workspace/shared/data/raw/study_phase_2_part_2/**`
+- `/workspace/shared/data/registry.py`
+- `/workspace/shared/data/dataloader.py`
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/**`
+- `/workspace/experiments/combine_data_into_stimulus_set_2026_09_08/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/tests/**`
+- The new sample S3 object
+- `/workspace/CHANGELOG.md` until Step 2 has a live S3 object and `RESULTS.md`
+
+## README contract
+
+Write `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/README.md` first, then implement the modules to match it.
+
+The README must:
+
+1. Start with the same agent read-only banner used in `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md`.
+2. Say the study needs 5 labels on every stimulus post, and that this value lives in `constants.py`.
+3. Describe the old batch: unique ids from `shared/data/raw/study_phase_2_part_2/stimuli/flips.csv`, remaining labels equal 5 minus the number of unique `prolific_id` raters for that id in `shared/data/raw/study_phase_2_part_2/results/full.csv`.
+4. Describe the new batch: every post in the 10,200-row parquet from pull request 267 needs 5 labels.
+5. Name the output columns `id`, `number_of_times_to_label`, and `batch`, and say rows with remaining count of 0 or less are dropped.
+6. Name the S3 bucket `mirrorview-experimental-artifacts` and the prefix `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/`.
+7. Name the output file `required_label_count_per_stimulus_post.csv`.
+8. List these required files: `constants.py`, `load.py`, `calculate.py`, `write.py`, `run.py`.
+9. Include the run command from the Main caller section below.
+
+After this README is committed, later steps must not edit it.
+
+## Pinned new sample
+
+| Field | Value |
+|-------|-------|
+| Object | `s3://mirrorview-experimental-artifacts/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/dataset.parquet` |
+| SHA-256 | `9788331f898aa27352dcdf32a962b5722aecc1da61a4638b7bbd77a404415ab9` |
+| Rows | 10200 |
+| Id column | `record_id` |
+
+A hash mismatch or a wrong row count raises `ValueError`. A missing source object raises `FileNotFoundError`. Duplicate `record_id` values raise `ValueError`.
+
+## Old catalog and results contract
+
+Load the old catalog with `load_dataset("STUDY_PHASE_2_PART_2_STIMULI")`. The id column is `post_primary_key`. Strip values. Drop empty cells and the literal `"nan"`. There must be 10,000 unique ids. Duplicate catalog ids raise `ValueError`. A missing `post_primary_key` column raises `ValueError`.
+
+Load the old results with `load_dataset("STUDY_PHASE_2_PART_2_RESULTS_FULL")`. Required columns are `post_id` and `prolific_id`. Missing columns raise `ValueError`.
+
+## Unique rater contract
+
+A rater is `prolific_id`, not `participant_id`. Two study sessions by the same Prolific account count as one rater.
+
+Keep results rows whose `post_id` and `prolific_id` are both non-empty after strip, and whose stripped values are not `"nan"`. For each `post_id`, count unique `prolific_id` values. Catalog ids that never appear get count 0.
+
+Remaining labels for an old post equal `REQUIRED_LABELS_PER_POST` minus that unique rater count. Drop rows whose remaining count is 0 or less.
+
+On the current files, unique rater counts on catalog ids are:
+
+| Unique raters | Posts |
+| ------------: | ----: |
+| 0 | 1209 |
+| 1 | 2414 |
+| 2 | 2392 |
+| 3 | 1796 |
+| 4 | 1088 |
+| 5 or more | 1101 |
+
+Expected old remaining posts: 8899. Expected old remaining labels: 27557. Expected dropped old posts: 1101.
+
+Do not filter by trial type.
+
+## New batch contract
+
+Every new `record_id` gets remaining labels equal to `REQUIRED_LABELS_PER_POST`, which is 5. Expected new posts: 10200. Expected new labels: 51000.
+
+Do not look up new ids in the old results file.
+
+## Combine contract
+
+Output columns, in this order:
+
+1. `id`
+2. `number_of_times_to_label`
+3. `batch`
+
+`batch` is `old` or `new`. Old ids come from catalog `post_primary_key`. New ids come from parquet `record_id`.
+
+If any id appears in both batches, raise `ValueError`.
+
+Keep only rows where `number_of_times_to_label` is greater than 0.
+
+Sort by `batch` with `old` first, then by `id`, with `kind="mergesort"`. Reset the index.
+
+Expected combined rows: 19099. Expected combined labels: 78557. Expected old rows: 8899. Expected new rows: 10200.
+
+## Outputs
+
+| Output | Path |
+|--------|------|
+| Local CSV | `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/required_label_count_per_stimulus_post.csv` |
+| S3 CSV | `s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/required_label_count_per_stimulus_post.csv` |
+| S3 key | `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/required_label_count_per_stimulus_post.csv` |
+| Report | `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/RESULTS.md` |
+| Cache | `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/cache/` (gitignored) |
+
+Write the CSV with `index=False`. Upload with `CampaignObjectStore.put_new`. The write fails if the S3 key already exists.
+
+Gitignore `cache/` under this experiment folder in both `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/.gitignore` and `/workspace/.gitignore`. Root `.gitignore` already ignores `*.csv`, so the local CSV is not committed.
+
+## RESULTS.md
+
+`RESULTS.md` must include:
+
+- The run command
+- New sample URI, SHA-256, and row count
+- Old catalog path and unique id count
+- Unique rater rule: count unique `prolific_id` per `post_id`
+- Local path, S3 URI, and SHA-256 of the CSV
+- Total remaining labels
+- Remaining labels for the old batch
+- Remaining labels for the new batch
+- Row counts overall, old, and new
+
+Stdout prints `old_posts=8899`, `old_labels=27557`, `new_posts=10200`, `new_labels=51000`, `total_posts=19099`, `total_labels=78557`, the S3 URI, and the CSV SHA-256.
+
+## Main caller
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/run.py
+```
+
+Expected stdout includes `old_posts=8899`, `old_labels=27557`, `new_posts=10200`, `new_labels=51000`, `total_posts=19099`, `total_labels=78557`, `s3_uri=s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/required_label_count_per_stimulus_post.csv`, and `csv_sha256=`.
+
+## Work
+
+Follow `/implement-from-spec`. Full auto. Do not add pytest. Phase 4 is the given/when/then live checks below, written in the `run.py` module docstring.
+
+### Modules
+
+Keep functions under 20 lines. Use a frozen dataclass for the pinned new sample. Do not pass unstructured dictionaries for source identity.
+
+`constants.py` holds required labels per post (5), registry names, column names, batch values `old` and `new`, the pinned new-sample URI, SHA-256, and row count, and the output S3 key.
+
+`load.py` loads the old catalog and old results through `load_dataset`, and downloads the new sample through `load_raw_candidate_dataset` with this experiment's pin and `cache_dir` under this experiment folder.
+
+`calculate.py` counts unique `prolific_id` values per old `post_id`, builds remaining counts for both batches, fails on overlapping ids, drops remaining counts of 0 or less, and sorts the table.
+
+`write.py` writes local CSV bytes, uploads with `put_new`, and writes `RESULTS.md`.
+
+`run.py` is the caller: load old, load new, calculate, write, print.
+
+Reuse `CampaignObjectStore`, `parse_s3_uri`, `sha256_hex`, `load_dataset`, and `load_raw_candidate_dataset`. Do not copy a new S3 client.
+
+### Live given / when / then (Phase 4)
+
+```text
+given AWS credentials from LAB_AWS_ACCESS_KEY_ID and LAB_AWS_ACCESS_KEY_SECRET
+and the pinned new sample parquet exists at SHA-256 9788331f898aa27352dcdf32a962b5722aecc1da61a4638b7bbd77a404415ab9
+when PYTHONPATH=. uv run python experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/run.py
+then old_posts=8899
+and old_labels=27557
+and new_posts=10200
+and new_labels=51000
+and total_posts=19099
+and total_labels=78557
+and local required_label_count_per_stimulus_post.csv exists
+and S3 object experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/required_label_count_per_stimulus_post.csv exists
+and its SHA-256 matches the local file
+and every number_of_times_to_label value is greater than 0
+and RESULTS.md contains total remaining labels 78557
+and RESULTS.md contains old remaining labels 27557
+and RESULTS.md contains new remaining labels 51000
+and stdout prints those counts
+
+given the S3 CSV key already exists
+when the command is run again
+then the process raises FileExistsError and does not change the new sample parquet
+```
+
+## Must pass
+
+- Imports from `run.py` resolve.
+- `README.md` exists and names unique `prolific_id` raters, required labels per post of 5, and the S3 prefix.
+- New sample SHA-256 and row count are checked before counting.
+- Old remaining labels use unique `prolific_id` per `post_id`, not row counts and not `participant_id`.
+- Output columns are `id`, `number_of_times_to_label`, and `batch` in that order.
+- Product scripts, the old catalog, the old results file, and the new sample parquet are unchanged.
+
+## Must fail
+
+- Hash mismatch on the new sample parquet.
+- Wrong new sample row count.
+- Missing `post_primary_key`, `post_id`, `prolific_id`, or `record_id`.
+- Duplicate catalog ids or duplicate new `record_id` values.
+- The same id in both batches.
+- Second upload to the same S3 key.
+
+## Implement-from-spec notes
+
+Phase 1 names `run.py` `main` as the caller.
+
+Phase 2 scaffolds the five Python modules with stub bodies and a thin `main` that calls load, calculate, write, print. Write `README.md` in this phase so the file list is locked.
+
+Phase 3 locks the pinned new-sample dataclass and the public function signatures. Continue without a pause because this run is full auto.
+
+Phase 4 writes the given/when/then block in the `run.py` docstring. Do not add files under `tests/`.
+
+Phase 5 implements in this order, one commit per unit of work:
+
+1. `README.md` and `constants.py`
+2. load old catalog and old results
+3. unique `prolific_id` counts and old remaining labels
+4. download and hash/row checks for the new sample
+5. new remaining labels, overlap check, drop remaining counts of 0 or less, sort
+6. local CSV write
+7. S3 `put_new`
+8. `RESULTS.md` writer and `main`
+
+Phase 6 is complete when the modules exist, imports resolve, `README.md` is present, and Step 2 can run the live command.

--- a/docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/steps/step2.md
+++ b/docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/steps/step2.md
@@ -1,0 +1,92 @@
+# Step 2: Run the command and write RESULTS.md
+
+## Scope
+
+- **Caller:** the same `run.py` `main` from Step 1.
+- **Task:** Export AWS credentials, run the command, confirm the local CSV and the S3 object, copy logs to `/opt/cursor/artifacts/`, and commit `RESULTS.md` with remaining label totals overall and split by old and new.
+- **Out of scope:** pytest, editing the experiment README, rewriting Step 1 modules except docstring fixes required by `write-docstring`, changing the old catalog, changing the old results file, changing the new sample parquet.
+
+## Files to inspect (read-only)
+
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/run.py`
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/README.md`
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/constants.py`
+- `/workspace/docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/plan.md`
+- `/workspace/docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/steps/step1.md`
+
+## Files allowed to change
+
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/RESULTS.md` (written by the live command, then committed)
+- `/workspace/CHANGELOG.md` after the live S3 object exists
+
+## Files forbidden to change
+
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/README.md`
+- `/workspace/shared/data/raw/study_phase_2_part_2/**`
+- `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/**`
+- `/workspace/data_platform/curate/**`
+- `/workspace/tests/**`
+- The new sample S3 object
+- `/workspace/docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/**`
+
+## Live commands
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/run.py
+```
+
+Expected stdout includes `old_posts=8899`, `old_labels=27557`, `new_posts=10200`, `new_labels=51000`, `total_posts=19099`, `total_labels=78557`, a local path under `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/required_label_count_per_stimulus_post.csv`, `s3_uri=s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/required_label_count_per_stimulus_post.csv`, and `csv_sha256=`.
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import hashlib
+from pathlib import Path
+import pandas as pd
+from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+
+local = Path(
+    "experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/"
+    "required_label_count_per_stimulus_post.csv"
+)
+store = CampaignObjectStore("mirrorview-experimental-artifacts")
+key = (
+    "experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/"
+    "required_label_count_per_stimulus_post.csv"
+)
+stored = store.get(key)
+assert stored is not None
+frame = pd.read_csv(local)
+assert list(frame.columns) == ["id", "number_of_times_to_label", "batch"]
+assert (frame["number_of_times_to_label"] > 0).all()
+assert len(frame) == 19099
+assert int((frame["batch"] == "old").sum()) == 8899
+assert int((frame["batch"] == "new").sum()) == 10200
+assert int(frame["number_of_times_to_label"].sum()) == 78557
+assert int(frame.loc[frame["batch"] == "old", "number_of_times_to_label"].sum()) == 27557
+assert int(frame.loc[frame["batch"] == "new", "number_of_times_to_label"].sum()) == 51000
+assert hashlib.sha256(local.read_bytes()).hexdigest() == hashlib.sha256(stored.body).hexdigest()
+print("required label counts ok", len(frame), int(frame["number_of_times_to_label"].sum()))
+PY
+```
+
+Expected: `required label counts ok 19099 78557`.
+
+Copy the command stdout to `/opt/cursor/artifacts/required_label_count_run.log`.
+
+## Must pass
+
+- Live command exits 0 on the first run.
+- `old_posts=8899` and `old_labels=27557`.
+- `new_posts=10200` and `new_labels=51000`.
+- `total_posts=19099` and `total_labels=78557`.
+- Local SHA-256 equals S3 object SHA-256.
+- `RESULTS.md` is committed and records those three remaining label totals.
+- New sample object SHA-256 is still `9788331f898aa27352dcdf32a962b5722aecc1da61a4638b7bbd77a404415ab9`.
+- `README.md` is unchanged from Step 1.
+
+## Must fail
+
+- A second run of the same command, because `put_new` must raise `FileExistsError`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implementation plan for issue 268, revised after review.

The plan is at `docs/plans/2026-09-08_required_label_count_per_post_5fd9ba/`. Step files are `steps/step1.md` and `steps/step2.md`.

## What the experiment does

Operators need 5 labels on every stimulus post. Remaining labels for an old catalog post equal 5 minus the number of unique `prolific_id` raters for that post in the phase 2 part 2 results file. Two study sessions by the same Prolific account count as one rater. The new sample is the 10,200-post parquet from pull request 267, and every new post needs 5 labels. Posts whose remaining count is 0 or less are dropped.

On the current files, remaining labels total 78,557 overall, 27,557 old, and 51,000 new. The table has 19,099 rows.

## Review decisions captured here

1. Unique raters, using `prolific_id`.
2. Output columns `id`, `number_of_times_to_label`, and `batch`.
3. Study phase 2 part 1 is out of scope.
4. New sample is the merged 10,200-row parquet, SHA-256 `9788331f898aa27352dcdf32a962b5722aecc1da61a4638b7bbd77a404415ab9`.
5. No pytest. Add `README.md` in the experiment folder.

## Implementation

Step 1 adds the README, modules, and command. Step 2 runs the command, uploads the CSV, and commits `RESULTS.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-130f624c-6cfa-4ff0-8b12-df0a77e0f66b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-130f624c-6cfa-4ff0-8b12-df0a77e0f66b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

