### PR TITLE
Fix garbled em dashes in the study UI

### DIFF
--- a/webapp/public/consent.js
+++ b/webapp/public/consent.js
@@ -48,7 +48,7 @@ const consent = {
             <p>We cannot promise any benefits to you or others from your taking part in this research. However, possible benefits include the inherent interest value you may find in responding to the surveys and the value in contributing to society's understanding of the human mind.</p>
 
             <h2>Is there any way being in this study could be bad for me?</h2>
-            <p>We do not foresee any risk in participating in this study. If you choose to participate, the effects should be comparable to those you would experience from completing a task and answering questions for few minutes using a mouse and keyboard (or using your smartphone). It is possible that you might be uncomfortable answering certain questions; if that happens, you may simply leave them blank. A possible risk for any research is that confidentiality could be compromised—that people outside the study might get hold of confidential study information. We will do everything we can to minimize this risk, as described in more detail later in this form.</p>
+            <p>We do not foresee any risk in participating in this study. If you choose to participate, the effects should be comparable to those you would experience from completing a task and answering questions for few minutes using a mouse and keyboard (or using your smartphone). It is possible that you might be uncomfortable answering certain questions; if that happens, you may simply leave them blank. A possible risk for any research is that confidentiality could be compromised, and that people outside the study might get hold of confidential study information. We will do everything we can to minimize this risk, as described in more detail later in this form.</p>
 
             <h2>What happens if I do not want to be in this research, or I change my mind later?</h2>
             <p>Participation in this research is voluntary. You may decide to participate or not to participate. If you do not want to be in this study or withdraw from the study at any point, your decision will not affect your compensation or relationship with Northwestern University in any way. You can leave the research at any time and it will not be held against you.</p>
@@ -71,7 +71,7 @@ const consent = {
 
             <h2>Who can I talk to?</h2>
             <p>If you have questions, concerns, or complaints, you can contact the Principal Investigator, William Brady, at william.brady@kellogg.northwestern.edu (or, if email doesn't work for you, via phone at 704-904-6420.</p>
-            <p>This research has been reviewed and approved by an Institutional Review Board ("IRB") – an IRB is a committee that protects the rights of people who participate in research studies. You may contact the IRB by phone at (312) 503-9338 or by email at irb@northwestern.edu if:</p>
+            <p>This research has been reviewed and approved by an Institutional Review Board ("IRB"). An IRB is a committee that protects the rights of people who participate in research studies. You may contact the IRB by phone at (312) 503-9338 or by email at irb@northwestern.edu if:</p>
             <ul>
                 <li>Your questions, concerns, or complaints are not being answered by the research team.</li>
                 <li>You cannot reach the research team.</li>

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta charset="utf-8">
     <title>MirrorView</title>
     
     <!-- jsPsych core -->
@@ -27,10 +28,10 @@
     <script src="config.js"></script>
     
     <!-- Consent form -->
-    <script src="consent.js"></script>
+    <script src="consent.js?v=20260910a"></script>
     
     <!-- Pre-surveys (political affiliation) -->
-    <script src="pre_surveys.js"></script>
+    <script src="pre_surveys.js?v=20260910a"></script>
 
     <!-- Post-surveys (ideology) -->
     <script src="post_surveys.js"></script>

--- a/webapp/public/pre_surveys.js
+++ b/webapp/public/pre_surveys.js
@@ -136,8 +136,8 @@ const politicalExpressionAttentionCheck = {
             <h1 style="margin: 0 0 16px; font-size: 28px; color: #3d1c63; font-weight: 700;">Political Expression</h1>
             <div style="background: #f3f4f6; border-left: 5px solid #5b2d8e; padding: 14px 16px; margin-bottom: 22px; color: #4b5563; line-height: 1.5; font-size: 15px;">
                 The next section is about expressing political views on social media.
-                By political expression, we mean any sort of public display of your political opinions —
-                this includes posts, reposts, and comments.
+                By political expression, we mean any sort of public display of your political opinions.
+                This includes posts, reposts, and comments.
             </div>
             <p style="font-size: 16px; line-height: 1.55; margin: 0 0 18px; color: #1f2937;">
                 To make sure we are on the same page, select the messages expressing a political view.


### PR DESCRIPTION
## Summary
- Declare UTF-8 in `index.html` so S3 website hosting does not decode survey copy as Windows-1252.
- Replace participant-facing em/en dashes in Political Expression and consent with plain punctuation.
- Cache-bust `consent.js` and `pre_surveys.js` so browsers pick up the new copy.

## Test plan
- [x] Uploaded `webapp/public/` to `jspsych-mirror-view-2026-09-09` and confirmed live `index.html` has `<meta charset="utf-8">`.
- [ ] Hard-refresh the study URL and confirm Political Expression shows a period, not `â€"`.
- [ ] Confirm the consent confidentiality and IRB sentences also read cleanly.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified consent-form language describing confidentiality risks and the role of the review board.
  - Improved readability of political-expression survey instructions while preserving their scope, including posts, reposts, and comments.

- **Compatibility**
  - Added explicit UTF-8 character encoding support to improve display of text and punctuation across browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->