### PR TITLE
Prevent expensive re-runs of the unused-post catalog experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-09-09
 
 1. Operators now have a 10,000 post study catalog sampled from the 10,200 post set plus 2,000 unused medium posts and 300 leftover right-medium posts relabeled as high using Perspective scores. Remaining labels for that catalog plus the old catalog total 77,557. [PR #273](https://github.com/METResearchGroup/mirrorView-task/pull/273)
+2. Operators can re-run the unused-post catalog experiments without calling Perspective or Bedrock when the output S3 keys already exist, and a smoke flip run cannot reuse `--run-id smoke` except with `--max-posts 10`. [PR #277](https://github.com/METResearchGroup/mirrorView-task/pull/277)
 
 ## 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-09
 
-1. Operators now have a 10,000 post study catalog from unused medium posts plus 300 leftover right-medium posts reclassified as high by Perspective, and remaining labels for that catalog plus the old catalog total 77,557. [PR #273](https://github.com/METResearchGroup/mirrorView-task/pull/273)
+1. Operators now have a 10,000 post study catalog sampled from the 10,200 post set plus 2,000 unused medium posts and 300 leftover right-medium posts relabeled as high using Perspective scores. Remaining labels for that catalog plus the old catalog total 77,557. [PR #273](https://github.com/METResearchGroup/mirrorView-task/pull/273)
 
 ## 2026-09-08
 

--- a/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/RESULTS.md
+++ b/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/RESULTS.md
@@ -15,7 +15,7 @@ Object `s3://mirrorview-experimental-artifacts/experiments/curate_study_2_phase_
 
 ## Old catalog
 
-Catalog `shared/data/raw/study_phase_2_part_2/stimuli/flips.csv` has 10000 unique ids. Remaining labels equal 5 minus the number of unique `prolific_id` raters per `post_id`.
+Catalog `shared/data/raw/study_phase_2_part_2/stimuli/flips.csv` has 10,000 unique ids. Remaining labels equal 5 minus the number of unique `prolific_id` raters per `post_id`. Posts with 0 remaining labels are dropped, so the old batch has 8,899 posts.
 
 ## Remaining labels
 

--- a/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/load.py
+++ b/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/load.py
@@ -98,6 +98,10 @@ def load_new_catalog(
     body = _bytes_matching_pinned_hash(source, store, cache_dir)
     frame = pd.read_csv(io.BytesIO(body))
     _require_column(frame, NEW_ID_COLUMN)
+    if len(frame) != source.expected_row_count:
+        raise ValueError(
+            f"row_count={len(frame)} expected={source.expected_row_count}"
+        )
     ids = _stripped_nonempty(frame[NEW_ID_COLUMN])
     _require_unique_id_count(ids, source.expected_row_count, NEW_ID_COLUMN)
     return frame

--- a/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/write.py
+++ b/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/write.py
@@ -179,7 +179,8 @@ def _old_catalog_sentence(result: LabelCountRunResult) -> str:
     return (
         f"Catalog `{OLD_CATALOG_DISPLAY_PATH}` has {result.old_catalog_ids} unique ids. "
         f"Remaining labels equal {REQUIRED_LABELS_PER_POST} minus the number of unique "
-        "`prolific_id` raters per `post_id`."
+        "`prolific_id` raters per `post_id`. Posts with 0 remaining labels are dropped, "
+        f"so the old batch has {result.old_posts} posts."
     )
 
 

--- a/experiments/curate_study_2_phase_3_stimuli/RESULTS.md
+++ b/experiments/curate_study_2_phase_3_stimuli/RESULTS.md
@@ -17,4 +17,4 @@ PYTHONPATH=. uv run python experiments/curate_study_2_phase_3_stimuli/run.py
 | right | 1696 | 3334 | 1354 | 6384 |
 | total | 3396 | 6029 | 3052 | 12477 |
 
-Catalog `experiments/curate_study_2_phase_3_stimuli/flips.csv` SHA-256 `c90fdcf86e89e393f0de4cc34e1dc4e4bb2bd876405926ad654ff679f3ab4139` has 10000 rows. S3 object `s3://mirrorview-experimental-artifacts/experiments/curate_study_2_phase_3_stimuli/flips.csv`.
+The catalog file `experiments/curate_study_2_phase_3_stimuli/flips.csv` has 10,000 rows, and its SHA-256 is `c90fdcf86e89e393f0de4cc34e1dc4e4bb2bd876405926ad654ff679f3ab4139`. The same bytes are on S3 at `s3://mirrorview-experimental-artifacts/experiments/curate_study_2_phase_3_stimuli/flips.csv`. The catalog has 5,000 left posts and 5,000 right posts, and it has 2,500 low, 5,000 medium, and 2,500 high posts.

--- a/experiments/curate_study_2_phase_3_stimuli/join_flips.py
+++ b/experiments/curate_study_2_phase_3_stimuli/join_flips.py
@@ -51,8 +51,9 @@ def join_posts_to_flips(
     Raises
     ------
     ValueError
-        When the same ``record_id`` appears in both joined pieces, original
-        text does not match post text, or ``mirrored_text`` is empty.
+        When a ``record_id`` is duplicated, the same ``record_id`` appears in
+        both joined pieces, original text does not match post text, or
+        ``mirrored_text`` is empty.
     """
     sample_joined = _inner_join(sample_posts, sample_flips)
     unified_joined = _inner_join(unified_posts, unified_flips)
@@ -81,10 +82,18 @@ def cells_meet_targets(available: dict[str, dict[str, int]]) -> bool:
 
 def _inner_join(posts: pd.DataFrame, flips: pd.DataFrame) -> pd.DataFrame:
     flip_rows = flips.loc[:, list(FLIP_KEEP_COLUMNS)]
+    _require_unique_record_ids(posts)
+    _require_unique_record_ids(flip_rows)
     joined = posts.merge(flip_rows, on=RECORD_ID_COLUMN, how="inner")
     _require_text_match(joined)
     _require_mirrored_text(joined)
     return joined
+
+
+def _require_unique_record_ids(frame: pd.DataFrame) -> None:
+    ids = frame[RECORD_ID_COLUMN].map(str)
+    if ids.nunique() != len(frame):
+        raise ValueError("duplicate record_id")
 
 
 def _require_text_match(joined: pd.DataFrame) -> None:

--- a/experiments/curate_study_2_phase_3_stimuli/write.py
+++ b/experiments/curate_study_2_phase_3_stimuli/write.py
@@ -183,8 +183,11 @@ def _catalog_status_sentence(result: CatalogRunResult) -> str:
     if not result.catalog_written:
         return "The catalog was not written, because at least one cell is short of its target."
     return (
-        f"Catalog `{result.local_path}` SHA-256 `{result.csv_sha256}` has "
-        f"{result.catalog_rows} rows. S3 object `{result.s3_uri}`."
+        f"The catalog file `{result.local_path}` has {result.catalog_rows} rows, "
+        f"and its SHA-256 is `{result.csv_sha256}`. The same bytes are on S3 at "
+        f"`{result.s3_uri}`. The catalog has {result.left} left posts and "
+        f"{result.right} right posts, and it has {result.low} low, "
+        f"{result.medium} medium, and {result.high} high posts."
     )
 
 

--- a/experiments/generate_flips_for_upsampled_posts_2026_09_08/run.py
+++ b/experiments/generate_flips_for_upsampled_posts_2026_09_08/run.py
@@ -97,14 +97,29 @@ def main(
     """
     resolved_run_id = run_id if run_id else get_current_timestamp()
     _require_smoke_is_not_full_run(resolved_run_id, max_posts)
+    _require_named_sibling_absent_for_full_run(max_posts, bucket)
     result = _generate_for_run(resolved_run_id, max_posts, bucket)
     _print_run_summary(result)
     _maybe_copy_named_sibling(result, max_posts, bucket)
 
 
 def _require_smoke_is_not_full_run(run_id: str, max_posts: int | None) -> None:
-    if run_id == SMOKE_RUN_ID and max_posts is None:
+    if run_id != SMOKE_RUN_ID:
+        return
+    if max_posts != SMOKE_MAX_POSTS:
         raise ValueError("do not reuse --run-id smoke for the full 2300 post job")
+
+
+def _require_named_sibling_absent_for_full_run(
+    max_posts: int | None, bucket: str
+) -> None:
+    if max_posts is not None:
+        return
+    store = CampaignObjectStore(bucket)
+    if store.get(NAMED_SIBLING_S3_KEY) is not None:
+        raise FileExistsError(
+            f"Object already exists: {s3_uri(bucket, NAMED_SIBLING_S3_KEY)}"
+        )
 
 
 def _generate_for_run(

--- a/experiments/upsample_medium_toxicity_posts_2026_09_08/sample_leftover_medium.py
+++ b/experiments/upsample_medium_toxicity_posts_2026_09_08/sample_leftover_medium.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pandas as pd
 
 from experiments.upsample_medium_toxicity_posts_2026_09_08.sources import (
+    EXPECTED_LEFTOVER_LEFT_MEDIUM,
+    EXPECTED_LEFTOVER_RIGHT_MEDIUM,
     LEFT_STANCE,
     LeftoverMediumSample,
     MEDIUM_TOXICITY,
@@ -41,11 +43,13 @@ def sample_leftover_medium(
     Raises
     ------
     ValueError
-        When either leftover medium cell has fewer than 1,000 rows.
+        When leftover medium counts do not match the pinned leftovers, or
+        either cell has fewer than 1,000 rows.
     """
     leftover_medium = _leftover_medium_rows(cleaned, sample)
     leftover_left = _stance_rows(leftover_medium, LEFT_STANCE)
     leftover_right = _stance_rows(leftover_medium, RIGHT_STANCE)
+    _require_leftover_counts(leftover_left, leftover_right)
     sampled = _concat_sorted(
         [
             _sample_cell(leftover_left, LEFT_STANCE),
@@ -69,6 +73,19 @@ def _leftover_medium_rows(cleaned: pd.DataFrame, sample: pd.DataFrame) -> pd.Dat
 
 def _stance_rows(frame: pd.DataFrame, stance: str) -> pd.DataFrame:
     return frame.loc[frame[STANCE_COLUMN] == stance]
+
+
+def _require_leftover_counts(leftover_left: pd.DataFrame, leftover_right: pd.DataFrame) -> None:
+    if len(leftover_left) != EXPECTED_LEFTOVER_LEFT_MEDIUM:
+        raise ValueError(
+            f"leftover_left_medium={len(leftover_left)} "
+            f"expected={EXPECTED_LEFTOVER_LEFT_MEDIUM}"
+        )
+    if len(leftover_right) != EXPECTED_LEFTOVER_RIGHT_MEDIUM:
+        raise ValueError(
+            f"leftover_right_medium={len(leftover_right)} "
+            f"expected={EXPECTED_LEFTOVER_RIGHT_MEDIUM}"
+        )
 
 
 def _sample_cell(cell: pd.DataFrame, stance: str) -> pd.DataFrame:

--- a/experiments/upsample_right_leaning_high_toxicity_posts_2026_09_08/RESULTS.md
+++ b/experiments/upsample_right_leaning_high_toxicity_posts_2026_09_08/RESULTS.md
@@ -32,4 +32,4 @@ PYTHONPATH=. uv run python experiments/upsample_right_leaning_high_toxicity_post
 
 ## Unified political stance by toxicity
 
-Left 1000, right 1300, medium 2000, high 300.
+The unified table has 1,000 left posts and 1,300 right posts. It has 2,000 medium posts and 300 high posts.

--- a/experiments/upsample_right_leaning_high_toxicity_posts_2026_09_08/candidates.py
+++ b/experiments/upsample_right_leaning_high_toxicity_posts_2026_09_08/candidates.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from experiments.upsample_right_leaning_high_toxicity_posts_2026_09_08.sources import (
     CandidateBuildResult,
+    EXPECTED_LEFTOVER_RIGHT_MEDIUM_AFTER_UPSAMPLE,
     MEDIUM_TOXICITY,
     MIN_CANDIDATES,
     PR260_PROMOTION_IDS_PATH,
@@ -70,6 +71,7 @@ def build_perspective_candidates(
     """
     leftover_medium = _leftover_medium(cleaned, sample, medium_upsample)
     leftover_right = leftover_medium.loc[leftover_medium[STANCE_COLUMN] == RIGHT_STANCE]
+    _require_leftover_right_count(leftover_right)
     candidates, dropped = _drop_pr260_ids(leftover_right, pr260_source_record_ids)
     _require_enough_candidates(candidates)
     return CandidateBuildResult(
@@ -77,6 +79,14 @@ def build_perspective_candidates(
         leftover_right_medium_after_upsample=len(leftover_right),
         pr260_ids_dropped=dropped,
     )
+
+
+def _require_leftover_right_count(leftover_right: pd.DataFrame) -> None:
+    if len(leftover_right) != EXPECTED_LEFTOVER_RIGHT_MEDIUM_AFTER_UPSAMPLE:
+        raise ValueError(
+            f"leftover_right_medium_after_upsample={len(leftover_right)} "
+            f"expected={EXPECTED_LEFTOVER_RIGHT_MEDIUM_AFTER_UPSAMPLE}"
+        )
 
 
 def _leftover_medium(

--- a/experiments/upsample_right_leaning_high_toxicity_posts_2026_09_08/run.py
+++ b/experiments/upsample_right_leaning_high_toxicity_posts_2026_09_08/run.py
@@ -31,6 +31,7 @@ import sys
 
 import pandas as pd
 
+from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
 from experiments.filter_posts_used_for_stimulus_dataset_2026_09_08.cleanup_raw_candidate_dataset import (
     cleanup_raw_candidate_dataset,
 )
@@ -48,6 +49,7 @@ from experiments.upsample_right_leaning_high_toxicity_posts_2026_09_08.score imp
     score_candidates,
 )
 from experiments.upsample_right_leaning_high_toxicity_posts_2026_09_08.sources import (
+    OUTPUT_S3_BUCKET,
     combined_cache_dir,
     medium_upsample_cache_dir,
     pinned_combined_source,
@@ -58,12 +60,14 @@ from experiments.upsample_right_leaning_high_toxicity_posts_2026_09_08.sources i
 )
 from experiments.upsample_right_leaning_high_toxicity_posts_2026_09_08.write import (
     print_run_summary,
+    require_output_keys_absent,
     write_unified_upsample,
 )
 
 
 def main() -> int:
     """Promote 300 right-high posts, write the unified upsample, and print counts."""
+    require_output_keys_absent(CampaignObjectStore(OUTPUT_S3_BUCKET))
     cleaned = _load_cleaned_combined()
     sample = _load_sample()
     medium_upsample = _load_medium_upsample()

--- a/experiments/upsample_right_leaning_high_toxicity_posts_2026_09_08/write.py
+++ b/experiments/upsample_right_leaning_high_toxicity_posts_2026_09_08/write.py
@@ -41,6 +41,18 @@ export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
 PYTHONPATH=. uv run python experiments/upsample_right_leaning_high_toxicity_posts_2026_09_08/run.py"""
 
 
+def require_output_keys_absent(store: CampaignObjectStore) -> None:
+    """Raise FileExistsError if the 300-row or unified S3 key already exists.
+
+    Raises
+    ------
+    FileExistsError
+        When either destination S3 key already exists.
+    """
+    _require_key_absent(store, PROMOTED_S3_KEY)
+    _require_key_absent(store, UNIFIED_S3_KEY)
+
+
 def write_unified_upsample(
     candidates: CandidateBuildResult,
     promotion: PromotionResult,
@@ -72,6 +84,7 @@ def write_unified_upsample(
     """
     resolved_dir = experiment_dir if experiment_dir is not None else EXPERIMENT_DIR
     resolved_store = store if store is not None else _default_store()
+    require_output_keys_absent(resolved_store)
     promoted_path, promoted_body = _write_local_parquet(
         promotion.promoted, resolved_dir / PROMOTED_FILENAME
     )
@@ -108,6 +121,11 @@ def print_run_summary(result: UnifiedUpsampleRunResult) -> None:
     print(f"promoted_sha256={result.promoted_sha256}")
     print(f"unified_s3_uri={result.unified_s3_uri}")
     print(f"unified_sha256={result.unified_sha256}")
+
+
+def _require_key_absent(store: CampaignObjectStore, key: str) -> None:
+    if store.get(key) is not None:
+        raise FileExistsError(f"Object already exists: {s3_uri(OUTPUT_S3_BUCKET, key)}")
 
 
 def _write_local_parquet(frame: pd.DataFrame, path: Path) -> tuple[Path, bytes]:
@@ -181,8 +199,9 @@ def _results_markdown(result: UnifiedUpsampleRunResult) -> str:
             "## Unified political stance by toxicity",
             "",
             (
-                f"Left {result.unified_left}, right {result.unified_right}, "
-                f"medium {result.unified_medium}, high {result.unified_high}."
+                f"The unified table has {result.unified_left} left posts and "
+                f"{result.unified_right} right posts. It has {result.unified_medium} "
+                f"medium posts and {result.unified_high} high posts."
             ),
             "",
         ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A second run of the unused-post catalog experiments still called Perspective or Bedrock, then failed when the output S3 key already existed. `--run-id smoke` with `--max-posts 2300` could also start a full-size flip job.

Those commands now fail before paid API work. `--run-id smoke` is allowed only with `--max-posts 10`.

## Purpose

Pull request 273 merged before this review follow-up landed. The live S3 objects are already written, so the risk is a costly accidental re-run, not a bad catalog.

This PR is that leftover commit, plus a changelog line for this PR. It does not change catalog contents or S3 bytes.

## Reproduction

1. Export `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from the lab keys.
2. `PYTHONPATH=. uv run python experiments/upsample_right_leaning_high_toxicity_posts_2026_09_08/run.py`
3. `PYTHONPATH=. uv run python experiments/generate_flips_for_upsampled_posts_2026_09_08/run.py --run-id smoke --max-posts 2300`

Expected: both commands fail immediately (`FileExistsError` / `ValueError`) with no Perspective or Bedrock work.
Actual on `main` after #273: step 2 scores candidates then fails at upload; `--run-id smoke --max-posts 2300` is treated as a limited run, not rejected.

## Root cause

Existence checks ran at `put_new`, after scoring and generation. The smoke guard only rejected `--run-id smoke` when `--max-posts` was omitted.

## Fix

Check the 300-row and unified keys, and the named flip object, before scoring or Bedrock. Require `--max-posts 10` for `--run-id smoke`. Also assert leftover cell counts, unique join ids, and new-catalog row count.

```mermaid
flowchart LR
  subgraph before [Before]
    Score[Score or generate] --> Put[put_new]
    Put -->|exists| Fail[FileExistsError]
  end
```

```mermaid
flowchart LR
  subgraph after [After]
    Check[Output key exists?] -->|yes| Fail2[FileExistsError]
    Check -->|no| Score2[Score or generate]
    Score2 --> Put2[put_new]
  end
```

## How to verify

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"

PYTHONPATH=. uv run python experiments/upsample_right_leaning_high_toxicity_posts_2026_09_08/run.py
# expect FileExistsError before Perspective

PYTHONPATH=. uv run python experiments/generate_flips_for_upsampled_posts_2026_09_08/run.py --run-id smoke --max-posts 2300
# expect ValueError
```

Follow-up to #273.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-302e0684-ae07-47e0-8dad-8be550984f74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-302e0684-ae07-47e0-8dad-8be550984f74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

