### PR TITLE
Count remaining labels for the pull request 273 catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,10 @@ experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/requi
 # Remaining-label CSV lives in S3. Keep the local cache out of git.
 experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/cache/
 
+# Remaining-label CSV for the pull request 273 catalog lives in S3.
+experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/cache/
+experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/required_label_count_per_stimulus_post.csv
+
 # OS generated files
 .DS_Store
 .DS_Store?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. Operators now have a 10,000 post study catalog sampled from the 10,200 post set plus 2,000 unused medium posts and 300 leftover right-medium posts relabeled as high using Perspective scores. Remaining labels for that catalog plus the old catalog total 77,557. [PR #273](https://github.com/METResearchGroup/mirrorView-task/pull/273)
 2. Operators can re-run the unused-post catalog experiments without calling Perspective or Bedrock when the output S3 keys already exist, and a smoke flip run cannot reuse `--run-id smoke` except with `--max-posts 10`. [PR #277](https://github.com/METResearchGroup/mirrorView-task/pull/277)
+3. Operators now have remaining label counts for the old catalog and the 10,000-post catalog from pull request 273. Remaining labels total 77,557, with 27,557 on old posts counted by unique Prolific raters and 50,000 on new posts. [PR #279](https://github.com/METResearchGroup/mirrorView-task/pull/279)
 
 ## 2026-09-08
 

--- a/docs/plans/2026-09-09_required_label_count_pr273_catalog_7ad7e0/plan.md
+++ b/docs/plans/2026-09-09_required_label_count_pr273_catalog_7ad7e0/plan.md
@@ -1,0 +1,64 @@
+# Recalculate remaining labels for the old catalog and the pull request 273 catalog
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Issue 268 still needs remaining-label counts for the next study round. Pull request 271 counted the 10,200-post sample from pull request 267. Pull request 273 replaced that sample with a 10,000-post catalog. This experiment redoes pull request 271 against that catalog. The old catalog still uses unique Prolific raters. Every new catalog post needs 5 labels. Posts with 0 remaining labels are dropped.
+
+## Happy flow
+
+An operator runs one command. The command fails immediately if the output S3 key already exists. Otherwise it loads the old catalog, the old results, and the pinned 10,000-row catalog. It writes a local CSV, uploads that CSV once, and writes `RESULTS.md`.
+
+```mermaid
+flowchart TD
+    A[Fail if output S3 key exists] --> B[Load old catalog and results]
+    C[Download pinned 10000 row catalog] --> D[Give each new post 5 remaining labels]
+    B --> E[Count unique raters per old post]
+    E --> F[Concatenate old and new rows]
+    D --> F
+    F --> G[Drop remaining count of 0 or less]
+    G --> H[Write local CSV]
+    H --> I[Upload CSV to S3]
+    I --> J[Write RESULTS.md]
+```
+
+## Approach
+
+Treat this as a new dated experiment. Copy remaining-label math from `experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/` rather than importing it, so the v1 and v2 folders stay untouched. Fail before loading if the new S3 key exists. Do not add pytest. Do not overwrite the v1 CSV, the v2 CSV, or the 10,000-row catalog.
+
+## Decisions
+
+- Create `experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/`. Set required labels per post to 5 in `constants.py`.
+- Old catalog is `shared/data/raw/study_phase_2_part_2/stimuli/flips.csv`. Id column `post_primary_key`. 10,000 unique ids. Remaining labels equal 5 minus unique `prolific_id` values in `shared/data/raw/study_phase_2_part_2/results/full.csv`. Empty ids do not count. Two sessions by the same Prolific account count as one rater.
+- New catalog is `s3://mirrorview-experimental-artifacts/experiments/curate_study_2_phase_3_stimuli/flips.csv`, SHA-256 `c90fdcf86e89e393f0de4cc34e1dc4e4bb2bd876405926ad654ff679f3ab4139`, 10,000 rows. Id column `post_primary_key`. Every new post gets 5 remaining labels. Do not look up new ids in the old results file.
+- Do not include study phase 2 part 1. If the same id appears in both batches, fail the run.
+- Output columns are `id`, `number_of_times_to_label`, and `batch`. Drop remaining counts of 0 or less. Sort by `batch` with `old` first, then by `id`.
+- Upload to `s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/required_label_count_per_stimulus_post.csv`. A second run must fail if that key exists, before any catalog download.
+- On the current old files, remaining labels total 77,557 overall, 27,557 old on 8,899 posts, and 50,000 new on 10,000 posts. The table has 18,899 rows.
+- Do not edit `experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/`, `experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/`, `experiments/curate_study_2_phase_3_stimuli/`, or files under `tests/`.
+
+## Steps
+
+### Step 1: Add the load, count, and upload command
+
+Add the experiment README, modules, and a `run.py` caller. Fail if the output key exists, load both batches, count remaining labels, write the local CSV, and upload it. See [steps/step1.md](steps/step1.md).
+
+### Step 2: Run the command and write RESULTS.md
+
+Run the command with AWS credentials. Confirm the local file and the S3 object, then commit `RESULTS.md`. See [steps/step2.md](steps/step2.md).
+
+## What "done" looks like
+
+1. `experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/` has `README.md`, `constants.py`, a runnable `run.py`, and the load, count, and write modules.
+2. `constants.py` sets required labels per post to 5.
+3. The CSV exists locally under that folder and at `s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/required_label_count_per_stimulus_post.csv`.
+4. The CSV has columns `id`, `number_of_times_to_label`, and `batch`, and every remaining count is greater than 0.
+5. `RESULTS.md` records total remaining labels and the same total split by old and new.
+6. On the current files, remaining labels total 77,557 overall, 27,557 old, and 50,000 new. The table has 18,899 rows, 8,899 old and 10,000 new.
+7. The v1 remaining-label CSV, the v2 remaining-label CSV, the 10,000-row catalog, the old catalog, and the old results file are unchanged.
+8. No pytest file was added or run.

--- a/docs/plans/2026-09-09_required_label_count_pr273_catalog_7ad7e0/steps/step1.md
+++ b/docs/plans/2026-09-09_required_label_count_pr273_catalog_7ad7e0/steps/step1.md
@@ -1,0 +1,153 @@
+# Step 1: Add the load, count, and upload command
+
+## Scope
+
+- **Caller:** `experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py` `main`
+- **Task:** Fail if the output S3 key exists. Load the old catalog and old results, download the pinned 10,000-row catalog from pull request 273, count unique `prolific_id` raters per old post, give every new post 5 remaining labels, drop remaining counts of 0 or less, write local `required_label_count_per_stimulus_post.csv`, upload that file to S3, print totals, write `RESULTS.md`, and add `README.md`.
+- **Out of scope:** pytest, study phase 2 part 1, generating mirrors, changing product scripts, overwriting the v1 or v2 remaining-label CSVs, looking up new-catalog ids in the old results file.
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-09_required_label_count_pr273_catalog_7ad7e0/plan.md` | Confirmed decisions, unique rater rule, expected totals |
+| `/workspace/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/run.py` | Caller shape and live given/when/then |
+| `/workspace/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/calculate.py` | Unique rater math, overlap check, drop remaining 0 or less |
+| `/workspace/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/load.py` | Old catalog, old results, and CSV catalog loader |
+| `/workspace/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/write.py` | CSV bytes, `put_new`, `RESULTS.md` |
+| `/workspace/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/constants.py` | `REQUIRED_LABELS_PER_POST = 5` and pinned catalog identity |
+| `/workspace/experiments/curate_study_2_phase_3_stimuli/RESULTS.md` | Pinned catalog SHA-256 `c90fdcf86e89e393f0de4cc34e1dc4e4bb2bd876405926ad654ff679f3ab4139` |
+| `/workspace/experiments/upsample_right_leaning_high_toxicity_posts_2026_09_08/write.py` | `require_output_keys_absent` before expensive work |
+| `/workspace/.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md` | Experiment code does not get unit tests |
+
+## Files allowed to change
+
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/README.md` (new)
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/constants.py` (new)
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/load.py` (new)
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/calculate.py` (new)
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/write.py` (new)
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py` (new)
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/.gitignore` (new)
+- `/workspace/.gitignore` (ignore cache and local CSV under this experiment folder only)
+
+## Files forbidden to change
+
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/**`
+- `/workspace/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/**`
+- `/workspace/experiments/curate_study_2_phase_3_stimuli/**`
+- `/workspace/shared/data/raw/study_phase_2_part_2/**`
+- `/workspace/tests/**`
+- The v1 remaining-label S3 object
+- The v2 remaining-label S3 object
+- The 10,000-row catalog S3 object
+- `/workspace/CHANGELOG.md` until Step 2 has a live S3 object and `RESULTS.md`
+
+## README contract
+
+Write `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/README.md` first, then implement the modules to match it.
+
+The README must:
+
+1. Start with the same agent read-only banner used in `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md`.
+2. Say the study needs 5 labels on every stimulus post, and that this value lives in `constants.py`.
+3. Describe the old batch: unique ids from `shared/data/raw/study_phase_2_part_2/stimuli/flips.csv`, remaining labels equal 5 minus the number of unique `prolific_id` raters for that id in `shared/data/raw/study_phase_2_part_2/results/full.csv`.
+4. Describe the new batch: every post in the 10,000-row catalog from pull request 273 needs 5 labels.
+5. Name the output columns `id`, `number_of_times_to_label`, and `batch`, and say rows with remaining count of 0 or less are dropped.
+6. Name the S3 bucket `mirrorview-experimental-artifacts` and the prefix `experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/`.
+7. Name the output file `required_label_count_per_stimulus_post.csv`.
+8. List these required files: `constants.py`, `load.py`, `calculate.py`, `write.py`, `run.py`.
+9. Include the run command from the Main caller section below.
+
+After this README is committed, later steps must not edit it.
+
+## Pinned new catalog
+
+| Field | Value |
+|-------|-------|
+| Object | `s3://mirrorview-experimental-artifacts/experiments/curate_study_2_phase_3_stimuli/flips.csv` |
+| SHA-256 | `c90fdcf86e89e393f0de4cc34e1dc4e4bb2bd876405926ad654ff679f3ab4139` |
+| Rows | 10000 |
+| Id column | `post_primary_key` |
+
+A hash mismatch, a wrong row count, or duplicate ids raises `ValueError`. A missing source object raises `FileNotFoundError`.
+
+## Contracts
+
+Copy remaining-label math from `experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/` rather than importing it.
+
+`REQUIRED_LABELS_PER_POST` is 5.
+
+Old catalog: `load_dataset("STUDY_PHASE_2_PART_2_STIMULI")`, id column `post_primary_key`, 10,000 unique ids.
+
+Old results: `load_dataset("STUDY_PHASE_2_PART_2_RESULTS_FULL")`. Rater is `prolific_id`. Empty `post_id` or `prolific_id` cells do not count.
+
+New catalog: download the pinned CSV. Id column `post_primary_key`. Expected 10,000 unique ids. Every new id gets remaining labels 5.
+
+If any id appears in both batches, raise `ValueError`. Drop remaining counts of 0 or less. Sort by `batch` with `old` first, then by `id`, `kind="mergesort"`.
+
+Call `require_output_key_absent` before loading. A second run must raise `FileExistsError` before the catalog download.
+
+Expected totals on the current old files:
+
+| Batch | Posts | Remaining labels |
+| ----- | ----: | ---------------: |
+| old | 8899 | 27557 |
+| new | 10000 | 50000 |
+| total | 18899 | 77557 |
+
+## Outputs
+
+| Output | Path |
+|--------|------|
+| Local CSV | `experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/required_label_count_per_stimulus_post.csv` |
+| S3 CSV | `s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/required_label_count_per_stimulus_post.csv` |
+| Report | `experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/RESULTS.md` |
+
+Upload with `put_new`. A second upload of that key must fail.
+
+## Main caller
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py
+```
+
+Expected stdout includes `old_posts=8899`, `old_labels=27557`, `new_posts=10000`, `new_labels=50000`, `total_posts=18899`, `total_labels=77557`.
+
+## Live given / when / then
+
+```text
+given AWS credentials from LAB_AWS_ACCESS_KEY_ID and LAB_AWS_ACCESS_KEY_SECRET
+and pull request 273 wrote the 10000 row catalog
+when PYTHONPATH=. uv run python experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py
+then old_posts=8899
+and old_labels=27557
+and new_posts=10000
+and new_labels=50000
+and total_posts=18899
+and total_labels=77557
+and every number_of_times_to_label value is greater than 0
+and the S3 CSV SHA-256 matches the local file
+and RESULTS.md records those totals
+
+given the S3 CSV key already exists
+when the command is run again
+then the process raises FileExistsError
+and the v1 remaining-label CSV is unchanged
+and the v2 remaining-label CSV is unchanged
+```
+
+## Must pass
+
+- Old remaining labels still 27,557 on 8,899 posts.
+- New remaining labels 50,000 on 10,000 posts.
+- V1 and v2 remaining-label experiment files are unchanged.
+
+## Must fail
+
+- Overlap between old catalog ids and new catalog ids.
+- Second run after the S3 key exists.
+- Hash mismatch or row-count mismatch on the pinned catalog.

--- a/docs/plans/2026-09-09_required_label_count_pr273_catalog_7ad7e0/steps/step2.md
+++ b/docs/plans/2026-09-09_required_label_count_pr273_catalog_7ad7e0/steps/step2.md
@@ -1,0 +1,92 @@
+# Step 2: Run the command and write RESULTS.md
+
+## Scope
+
+- **Caller:** the same `run.py` `main` from Step 1.
+- **Task:** Export AWS credentials, run the command, confirm the local CSV and the S3 object, copy logs to `/opt/cursor/artifacts/`, and commit `RESULTS.md` with remaining label totals overall and split by old and new.
+- **Out of scope:** pytest, editing the experiment README, changing the old catalog, changing the old results file, changing the 10,000-row catalog, changing the v1 or v2 remaining-label CSVs.
+
+## Files to inspect (read-only)
+
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py`
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/README.md`
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/constants.py`
+- `/workspace/docs/plans/2026-09-09_required_label_count_pr273_catalog_7ad7e0/plan.md`
+- `/workspace/docs/plans/2026-09-09_required_label_count_pr273_catalog_7ad7e0/steps/step1.md`
+
+## Files allowed to change
+
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/RESULTS.md` (written by the live command, then committed)
+- `/workspace/CHANGELOG.md` after the live S3 object exists
+
+## Files forbidden to change
+
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/README.md`
+- `/workspace/experiments/calculate_required_label_count_per_stimulus_post_2026_09_08/**`
+- `/workspace/experiments/calculate_v2_required_label_count_per_stimulus_post_2026_09_08/**`
+- `/workspace/experiments/curate_study_2_phase_3_stimuli/**`
+- `/workspace/shared/data/raw/study_phase_2_part_2/**`
+- `/workspace/tests/**`
+- `/workspace/docs/plans/2026-09-09_required_label_count_pr273_catalog_7ad7e0/**`
+
+## Live commands
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py
+```
+
+Expected stdout includes `old_posts=8899`, `old_labels=27557`, `new_posts=10000`, `new_labels=50000`, `total_posts=18899`, `total_labels=77557`, a local path under `experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/required_label_count_per_stimulus_post.csv`, `s3_uri=s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/required_label_count_per_stimulus_post.csv`, and `csv_sha256=`.
+
+```bash
+PYTHONPATH=. uv run python - <<'PY'
+import hashlib
+from pathlib import Path
+import pandas as pd
+from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+
+local = Path(
+    "experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/"
+    "required_label_count_per_stimulus_post.csv"
+)
+store = CampaignObjectStore("mirrorview-experimental-artifacts")
+key = (
+    "experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/"
+    "required_label_count_per_stimulus_post.csv"
+)
+stored = store.get(key)
+assert stored is not None
+frame = pd.read_csv(local)
+assert list(frame.columns) == ["id", "number_of_times_to_label", "batch"]
+assert (frame["number_of_times_to_label"] > 0).all()
+assert len(frame) == 18899
+assert int((frame["batch"] == "old").sum()) == 8899
+assert int((frame["batch"] == "new").sum()) == 10000
+assert int(frame["number_of_times_to_label"].sum()) == 77557
+assert int(frame.loc[frame["batch"] == "old", "number_of_times_to_label"].sum()) == 27557
+assert int(frame.loc[frame["batch"] == "new", "number_of_times_to_label"].sum()) == 50000
+assert hashlib.sha256(local.read_bytes()).hexdigest() == hashlib.sha256(stored.body).hexdigest()
+print("required label counts ok", len(frame), int(frame["number_of_times_to_label"].sum()))
+PY
+```
+
+Expected: `required label counts ok 18899 77557`.
+
+Copy the command stdout to `/opt/cursor/artifacts/required_label_count_pr273_run.log`.
+
+## Must pass
+
+- Live command exits 0 on the first run.
+- `old_posts=8899` and `old_labels=27557`.
+- `new_posts=10000` and `new_labels=50000`.
+- `total_posts=18899` and `total_labels=77557`.
+- Local SHA-256 equals S3 object SHA-256.
+- `RESULTS.md` is committed and records those three remaining label totals.
+- New catalog object SHA-256 is still `c90fdcf86e89e393f0de4cc34e1dc4e4bb2bd876405926ad654ff679f3ab4139`.
+- `README.md` is unchanged from Step 1.
+
+## Must fail
+
+- A second run of the same command, because `require_output_key_absent` and `put_new` must raise `FileExistsError`.

--- a/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/.gitignore
+++ b/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/.gitignore
@@ -1,0 +1,2 @@
+cache/
+required_label_count_per_stimulus_post.csv

--- a/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/README.md
+++ b/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/README.md
@@ -1,0 +1,30 @@
+# Calculate required label count per stimulus post
+
+<-- NOTE TO AI AGENTS: do NOT touch this file. This file is READ-ONLY. If something here is incorrect or needs updating, inform the user and they will make the change themselves -->
+
+The next study round needs 5 labels on every stimulus post. That value lives in `constants.py`.
+
+Old batch: unique ids from `shared/data/raw/study_phase_2_part_2/stimuli/flips.csv`. Remaining labels for each id equal 5 minus the number of unique `prolific_id` raters for that id in `shared/data/raw/study_phase_2_part_2/results/full.csv`.
+
+New batch: every post in the 10,000-row catalog from pull request 273 needs 5 labels. That catalog is `experiments/curate_study_2_phase_3_stimuli/flips.csv`.
+
+The output CSV has columns `id`, `number_of_times_to_label`, and `batch`. Rows whose remaining count is 0 or less are dropped.
+
+Upload to the `mirrorview-experimental-artifacts` bucket under the prefix `experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/`. The output file is `required_label_count_per_stimulus_post.csv`.
+
+Required files:
+
+- constants.py
+- load.py
+- calculate.py
+- write.py
+- run.py
+
+## Run
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py
+```

--- a/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/RESULTS.md
+++ b/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/RESULTS.md
@@ -1,0 +1,31 @@
+# Calculate required label count per stimulus post, results
+
+## Command
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py
+```
+
+## New catalog
+
+Object `s3://mirrorview-experimental-artifacts/experiments/curate_study_2_phase_3_stimuli/flips.csv` SHA-256 `c90fdcf86e89e393f0de4cc34e1dc4e4bb2bd876405926ad654ff679f3ab4139` has 10,000 rows.
+
+## Old catalog
+
+Catalog `shared/data/raw/study_phase_2_part_2/stimuli/flips.csv` has 10,000 unique ids. Remaining labels equal 5 minus the number of unique `prolific_id` raters per `post_id`. Posts with 0 remaining labels are dropped, so the old batch has 8,899 posts.
+
+## Remaining labels
+
+| File | Path | SHA-256 |
+| ---- | ---- | ------- |
+| Local CSV | `experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/required_label_count_per_stimulus_post.csv` | `188d627e8972d9b1ec5eb378814fd02fd588328df0a1ffc8603b0eba63d05c91` |
+| S3 CSV | `s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/required_label_count_per_stimulus_post.csv` | `188d627e8972d9b1ec5eb378814fd02fd588328df0a1ffc8603b0eba63d05c91` |
+
+| Batch | Posts | Remaining labels |
+| ----- | ----: | ---------------: |
+| old | 8899 | 27557 |
+| new | 10000 | 50000 |
+| total | 18899 | 77557 |

--- a/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/calculate.py
+++ b/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/calculate.py
@@ -1,0 +1,145 @@
+"""Compute remaining labels for old posts and the new 10,000 row catalog."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from experiments.calculate_required_label_count_per_stimulus_post_2026_09_09.constants import (
+    Batch,
+    EMPTY_CELL,
+    NAN_CELL,
+    NEW_ID_COLUMN,
+    OLD_ID_COLUMN,
+    OUTPUT_BATCH_COLUMN,
+    OUTPUT_COUNT_COLUMN,
+    OUTPUT_ID_COLUMN,
+    RATER_COLUMN,
+    RESULTS_ID_COLUMN,
+    SORT_KIND,
+)
+
+OLD_BATCH_SORT_RANK = 0
+NEW_BATCH_SORT_RANK = 1
+BATCH_SORT_RANK = {
+    Batch.OLD.value: OLD_BATCH_SORT_RANK,
+    Batch.NEW.value: NEW_BATCH_SORT_RANK,
+}
+KEEP_REMAINING_ABOVE = 0
+BATCH_RANK_COLUMN = "_batch_rank"
+
+
+def count_unique_raters_per_post(old_results: pd.DataFrame) -> pd.Series:
+    """Count unique ``prolific_id`` raters for each ``post_id``.
+
+    Returns
+    -------
+    pandas.Series
+        Rater counts indexed by ``post_id``. Empty post ids and rater ids
+        are ignored.
+    """
+    rows = _usable_rater_rows(old_results)
+    counts = rows.groupby(RESULTS_ID_COLUMN, sort=False)[RATER_COLUMN].nunique()
+    counts.name = RATER_COLUMN
+    return counts
+
+
+def remaining_labels_for_old_posts(
+    old_catalog: pd.DataFrame,
+    rater_counts: pd.Series,
+    required_labels_per_post: int,
+) -> pd.DataFrame:
+    """Return remaining labels for each old catalog post.
+
+    Remaining labels equal ``required_labels_per_post`` minus unique raters.
+    Posts with no raters receive the full required count.
+    """
+    ids = old_catalog[OLD_ID_COLUMN]
+    unique_raters = ids.map(rater_counts).fillna(0).astype(int)
+    remaining = required_labels_per_post - unique_raters
+    return pd.DataFrame(
+        {
+            OUTPUT_ID_COLUMN: ids.to_numpy(),
+            OUTPUT_COUNT_COLUMN: remaining.to_numpy(),
+            OUTPUT_BATCH_COLUMN: Batch.OLD.value,
+        }
+    )
+
+
+def remaining_labels_for_new_posts(
+    new_catalog: pd.DataFrame,
+    required_labels_per_post: int,
+) -> pd.DataFrame:
+    """Assign every new catalog post the full required label count.
+
+    New posts are not looked up in the old results file.
+    """
+    ids = new_catalog[NEW_ID_COLUMN].astype(str).str.strip()
+    return pd.DataFrame(
+        {
+            OUTPUT_ID_COLUMN: ids.to_numpy(),
+            OUTPUT_COUNT_COLUMN: required_labels_per_post,
+            OUTPUT_BATCH_COLUMN: Batch.NEW.value,
+        }
+    )
+
+
+def combine_and_filter_batches(
+    old_counts: pd.DataFrame,
+    new_counts: pd.DataFrame,
+) -> pd.DataFrame:
+    """Concatenate batches, fail on overlapping ids, and drop remaining counts of 0 or less."""
+    _require_no_id_overlap(old_counts[OUTPUT_ID_COLUMN], new_counts[OUTPUT_ID_COLUMN])
+    combined = pd.concat([old_counts, new_counts], ignore_index=True)
+    remaining = combined[combined[OUTPUT_COUNT_COLUMN] > KEEP_REMAINING_ABOVE].copy()
+    return _sort_remaining_rows(remaining)
+
+
+def calculate_required_label_counts(
+    old_catalog: pd.DataFrame,
+    old_results: pd.DataFrame,
+    new_catalog: pd.DataFrame,
+    required_labels_per_post: int,
+) -> pd.DataFrame:
+    """Return remaining label counts for old posts and the new catalog.
+
+    Raises
+    ------
+    ValueError
+        When the same id appears in both batches.
+    """
+    rater_counts = count_unique_raters_per_post(old_results)
+    old_counts = remaining_labels_for_old_posts(
+        old_catalog, rater_counts, required_labels_per_post
+    )
+    new_counts = remaining_labels_for_new_posts(new_catalog, required_labels_per_post)
+    return combine_and_filter_batches(old_counts, new_counts)
+
+
+def _usable_rater_rows(old_results: pd.DataFrame) -> pd.DataFrame:
+    post_ids = _stripped_values(old_results[RESULTS_ID_COLUMN])
+    raters = _stripped_values(old_results[RATER_COLUMN])
+    usable = _is_nonempty(post_ids) & _is_nonempty(raters)
+    return pd.DataFrame(
+        {RESULTS_ID_COLUMN: post_ids.loc[usable], RATER_COLUMN: raters.loc[usable]}
+    )
+
+
+def _stripped_values(values: pd.Series) -> pd.Series:
+    return values.fillna(EMPTY_CELL).astype(str).str.strip()
+
+
+def _is_nonempty(values: pd.Series) -> pd.Series:
+    return (values != EMPTY_CELL) & (values.str.lower() != NAN_CELL)
+
+
+def _require_no_id_overlap(old_ids: pd.Series, new_ids: pd.Series) -> None:
+    overlap = set(old_ids) & set(new_ids)
+    if overlap:
+        raise ValueError(f"overlapping id {sorted(overlap)[0]}")
+
+
+def _sort_remaining_rows(remaining: pd.DataFrame) -> pd.DataFrame:
+    ranked = remaining.copy()
+    ranked[BATCH_RANK_COLUMN] = ranked[OUTPUT_BATCH_COLUMN].map(BATCH_SORT_RANK)
+    ordered = ranked.sort_values([BATCH_RANK_COLUMN, OUTPUT_ID_COLUMN], kind=SORT_KIND)
+    return ordered.drop(columns=[BATCH_RANK_COLUMN]).reset_index(drop=True)

--- a/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/constants.py
+++ b/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/constants.py
@@ -1,0 +1,103 @@
+"""Pinned constants for remaining labels on the pull request 273 catalog."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from shared.data.registry import (
+    STUDY_PHASE_2_PART_2_RESULTS_FULL,
+    STUDY_PHASE_2_PART_2_STIMULI,
+)
+
+REQUIRED_LABELS_PER_POST = 5
+OLD_STIMULI_DATASET = STUDY_PHASE_2_PART_2_STIMULI
+OLD_RESULTS_DATASET = STUDY_PHASE_2_PART_2_RESULTS_FULL
+EXPECTED_OLD_CATALOG_IDS = 10000
+OLD_ID_COLUMN = "post_primary_key"
+RESULTS_ID_COLUMN = "post_id"
+RATER_COLUMN = "prolific_id"
+NEW_ID_COLUMN = "post_primary_key"
+OUTPUT_ID_COLUMN = "id"
+OUTPUT_COUNT_COLUMN = "number_of_times_to_label"
+OUTPUT_BATCH_COLUMN = "batch"
+OUTPUT_COLUMNS = (OUTPUT_ID_COLUMN, OUTPUT_COUNT_COLUMN, OUTPUT_BATCH_COLUMN)
+EMPTY_CELL = ""
+NAN_CELL = "nan"
+SORT_KIND = "mergesort"
+CSV_INDEX = False
+
+NEW_CATALOG_S3_BUCKET = "mirrorview-experimental-artifacts"
+NEW_CATALOG_S3_KEY = "experiments/curate_study_2_phase_3_stimuli/flips.csv"
+NEW_CATALOG_S3_URI = f"s3://{NEW_CATALOG_S3_BUCKET}/{NEW_CATALOG_S3_KEY}"
+NEW_CATALOG_SHA256 = (
+    "c90fdcf86e89e393f0de4cc34e1dc4e4bb2bd876405926ad654ff679f3ab4139"
+)
+NEW_CATALOG_ROW_COUNT = 10000
+
+OUTPUT_S3_BUCKET = "mirrorview-experimental-artifacts"
+OUTPUT_S3_KEY = (
+    "experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/"
+    "required_label_count_per_stimulus_post.csv"
+)
+DATASET_FILENAME = "required_label_count_per_stimulus_post.csv"
+RESULTS_FILENAME = "RESULTS.md"
+CACHE_DIRNAME = "cache"
+CACHE_FILENAME = "flips.csv"
+EXPERIMENT_DIRNAME = "calculate_required_label_count_per_stimulus_post_2026_09_09"
+
+
+class Batch(str, Enum):
+    """Which stimulus batch a remaining-label row belongs to."""
+
+    OLD = "old"
+    NEW = "new"
+
+
+@dataclass(frozen=True)
+class NewCatalogSource:
+    """Pinned new catalog CSV identity."""
+
+    s3_uri: str
+    sha256: str
+    expected_row_count: int
+
+
+@dataclass(frozen=True)
+class LabelCountRunResult:
+    """Counts and paths from one remaining-label run."""
+
+    old_catalog_ids: int
+    old_posts: int
+    old_labels: int
+    new_posts: int
+    new_labels: int
+    total_posts: int
+    total_labels: int
+    local_path: str
+    s3_uri: str
+    csv_sha256: str
+    new_catalog_uri: str
+    new_catalog_sha256: str
+    new_catalog_rows: int
+
+
+@dataclass(frozen=True)
+class LocalCsvWrite:
+    """Local CSV path and file bytes."""
+
+    path: Path
+    body: bytes
+
+
+PINNED_NEW_CATALOG = NewCatalogSource(
+    s3_uri=NEW_CATALOG_S3_URI,
+    sha256=NEW_CATALOG_SHA256,
+    expected_row_count=NEW_CATALOG_ROW_COUNT,
+)
+
+
+def pinned_new_catalog() -> NewCatalogSource:
+    """Return the pinned 10,000 row catalog identity."""
+    return PINNED_NEW_CATALOG

--- a/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/load.py
+++ b/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/load.py
@@ -1,0 +1,162 @@
+"""Load the old catalog, old results, and new 10,000 row catalog."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pandas as pd
+
+from data_platform.generate_features.s3_feature_campaign import (
+    CampaignObjectStore,
+    parse_s3_uri,
+)
+from data_platform.utils.object_store import sha256_hex
+from experiments.calculate_required_label_count_per_stimulus_post_2026_09_09.constants import (
+    CACHE_FILENAME,
+    EMPTY_CELL,
+    EXPECTED_OLD_CATALOG_IDS,
+    NAN_CELL,
+    NEW_ID_COLUMN,
+    NewCatalogSource,
+    OLD_ID_COLUMN,
+    OLD_RESULTS_DATASET,
+    OLD_STIMULI_DATASET,
+    RATER_COLUMN,
+    RESULTS_ID_COLUMN,
+)
+from shared.data.dataloader import load_dataset
+
+
+def load_old_catalog() -> pd.DataFrame:
+    """Load unique ids from the old stimulus catalog.
+
+    Returns
+    -------
+    pd.DataFrame
+        Catalog rows with a unique ``post_primary_key`` per row.
+
+    Raises
+    ------
+    ValueError
+        When the id column is missing or catalog ids are not unique.
+    """
+    catalog = load_dataset(OLD_STIMULI_DATASET)
+    _require_column(catalog, OLD_ID_COLUMN)
+    ids = _stripped_nonempty(catalog[OLD_ID_COLUMN])
+    _require_unique_id_count(ids, EXPECTED_OLD_CATALOG_IDS, OLD_ID_COLUMN)
+    return pd.DataFrame({OLD_ID_COLUMN: ids.to_numpy()})
+
+
+def load_old_results() -> pd.DataFrame:
+    """Load the old study results used to count unique raters.
+
+    Returns
+    -------
+    pd.DataFrame
+        Results rows that include ``post_id`` and ``prolific_id``.
+
+    Raises
+    ------
+    ValueError
+        When ``post_id`` or ``prolific_id`` is missing.
+    """
+    results = load_dataset(OLD_RESULTS_DATASET)
+    _require_column(results, RESULTS_ID_COLUMN)
+    _require_column(results, RATER_COLUMN)
+    return results
+
+
+def load_new_catalog(
+    source: NewCatalogSource,
+    store: CampaignObjectStore,
+    cache_dir: Path,
+) -> pd.DataFrame:
+    """Download the pinned new catalog CSV and check its identity.
+
+    Parameters
+    ----------
+    source
+        Pinned CSV URI, SHA-256, and row count.
+    store
+        Object store used only to download the pinned CSV.
+    cache_dir
+        Directory for a local copy of the source bytes.
+
+    Returns
+    -------
+    pd.DataFrame
+        New catalog rows with unique ``post_primary_key`` values.
+
+    Raises
+    ------
+    FileNotFoundError
+        When the source object is missing.
+    ValueError
+        When the SHA-256, row count, or id uniqueness does not match.
+    """
+    body = _bytes_matching_pinned_hash(source, store, cache_dir)
+    frame = pd.read_csv(io.BytesIO(body))
+    _require_column(frame, NEW_ID_COLUMN)
+    if len(frame) != source.expected_row_count:
+        raise ValueError(
+            f"row_count={len(frame)} expected={source.expected_row_count}"
+        )
+    ids = _stripped_nonempty(frame[NEW_ID_COLUMN])
+    _require_unique_id_count(ids, source.expected_row_count, NEW_ID_COLUMN)
+    return frame
+
+
+def _object_key(source: NewCatalogSource) -> str:
+    _bucket, key = parse_s3_uri(source.s3_uri)
+    return key
+
+
+def _cache_path(cache_dir: Path) -> Path:
+    return cache_dir / CACHE_FILENAME
+
+
+def _download_source_bytes(source: NewCatalogSource, store: CampaignObjectStore) -> bytes:
+    stored = store.get(_object_key(source))
+    if stored is None:
+        raise FileNotFoundError(source.s3_uri)
+    return stored.body
+
+
+def _bytes_matching_pinned_hash(
+    source: NewCatalogSource,
+    store: CampaignObjectStore,
+    cache_dir: Path,
+) -> bytes:
+    cache_path = _cache_path(cache_dir)
+    if cache_path.is_file():
+        cached = cache_path.read_bytes()
+        if sha256_hex(cached) == source.sha256:
+            return cached
+    body = _download_source_bytes(source, store)
+    if sha256_hex(body) != source.sha256:
+        raise ValueError(f"SHA-256 mismatch for {source.s3_uri}")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(body)
+    return body
+
+
+def _require_column(frame: pd.DataFrame, column_name: str) -> None:
+    if column_name not in frame.columns:
+        raise ValueError(f"missing column {column_name}")
+
+
+def _stripped_nonempty(values: pd.Series) -> pd.Series:
+    stripped = values.fillna(EMPTY_CELL).astype(str).str.strip()
+    nonempty = (stripped != EMPTY_CELL) & (stripped.str.lower() != NAN_CELL)
+    return stripped.loc[nonempty]
+
+
+def _require_unique_id_count(
+    ids: pd.Series, expected_count: int, column_name: str
+) -> None:
+    unique_count = int(ids.nunique())
+    if unique_count != len(ids):
+        raise ValueError(f"duplicate {column_name}")
+    if unique_count != expected_count:
+        raise ValueError(f"{column_name} count={unique_count} expected={expected_count}")

--- a/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py
+++ b/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py
@@ -1,0 +1,84 @@
+"""Count remaining labels for the old catalog and the pull request 273 catalog.
+
+given AWS credentials from LAB_AWS_ACCESS_KEY_ID and LAB_AWS_ACCESS_KEY_SECRET
+and pull request 273 wrote the 10000 row catalog
+when PYTHONPATH=. uv run python experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py
+then old_posts=8899
+and old_labels=27557
+and new_posts=10000
+and new_labels=50000
+and total_posts=18899
+and total_labels=77557
+and every number_of_times_to_label value is greater than 0
+and the S3 CSV SHA-256 matches the local file
+and RESULTS.md records those totals
+
+given the S3 CSV key already exists
+when the command is run again
+then the process raises FileExistsError
+and the v1 remaining-label CSV is unchanged
+and the v2 remaining-label CSV is unchanged
+
+Run from the repo root:
+
+    PYTHONPATH=. uv run python experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from data_platform.generate_features.s3_feature_campaign import CampaignObjectStore
+from experiments.calculate_required_label_count_per_stimulus_post_2026_09_09.calculate import (
+    calculate_required_label_counts,
+)
+from experiments.calculate_required_label_count_per_stimulus_post_2026_09_09.constants import (
+    CACHE_DIRNAME,
+    EXPERIMENT_DIRNAME,
+    LabelCountRunResult,
+    OUTPUT_S3_BUCKET,
+    REQUIRED_LABELS_PER_POST,
+    pinned_new_catalog,
+)
+from experiments.calculate_required_label_count_per_stimulus_post_2026_09_09.load import (
+    load_new_catalog,
+    load_old_catalog,
+    load_old_results,
+)
+from experiments.calculate_required_label_count_per_stimulus_post_2026_09_09.write import (
+    print_run_summary,
+    require_output_key_absent,
+    write_required_label_counts,
+)
+from lib.constants import REPO_ROOT
+
+
+def main() -> int:
+    """Count remaining labels for the old catalog and the new catalog."""
+    print_run_summary(_run_pipeline())
+    return 0
+
+
+def _run_pipeline() -> LabelCountRunResult:
+    source = pinned_new_catalog()
+    experiment_dir = _experiment_dir()
+    store = CampaignObjectStore(OUTPUT_S3_BUCKET)
+    require_output_key_absent(store)
+    old_catalog = load_old_catalog()
+    old_results = load_old_results()
+    new_catalog = load_new_catalog(source, store, experiment_dir / CACHE_DIRNAME)
+    counts = calculate_required_label_counts(
+        old_catalog, old_results, new_catalog, REQUIRED_LABELS_PER_POST
+    )
+    return write_required_label_counts(
+        counts, source, experiment_dir, store, len(old_catalog)
+    )
+
+
+def _experiment_dir() -> Path:
+    return REPO_ROOT / "experiments" / EXPERIMENT_DIRNAME
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/write.py
+++ b/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/write.py
@@ -1,0 +1,221 @@
+"""Write remaining label counts locally, upload to S3, and write RESULTS.md."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from data_platform.generate_features.s3_feature_campaign import (
+    CampaignObjectStore,
+    s3_uri,
+)
+from data_platform.utils.object_store import sha256_hex
+from experiments.calculate_required_label_count_per_stimulus_post_2026_09_09.constants import (
+    Batch,
+    CSV_INDEX,
+    DATASET_FILENAME,
+    LabelCountRunResult,
+    LocalCsvWrite,
+    NewCatalogSource,
+    OUTPUT_BATCH_COLUMN,
+    OUTPUT_COLUMNS,
+    OUTPUT_COUNT_COLUMN,
+    OUTPUT_S3_BUCKET,
+    OUTPUT_S3_KEY,
+    REQUIRED_LABELS_PER_POST,
+    RESULTS_FILENAME,
+)
+from lib.constants import REPO_ROOT
+
+CSV_ENCODING = "utf-8"
+OLD_CATALOG_DISPLAY_PATH = "shared/data/raw/study_phase_2_part_2/stimuli/flips.csv"
+RUN_COMMAND = """export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py"""
+
+
+def require_output_key_absent(store: CampaignObjectStore) -> None:
+    """Raise FileExistsError if the remaining-label S3 key already exists.
+
+    Raises
+    ------
+    FileExistsError
+        When the destination S3 key already exists.
+    """
+    if store.get(OUTPUT_S3_KEY) is not None:
+        raise FileExistsError(
+            f"Object already exists: {s3_uri(OUTPUT_S3_BUCKET, OUTPUT_S3_KEY)}"
+        )
+
+
+def write_local_csv(counts: pd.DataFrame, experiment_dir: Path) -> LocalCsvWrite:
+    """Write the remaining-label CSV under the experiment folder."""
+    body = _csv_bytes(counts)
+    path = experiment_dir / DATASET_FILENAME
+    path.write_bytes(body)
+    return LocalCsvWrite(path=path, body=body)
+
+
+def upload_csv(body: bytes, store: CampaignObjectStore) -> str:
+    """Upload CSV bytes with put_new and return the SHA-256.
+
+    Raises
+    ------
+    FileExistsError
+        When the destination S3 key already exists.
+    """
+    store.put_new(OUTPUT_S3_KEY, body)
+    return sha256_hex(body)
+
+
+def write_results_md(result: LabelCountRunResult, experiment_dir: Path) -> Path:
+    """Write RESULTS.md with remaining-label totals."""
+    path = experiment_dir / RESULTS_FILENAME
+    path.write_text(_results_markdown(result))
+    return path
+
+
+def write_required_label_counts(
+    counts: pd.DataFrame,
+    source: NewCatalogSource,
+    experiment_dir: Path,
+    store: CampaignObjectStore,
+    old_catalog_ids: int,
+) -> LabelCountRunResult:
+    """Write the local CSV, upload it once, and write RESULTS.md.
+
+    Raises
+    ------
+    FileExistsError
+        When the destination S3 key already exists.
+    """
+    local = write_local_csv(counts, experiment_dir)
+    digest = upload_csv(local.body, store)
+    result = _label_count_run_result(counts, source, local.path, digest, old_catalog_ids)
+    write_results_md(result, experiment_dir)
+    return result
+
+
+def print_run_summary(result: LabelCountRunResult) -> None:
+    """Print remaining label totals and the S3 URI."""
+    print(f"old_posts={result.old_posts}")
+    print(f"old_labels={result.old_labels}")
+    print(f"new_posts={result.new_posts}")
+    print(f"new_labels={result.new_labels}")
+    print(f"total_posts={result.total_posts}")
+    print(f"total_labels={result.total_labels}")
+    print(f"s3_uri={result.s3_uri}")
+    print(f"csv_sha256={result.csv_sha256}")
+
+
+def _csv_bytes(counts: pd.DataFrame) -> bytes:
+    ordered = counts.loc[:, list(OUTPUT_COLUMNS)]
+    return ordered.to_csv(index=CSV_INDEX).encode(CSV_ENCODING)
+
+
+def _label_count_run_result(
+    counts: pd.DataFrame,
+    source: NewCatalogSource,
+    local_path: Path,
+    digest: str,
+    old_catalog_ids: int,
+) -> LabelCountRunResult:
+    old_posts, old_labels = _batch_totals(counts, Batch.OLD)
+    new_posts, new_labels = _batch_totals(counts, Batch.NEW)
+    return LabelCountRunResult(
+        old_catalog_ids=old_catalog_ids,
+        old_posts=old_posts,
+        old_labels=old_labels,
+        new_posts=new_posts,
+        new_labels=new_labels,
+        total_posts=len(counts),
+        total_labels=int(counts[OUTPUT_COUNT_COLUMN].sum()),
+        local_path=str(local_path.relative_to(REPO_ROOT)),
+        s3_uri=s3_uri(OUTPUT_S3_BUCKET, OUTPUT_S3_KEY),
+        csv_sha256=digest,
+        new_catalog_uri=source.s3_uri,
+        new_catalog_sha256=source.sha256,
+        new_catalog_rows=source.expected_row_count,
+    )
+
+
+def _batch_totals(counts: pd.DataFrame, batch: Batch) -> tuple[int, int]:
+    rows = counts[counts[OUTPUT_BATCH_COLUMN] == batch.value]
+    return len(rows), int(rows[OUTPUT_COUNT_COLUMN].sum())
+
+
+def _results_markdown(result: LabelCountRunResult) -> str:
+    return "\n".join([*_results_preamble(result), *_results_totals(result)])
+
+
+def _results_preamble(result: LabelCountRunResult) -> list[str]:
+    return [
+        "# Calculate required label count per stimulus post, results",
+        "",
+        "## Command",
+        "",
+        "```bash",
+        RUN_COMMAND,
+        "```",
+        "",
+        "## New catalog",
+        "",
+        _new_catalog_sentence(result),
+        "",
+        "## Old catalog",
+        "",
+        _old_catalog_sentence(result),
+        "",
+    ]
+
+
+def _results_totals(result: LabelCountRunResult) -> list[str]:
+    return [
+        "## Remaining labels",
+        "",
+        _csv_table_markdown(result),
+        "",
+        _totals_table_markdown(result),
+        "",
+    ]
+
+
+def _new_catalog_sentence(result: LabelCountRunResult) -> str:
+    return (
+        f"Object `{result.new_catalog_uri}` SHA-256 `{result.new_catalog_sha256}` "
+        f"has {result.new_catalog_rows:,} rows."
+    )
+
+
+def _old_catalog_sentence(result: LabelCountRunResult) -> str:
+    return (
+        f"Catalog `{OLD_CATALOG_DISPLAY_PATH}` has {result.old_catalog_ids:,} unique ids. "
+        f"Remaining labels equal {REQUIRED_LABELS_PER_POST} minus the number of unique "
+        "`prolific_id` raters per `post_id`. Posts with 0 remaining labels are dropped, "
+        f"so the old batch has {result.old_posts:,} posts."
+    )
+
+
+def _csv_table_markdown(result: LabelCountRunResult) -> str:
+    return "\n".join(
+        [
+            "| File | Path | SHA-256 |",
+            "| ---- | ---- | ------- |",
+            f"| Local CSV | `{result.local_path}` | `{result.csv_sha256}` |",
+            f"| S3 CSV | `{result.s3_uri}` | `{result.csv_sha256}` |",
+        ]
+    )
+
+
+def _totals_table_markdown(result: LabelCountRunResult) -> str:
+    return "\n".join(
+        [
+            "| Batch | Posts | Remaining labels |",
+            "| ----- | ----: | ---------------: |",
+            f"| old | {result.old_posts} | {result.old_labels} |",
+            f"| new | {result.new_posts} | {result.new_labels} |",
+            f"| total | {result.total_posts} | {result.total_labels} |",
+        ]
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Remaining labels for the pull request 273 catalog

Closes #268.

## Summary

Issue 268 asked for remaining-label counts per stimulus post. Pull request 271 counted the 10,200-post sample from pull request 267. Pull request 273 replaced that sample with a 10,000-post catalog. This experiment redoes those counts against that catalog.

Remaining labels total 77,557. The old catalog still needs 27,557 labels on 8,899 posts, counting unique Prolific raters. The new catalog needs 50,000 labels on 10,000 posts. Posts that already have 5 or more unique raters are dropped.

## Purpose

Measure how many more labels the next study round still needs on each stimulus post after pull request 273.

The experiment is intended to identify:

- How many unique Prolific raters each old catalog post already has
- How many labels remain after targeting 5 per post
- How those remaining labels split between the old catalog and the pull request 273 catalog

## Setup

- Old catalog: `shared/data/raw/study_phase_2_part_2/stimuli/flips.csv`
- Old results: `shared/data/raw/study_phase_2_part_2/results/full.csv`
- New catalog: `s3://mirrorview-experimental-artifacts/experiments/curate_study_2_phase_3_stimuli/flips.csv` (SHA-256 `c90fdcf86e89e393f0de4cc34e1dc4e4bb2bd876405926ad654ff679f3ab4139`, 10,000 rows)
- Method: remaining labels = 5 minus unique `prolific_id` raters per old post; every new post needs 5
- Conditions: one remaining-label path (not a model comparison)
- Primary metric: total remaining labels
- Secondary metrics: remaining labels for the old batch and the new batch
- Important fixed parameters: rater is `prolific_id`; two sessions by the same Prolific account count as one rater; posts with remaining count of 0 or less are dropped; a second run fails if the output S3 key already exists

Plan: `docs/plans/2026-09-09_required_label_count_pr273_catalog_7ad7e0/`

## Flow

Stages:

- `Guard` fails if the output S3 key already exists.
- `Load` loads the old catalog and results, and downloads the pinned new catalog CSV.
- `Count` counts unique Prolific raters on each old post and gives every new post 5 remaining labels.
- `Filter` drops remaining counts of 0 or less.
- `Write` writes the local CSV, uploads with `put_new`, and records totals in RESULTS.md.

```mermaid
flowchart TD
    A[Fail if output S3 key exists] --> B[Load old catalog and results]
    C[Download pinned 10000 row catalog] --> D[Give each new post 5 remaining labels]
    B --> E[Count unique raters per old post]
    E --> F[Concatenate old and new rows]
    D --> F
    F --> G[Drop remaining count of 0 or less]
    G --> H[Write local CSV]
    H --> I[Upload CSV to S3]
    I --> J[Write RESULTS.md]
```

## Run

```bash
export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"

PYTHONPATH=. uv run python experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/run.py
```

A second run raises `FileExistsError` if the S3 object already exists.

## Results

| Batch | Posts | Remaining labels |
| ----- | ----: | ---------------: |
| old | 8899 | 27557 |
| new | 10000 | 50000 |
| total | 18899 | 77557 |

Outputs:

- Local CSV `experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/required_label_count_per_stimulus_post.csv`
- S3 CSV `s3://mirrorview-experimental-artifacts/experiments/calculate_required_label_count_per_stimulus_post_2026_09_09/required_label_count_per_stimulus_post.csv`
- SHA-256 `188d627e8972d9b1ec5eb378814fd02fd588328df0a1ffc8603b0eba63d05c91`

That digest matches the remaining-label v2 CSV from pull request 273, because both tables use the same old files and the same 10,000-row catalog. The v1 CSV from pull request 271, the v2 CSV, and the catalog object were left unchanged. A second run of this command raised `FileExistsError` before downloading the catalog.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf96ef56-9d0a-41a9-a970-b1a012e39c91?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf96ef56-9d0a-41a9-a970-b1a012e39c91&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experiment to calculate the remaining required labels for existing catalog posts and the full label requirements for new posts.
  * Added validation for catalog and study data, including identifier, count, uniqueness, and integrity checks.
  * Added CSV export, cloud upload, checksum metadata, and Markdown run summaries.
  * Added safeguards to prevent overwriting existing output files.
  * Added caching for validated catalog data to support repeatable runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->