### PR TITLE
MirrorView decision-making experiments

### DIFF
--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/plan.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/plan.md
@@ -1,0 +1,150 @@
+# Predict September 2026 keep/remove choices with four prompt variants and four models
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Delegated tasks must be impossible to misread.
+
+## Overview
+
+Issue 290 asks whether language models can match the keep/remove choices that September 2026 MirrorView participants made on 20 linked-fate post pairs. The live study is `mirrorview_2026_09_09` in bucket `jspsych-mirror-view-2026-09-09`. The work lives under `experiments/ai_simulation_responses_2026_09_11/`. Four prompt variants share one cohort and one runner. They also share one output schema. A fifth folder only scores errors on those labels. No full model run starts until a smoke cost table is approved. Experiment 2 also waits on prompt-template approval.
+
+## Happy flow
+
+An operator downloads Prolific CSVs from the September bucket. The operator then confirms up to 1,000 complete participants in earliest-upload order and writes one shared cohort. Next the operator smokes 10 users on four models, writes a cost table, and stops. After approval, four parallel Cursor Grok High subagents label the full cohort for experiments 1 through 4. A later command ranks posts and users with the highest error rates from those labels.
+
+```mermaid
+flowchart TD
+    A[Download September Prolific CSVs] --> B[Confirm up to 1000 complete users]
+    B --> C[Write shared cohort parquet]
+    C --> D[Smoke 10 users on 4 models]
+    D --> E[Write cost tables and experiment 2 prompt]
+    E --> F{User approves cost and experiment 2 prompt}
+    F -->|no| STOP[Stop]
+    F -->|yes| G1[Experiment 1 four models]
+    F -->|yes| G2[Experiment 2 four models]
+    F -->|yes| G3[Experiment 3 four models]
+    F -->|yes| G4[Experiment 4 four models]
+    G1 --> H[Score experiments 1 to 4]
+    G2 --> H
+    G3 --> H
+    G4 --> H
+    H --> I[Experiment 5 error analysis]
+    I --> J[Write RESULTS.md files]
+```
+
+## Approach
+
+Reuse the OpenAI Batch engine and the Bedrock Converse helpers that the original-versus-mirror separability experiment already uses. Do not copy those engines four times. One shared runner takes an experiment number and a model name. Experiments 1 through 4 only change the extra context block in the user prompt. Keep gold labels and predictions as separate parquet objects. Treat the four prompt variants as prompt ablations on the same people, not as a causal test of demographics or reflection. Report user-level means and post-level scores separately, because those two aggregations are not the same number. Simplicity and persona notes are in `reviews.md`.
+
+## Decisions
+
+- Create `experiments/ai_simulation_responses_2026_09_11/` with `shared/` plus `experiment1` through `experiment5`. Shared code lives in `shared/`. Each experiment folder has `README.md`, `SETUP.md`, `RESULTS.md`, and `outputs/{openai,bedrock_micro_nova,bedrock_qwen,bedrock_claude}/`. Experiment 5 has no model outputs.
+- Parent `experiments/ai_simulation_responses_2026_09_11/README.md` is two sentences that name issue 290 and point at each experiment folder. Each experiment README is one or two sentences for the ablation question, then a redirect to that folder's `SETUP.md` and `RESULTS.md`. Start every README with the agent read-only banner from `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md`.
+- Do not use `shared/data/raw/study_phase_2_part_2/`. The September run is not in the registry yet. Download from `s3://jspsych-mirror-view-2026-09-09/data/prolific/` using the list, download, and filter helpers in `scripts/export_study_results.py`, with `--since-date 2026-09-09`. Keep the S3 filename epoch on every user. Do not sort by assignment-sheet `created_at`.
+- A complete user has exactly 20 Phase 1 rows with `evaluation_mode` equal to `linked_fate` and `decision` in `{keep, remove}`, plus a non-empty `phase1_pair_reflection_text` and a 1 to 7 `phase1_pair_influence_rating`. Sort unique `prolific_id` values by the earliest matching `data_<epoch_ms>_*.csv` filename, then take the first 1,000. If fewer than 1,000 complete users exist, take all of them and record the count. The issue's "1,000 rows" means 1,000 participants, not 1,000 trial rows. `scripts/export_study_results.py` currently expects 190 files, so the live count may be under 1,000.
+- Write `cohort_users.parquet` and `cohort_trials.parquet` once with `CampaignObjectStore.put_new` to `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/shared/`. A second upload of either key must raise `FileExistsError` before any model is called. Local copies may exist under `experiments/ai_simulation_responses_2026_09_11/shared/` and must stay out of git.
+- Pair presentation follows the stored `pair_order` on that trial, so Post 1 and Post 2 match what that participant saw. Do not reshuffle. If `pair_order` is missing or is not a two-item list of `original` and `mirror`, drop the user from the cohort and count the drop. Pair numbers are 1-indexed in the order of those 20 trials after sorting by `trial_index`.
+- Gold label is 1 when `decision` is `remove` and 0 when `decision` is `keep`. The model returns a list of 1-indexed pair numbers to remove. Expand that list into 20 binary predictions. An empty list means keep all 20. A duplicate index, a value outside 1 to 20, or a parse failure sends the user to `errors.jsonl` and excludes that user from scoring for that model.
+- Shared Pydantic output schema: one field, a list of integers named `remove_pair_indexes`. Persist a row model with `source_record_id`, `label_timestamp`, and that list. `source_record_id` is `prolific_id`.
+- Instruction text is the training_assisted copy in `webapp/public/main.js` (the paragraph that starts "We are developing a new social media platform" and the political-mirror example). The task change from the website is that the model sees all 20 pairs at once and returns remove indexes instead of clicking Allow Both or Remove Both on each trial. State in every `SETUP.md` that humans judged one pair at a time and the model sees the full set in one prompt. Do not spend 20 calls per user to make the model judge one pair at a time.
+- Experiment 1 user prompt is only the 20 pairs. Experiment 2 prepends every exported demographic and attitude field that is non-empty for that user. Experiment 3 prepends the exact reflection question from `webapp/public/main.js` plus the written answer and the 1 to 7 influence rating. Experiment 4 concatenates the experiment 2 block, then the experiment 3 block, then the pairs. Language, employment, and social-media items are collected in `webapp/public/post_surveys.js` but are not in `columnsToKeep` in `webapp/public/main.js`, so they are unavailable. Do not invent them.
+- Demographic fields to render when present, with the survey wording as the label: `age`, `gender`, `education`, `political_affiliation`, `party_lean`, `party_group`, `political_ideology`, `political_follow`, `rep_id`, `dem_id`, `attitude_reduce_abortion`, `attitude_citizenship_undocumented`, `attitude_restrict_guns`, `attitude_regulate_environment`, `attitude_raise_wealth_taxes`, `attitude_expand_medicaid`. Likert items keep the 1 to 7 anchors from `webapp/public/post_surveys.js`. Attitude sliders are 0 to 100.
+- Experiment 2 prompt template must be printed by `--print-experiment-2-prompt` and written into `experiments/ai_simulation_responses_2026_09_11/experiment2/SETUP.md` before any experiment 2 model call. Full labeling of experiment 2 waits on explicit approval of that template.
+- Models, in output-folder order:
+  - `openai`: OpenAI Batch, `gpt-5.4-nano` (`DEFAULT_LLM_MODEL`), through `build_openai_engine`
+  - `bedrock_micro_nova`: Bedrock Converse, `us.amazon.nova-micro-v1:0`, through `label_tasks_collecting_failures`
+  - `bedrock_qwen`: Bedrock Converse, `qwen.qwen3-32b-v1:0` from `experiments/predict_keep_remove_2026_07_01/models/llm_finetuning/api_baselines/constants.py`
+  - `bedrock_claude`: Bedrock Converse, `us.anthropic.claude-sonnet-4-6` (`DEFAULT_BEDROCK_SONNET_MODEL`), the flips model
+- Do not call `build_bedrock_engine` for Qwen or Claude, because that factory hardcodes Nova Micro. Do not call `generate_campaign_feature`, because the Reddit campaign retries Bedrock content-filter failures through OpenAI. Raise Bedrock `max_tokens` to 256 on this experiment's Converse calls only, the same override the separability experiment used. Concurrency for Bedrock is `BEDROCK_CAMPAIGN_MAX_CONCURRENCY` (8). OpenAI Batch part size is `CAMPAIGN_BATCH_SIZE` (2000), so 1,000 users become one part per model.
+- Label layout matches campaign feature generation, under `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment{N}/outputs/{model}/`: `batches/part-NNNNN.parquet`, `manifest.json`, `progress.jsonl`, `errors.jsonl`, `final.parquet`, plus `active_openai_batch.json` or `active_bedrock_job.json` while a job is open. Smoke writes under that model's `smoke/` prefix and must not copy rows into `final.parquet`. Resume by skipping parts already in the manifest. If `final.parquet` exists, the command returns without labeling.
+- Pricing constants for the cost table, in USD per million tokens. OpenAI Batch: 0.10 input, 0.625 output, from `data_platform/generate_features/campaign_cost_report.py`. Nova Micro on-demand: 0.035 input, 0.14 output, from the same file. Qwen3 32B on-demand in `us-east-2`: 0.15 input, 0.60 output, from the Bedrock price list. Claude Sonnet 4.6 on-demand: 3.00 input, 15.00 output, from the Bedrock Marketplace listing. Record those source URLs in `COST_ESTIMATE.md`. Smoke 10 users (or the full cohort if smaller) on all four models using the experiment 1 prompt. Estimate experiments 2 to 4 by scaling experiment 1 mean input tokens by the ratio of rendered prompt character counts. Keep output tokens at the experiment 1 smoke mean. Median cost is smoke-median tokens times user count times the rates. Low is 0.5 times median. High is 2 times median. Experiment 5 is 0. Stop after writing the tables. Do not start full labeling in the same command.
+- Cost table columns, exactly: model, estimated tokens in, estimated tokens out, median estimated cost, low/high estimated cost. One section per experiment 1 to 4, then a total section. Write `experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md` and print it to stdout.
+- Scoring uses scikit-learn with `zero_division=0`, matching `experiments/finetune_qwen_model_2026_08_08/evaluate.py`. Positive class is remove. User-level scores are precision, recall, F1, and accuracy on that user's 20 pairs, then the mean of those user scores. Post-level scores are the same four metrics on all user-pair rows pooled, plus the baseline remove rate. Party tables repeat user-level scores inside `party_group` `democrat` and `republican`. Toxicity tables repeat post-level scores inside `sample_low_toxicity`, `sample_middle_toxicity`, and `sample_high_toxicity`. Stance tables repeat post-level scores inside `sampled_stance` `left` and `right`. Each table names the scored-row count and the error-row count. Do not add significance tests.
+- Experiment 5 uses existing labels and existing post and user fields only. Rank posts by false-negative rate across models and experiments 1 to 4 (model said keep, gold is remove) and take the top 75. Rank posts by false-positive rate (model said remove, gold is keep) and take the top 75. The issue's second clause repeats the false-negative wording. Complementary errors are the useful split, so use 75 false negatives and 75 false positives. Compare toxicity and stance shares in that set of 150 against the rest of the cohort posts. Rank users by mean user-level F1 across models and experiments 1 to 4, lowest first, and take 100. Describe those users with `party_group`, `political_ideology`, `age`, `education`, and mean gold remove rate. Within-user variance is the variance of per-pair correctness on experiment 1. Report summary statistics of that variance across users, one row per model. Across-model variance is the standard deviation of the four models' experiment 1 remove predictions on each user-pair. Report summary statistics of those standard deviations.
+- After cost approval, launch four Cursor Grok High subagents in parallel, one per experiment 1 to 4. Each subagent runs all four models for its experiment and does not score. Scoring is Step 4. Experiment 5 starts only when all 16 `final.parquet` objects exist. Do not implement a plugin registry, a prompt-strategy interface, or a second schema.
+- Pytest lives under `experiments/ai_simulation_responses_2026_09_11/shared/tests/` and must not call OpenAI, Bedrock, or S3. Cover cohort completeness, pair-order rendering, 1-indexed expansion, and the metric tables. The usual "experiments skip pytest" line in `UNIT_TESTING_STANDARDS.md` does not apply, because a 0-based index bug would invalidate every score.
+- Do not edit `data_platform/`, `webapp/`, `scripts/export_study_results.py`, `lib/constants.py`, `shared/flip_generation/`, or files under repo-root `tests/`. Do not upload to the study website bucket. `CHANGELOG.md` waits until a live full run has `RESULTS.md` files.
+
+## Steps
+
+### Step 1: Add the shared cohort, prompts, schema, runner, and tests
+
+Add the folder layout and confirm the September cohort. Implement prompt rendering, the output schema, the four model runners, and the scorer. Upload the cohort parquet. Do not call OpenAI or Bedrock. See [steps/step1.md](steps/step1.md).
+
+### Step 2: Smoke 10 users, write the cost table, and print the experiment 2 prompt
+
+Run a 10-user smoke on all four models with the experiment 1 prompt. Scale token estimates to experiments 2 to 4. Write `COST_ESTIMATE.md` and print the experiment 2 template with one filled example. Stop for approval. See [steps/step2.md](steps/step2.md).
+
+### Step 3: Label the full cohort for experiments 1 through 4
+
+After explicit approval of the cost table and the experiment 2 template, run four parallel Cursor Grok High subagents. Each subagent labels all four models for one experiment into campaign parquet parts. See [steps/step3.md](steps/step3.md).
+
+### Step 4: Score experiments 1 through 4
+
+Join each `final.parquet` to the cohort gold labels. Write the user-level, post-level, party, toxicity, and stance tables into each experiment's `RESULTS.md`. See [steps/step4.md](steps/step4.md).
+
+### Step 5: Analyze error-rate ranks and prediction variance
+
+Read the 16 final parquets. Write the 75 plus 75 post lists, the 100-user list, within-user variance, and across-model variance into `experiments/ai_simulation_responses_2026_09_11/experiment5/RESULTS.md`. See [steps/step5.md](steps/step5.md).
+
+## What "done" looks like
+
+1. `experiments/ai_simulation_responses_2026_09_11/` has `shared/`, five experiment folders, parent `README.md`, and `COST_ESTIMATE.md` after Step 2.
+2. Cohort parquet exists on S3 and has at most 1,000 users, each with 20 gold pairs, stored pair order, and a reflection. A second cohort upload fails.
+3. Step 2 wrote a cost table in the issue's column layout, smoked 10 users (or fewer) on four models, and printed the experiment 2 prompt. Full labeling did not run in Step 2.
+4. After approval, each of experiments 1 to 4 has four `final.parquet` files, one per model, plus smoke objects that are separate from those finals.
+5. Each of experiments 1 to 4 has `RESULTS.md` with user-level means, post-level scores including baseline remove rate, party tables, toxicity tables, and stance tables.
+6. Experiment 5 `RESULTS.md` has the 150-post error set, the 100-user set, within-user variance, and across-model variance, using only existing fields.
+7. `PYTHONPATH=. uv run pytest experiments/ai_simulation_responses_2026_09_11/shared/tests -q` exits 0. Product engines, the website, and the September study bucket objects are unchanged.
+
+## Commands
+
+Run from the repo root. Export AWS keys from `LAB_AWS_ACCESS_KEY_ID` and `LAB_AWS_ACCESS_KEY_SECRET`. Set `OPENAI_API_KEY` before any OpenAI command.
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run pytest experiments/ai_simulation_responses_2026_09_11/shared/tests -q
+```
+
+Expected: exit 0.
+
+```bash
+PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/shared/run.py --write-cohort
+```
+
+Expected stdout includes `user_count=` (at most 1000), `trial_rows=` (20 times user count), the two S3 URIs, and both SHA-256 values. A second run exits non-zero because the cohort keys exist.
+
+```bash
+PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/shared/run.py --smoke
+PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/shared/run.py --print-experiment-2-prompt
+PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/shared/run.py --estimate-cost
+```
+
+Each smoke writes 10 labels (or the cohort size if smaller) under each model's `experiment1/outputs/{model}/smoke/` prefix and prints `labeled N of N`. `--estimate-cost` writes `COST_ESTIMATE.md` and prints the four experiment sections plus the total. `--print-experiment-2-prompt` prints the template and one filled user. Full labeling must not start.
+
+After written approval of the cost table and the experiment 2 prompt, one subagent per experiment runs the four `--model` commands. Scoring is a later command.
+
+```bash
+PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/experiment1/run.py --model openai
+PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/experiment1/run.py --model bedrock_micro_nova
+PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/experiment1/run.py --model bedrock_qwen
+PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/experiment1/run.py --model bedrock_claude
+```
+
+Replace `experiment1` with `experiment2`, `experiment3`, or `experiment4`. Each label command prints `labeled N` or a scored-count plus failed-count line.
+
+```bash
+PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/experiment1/run.py --score
+```
+
+Replace `experiment1` the same way. `--score` writes that experiment's `RESULTS.md`.
+
+```bash
+PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/experiment5/run.py --analyze-errors
+```
+
+Expected: writes `experiment5/RESULTS.md` and prints the 75, 75, and 100 counts.

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/plan.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/plan.md
@@ -8,18 +8,18 @@
 
 ## Overview
 
-Issue 290 asks whether language models can match the keep/remove choices that September 2026 MirrorView participants made on 20 linked-fate post pairs. The live study is `mirrorview_2026_09_09` in bucket `jspsych-mirror-view-2026-09-09`. The work lives under `experiments/ai_simulation_responses_2026_09_11/`. Four prompt variants share one cohort and one runner. They also share one output schema. A fifth folder only scores errors on those labels. No full model run starts until a smoke cost table is approved. Experiment 2 also waits on prompt-template approval.
+Issue 290 asks whether language models can match the keep/remove choices that September 2026 MirrorView participants made on 20 linked-fate post pairs. The live study is `mirrorview_2026_09_09` in bucket `jspsych-mirror-view-2026-09-09`. The work lives under `experiments/ai_simulation_responses_2026_09_11/`, and every derived file is also stored on S3 at that same path in bucket `mirrorview-experimental-artifacts`. Four prompt variants share one cohort and one runner. They also share one output schema. A fifth folder only scores errors on those labels. No full model run starts until a smoke cost table is approved. Experiment 2 also waits on prompt-template approval.
 
 ## Happy flow
 
-An operator downloads Prolific CSVs from the September bucket. The operator then confirms up to 1,000 complete participants in earliest-upload order and writes one shared cohort. Next the operator smokes 10 users on four models, writes a cost table, and stops. After approval, four parallel Cursor Grok High subagents label the full cohort for experiments 1 through 4. A later command ranks posts and users with the highest error rates from those labels.
+An operator downloads Prolific CSVs from the September bucket. The operator then confirms up to 1,000 complete participants in earliest-upload order and writes one shared cohort locally and on S3. Next the operator smokes 10 users on four models and writes a cost table at the same local path and S3 key. The operator then stops. After approval, four parallel Cursor Grok High subagents label the full cohort for experiments 1 through 4. A later command ranks 75 false-negative posts, 75 false-positive posts, and 100 lowest-F1 users, then uploads those lists to S3.
 
 ```mermaid
 flowchart TD
     A[Download September Prolific CSVs] --> B[Confirm up to 1000 complete users]
-    B --> C[Write shared cohort parquet]
+    B --> C[Write shared cohort parquet locally and on S3]
     C --> D[Smoke 10 users on 4 models]
-    D --> E[Write cost tables and experiment 2 prompt]
+    D --> E[Write COST_ESTIMATE.md locally and on S3]
     E --> F{User approves cost and experiment 2 prompt}
     F -->|no| STOP[Stop]
     F -->|yes| G1[Experiment 1 four models]
@@ -31,20 +31,21 @@ flowchart TD
     G3 --> H
     G4 --> H
     H --> I[Experiment 5 error analysis]
-    I --> J[Write RESULTS.md files]
+    I --> J[Write RESULTS.md and ranked CSVs locally and on S3]
 ```
 
 ## Approach
 
-Reuse the OpenAI Batch engine and the Bedrock Converse helpers that the original-versus-mirror separability experiment already uses. Do not copy those engines four times. One shared runner takes an experiment number and a model name. Experiments 1 through 4 only change the extra context block in the user prompt. Keep gold labels and predictions as separate parquet objects. Treat the four prompt variants as prompt ablations on the same people, not as a causal test of demographics or reflection. Report user-level means and post-level scores separately, because those two aggregations are not the same number. Simplicity and persona notes are in `reviews.md`.
+Reuse the OpenAI Batch engine and the Bedrock Converse helpers that the original-versus-mirror separability experiment already uses. Do not copy those engines four times. One shared runner takes an experiment number and a model name. Experiments 1 through 4 only change the extra context block in the user prompt. Keep gold labels and predictions as separate parquet objects. Store every derived file in bucket `mirrorview-experimental-artifacts` with an object key that equals the local path, matching the other September 2026 experiments. Treat the four prompt variants as prompt ablations on the same people, not as a causal test of demographics or reflection. Report user-level means and post-level scores separately, because those two aggregations are not the same number. Simplicity and persona notes are in `reviews.md`.
 
 ## Decisions
 
-- Create `experiments/ai_simulation_responses_2026_09_11/` with `shared/` plus `experiment1` through `experiment5`. Shared code lives in `shared/`. Each experiment folder has `README.md`, `SETUP.md`, `RESULTS.md`, and `outputs/{openai,bedrock_micro_nova,bedrock_qwen,bedrock_claude}/`. Experiment 5 has no model outputs.
+- Create `experiments/ai_simulation_responses_2026_09_11/` with `shared/` plus `experiment1` through `experiment5`. Shared code lives in `shared/`. Each of experiments 1 to 4 has `README.md`, `SETUP.md`, `RESULTS.md`, and `outputs/{openai,bedrock_micro_nova,bedrock_qwen,bedrock_claude}/`. Experiment 5 has no model labels. Experiment 5 does have ranked CSVs under `experiment5/outputs/`.
+- Store every derived file on S3 as well as locally. The bucket is `mirrorview-experimental-artifacts`. The object key equals the repo-relative path. `experiments/generate_study_user_assignments_2026_09_08` and `experiments/test_separability_original_mirror_posts_2026_09_09` already use that mapping. Do not copy the older finetune prefix `mirrorview-finetune_qwen_model_2026_08_08/`. Upload with `CampaignObjectStore.put_new`. A second upload of the same key raises `FileExistsError`. Python, tests, `README.md`, and `SETUP.md` stay in git only, because later steps still edit SETUP. Derived parquet, campaign label objects, `COST_ESTIMATE.md`, each `RESULTS.md`, and the experiment 5 ranked CSVs are required on S3. Do not upload to the study website bucket `jspsych-mirror-view-2026-09-09`.
 - Parent `experiments/ai_simulation_responses_2026_09_11/README.md` is two sentences that name issue 290 and point at each experiment folder. Each experiment README is one or two sentences for the ablation question, then a redirect to that folder's `SETUP.md` and `RESULTS.md`. Start every README with the agent read-only banner from `experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md`.
 - Do not use `shared/data/raw/study_phase_2_part_2/`. The September run is not in the registry yet. Download from `s3://jspsych-mirror-view-2026-09-09/data/prolific/` using the list, download, and filter helpers in `scripts/export_study_results.py`, with `--since-date 2026-09-09`. Keep the S3 filename epoch on every user. Do not sort by assignment-sheet `created_at`.
-- A complete user has exactly 20 Phase 1 rows with `evaluation_mode` equal to `linked_fate` and `decision` in `{keep, remove}`, plus a non-empty `phase1_pair_reflection_text` and a 1 to 7 `phase1_pair_influence_rating`. Sort unique `prolific_id` values by the earliest matching `data_<epoch_ms>_*.csv` filename, then take the first 1,000. If fewer than 1,000 complete users exist, take all of them and record the count. The issue's "1,000 rows" means 1,000 participants, not 1,000 trial rows. `scripts/export_study_results.py` currently expects 190 files, so the live count may be under 1,000.
-- Write `cohort_users.parquet` and `cohort_trials.parquet` once with `CampaignObjectStore.put_new` to `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/shared/`. A second upload of either key must raise `FileExistsError` before any model is called. Local copies may exist under `experiments/ai_simulation_responses_2026_09_11/shared/` and must stay out of git.
+- A complete user has exactly 20 Phase 1 rows with `evaluation_mode` equal to `linked_fate` and `decision` in `{keep, remove}`, plus a non-empty `phase1_pair_reflection_text` and a 1 to 7 `phase1_pair_influence_rating`. Sort unique `prolific_id` values by the earliest matching `data_<epoch_ms>_*.csv` filename, then take the first 1,000. The target is 1,000 complete participants, not 1,000 trial rows. If fewer than 1,000 complete users exist, take all of them and record the count. `scripts/export_study_results.py` currently expects 190 files, so the live count may be under 1,000.
+- Write `cohort_users.parquet` and `cohort_trials.parquet` once, locally and with `CampaignObjectStore.put_new`, at `experiments/ai_simulation_responses_2026_09_11/shared/{cohort_users,cohort_trials}.parquet`. The matching S3 objects are `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/shared/{cohort_users,cohort_trials}.parquet`. A second upload of either key must raise `FileExistsError` before any model is called. Local parquet stays out of git.
 - Pair presentation follows the stored `pair_order` on that trial, so Post 1 and Post 2 match what that participant saw. Do not reshuffle. If `pair_order` is missing or is not a two-item list of `original` and `mirror`, drop the user from the cohort and count the drop. Pair numbers are 1-indexed in the order of those 20 trials after sorting by `trial_index`.
 - Gold label is 1 when `decision` is `remove` and 0 when `decision` is `keep`. The model returns a list of 1-indexed pair numbers to remove. Expand that list into 20 binary predictions. An empty list means keep all 20. A duplicate index, a value outside 1 to 20, or a parse failure sends the user to `errors.jsonl` and excludes that user from scoring for that model.
 - Shared Pydantic output schema: one field, a list of integers named `remove_pair_indexes`. Persist a row model with `source_record_id`, `label_timestamp`, and that list. `source_record_id` is `prolific_id`.
@@ -58,24 +59,42 @@ Reuse the OpenAI Batch engine and the Bedrock Converse helpers that the original
   - `bedrock_qwen`: Bedrock Converse, `qwen.qwen3-32b-v1:0` from `experiments/predict_keep_remove_2026_07_01/models/llm_finetuning/api_baselines/constants.py`
   - `bedrock_claude`: Bedrock Converse, `us.anthropic.claude-sonnet-4-6` (`DEFAULT_BEDROCK_SONNET_MODEL`), the flips model
 - Do not call `build_bedrock_engine` for Qwen or Claude, because that factory hardcodes Nova Micro. Do not call `generate_campaign_feature`, because the Reddit campaign retries Bedrock content-filter failures through OpenAI. Raise Bedrock `max_tokens` to 256 on this experiment's Converse calls only, the same override the separability experiment used. Concurrency for Bedrock is `BEDROCK_CAMPAIGN_MAX_CONCURRENCY` (8). OpenAI Batch part size is `CAMPAIGN_BATCH_SIZE` (2000), so 1,000 users become one part per model.
-- Label layout matches campaign feature generation, under `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment{N}/outputs/{model}/`: `batches/part-NNNNN.parquet`, `manifest.json`, `progress.jsonl`, `errors.jsonl`, `final.parquet`, plus `active_openai_batch.json` or `active_bedrock_job.json` while a job is open. Smoke writes under that model's `smoke/` prefix and must not copy rows into `final.parquet`. Resume by skipping parts already in the manifest. If `final.parquet` exists, the command returns without labeling.
+- Label layout matches campaign feature generation. The S3 key and the local relative path are the same string: `experiments/ai_simulation_responses_2026_09_11/experiment{N}/outputs/{model}/` plus `batches/part-NNNNN.parquet`, `manifest.json`, `progress.jsonl`, `errors.jsonl`, `final.parquet`, plus `active_openai_batch.json` or `active_bedrock_job.json` while a job is open. Smoke writes under that model's `smoke/` prefix and must not copy rows into `final.parquet`. Resume by skipping parts already in the manifest. If `final.parquet` exists, the command returns without labeling. Campaign helpers already write those objects to S3. A local cache under the same relative path is allowed and gitignored.
 - Pricing constants for the cost table, in USD per million tokens. OpenAI Batch: 0.10 input, 0.625 output, from `data_platform/generate_features/campaign_cost_report.py`. Nova Micro on-demand: 0.035 input, 0.14 output, from the same file. Qwen3 32B on-demand in `us-east-2`: 0.15 input, 0.60 output, from the Bedrock price list. Claude Sonnet 4.6 on-demand: 3.00 input, 15.00 output, from the Bedrock Marketplace listing. Record those source URLs in `COST_ESTIMATE.md`. Smoke 10 users (or the full cohort if smaller) on all four models using the experiment 1 prompt. Estimate experiments 2 to 4 by scaling experiment 1 mean input tokens by the ratio of rendered prompt character counts. Keep output tokens at the experiment 1 smoke mean. Median cost is smoke-median tokens times user count times the rates. Low is 0.5 times median. High is 2 times median. Experiment 5 is 0. Stop after writing the tables. Do not start full labeling in the same command.
-- Cost table columns, exactly: model, estimated tokens in, estimated tokens out, median estimated cost, low/high estimated cost. One section per experiment 1 to 4, then a total section. Write `experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md` and print it to stdout.
+- Cost table columns, exactly: model, estimated tokens in, estimated tokens out, median estimated cost, low/high estimated cost. One section per experiment 1 to 4, then a total section. Write `experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md` locally and upload it with `put_new` to `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md`. Print the file to stdout. A second cost upload raises `FileExistsError`.
 - Scoring uses scikit-learn with `zero_division=0`, matching `experiments/finetune_qwen_model_2026_08_08/evaluate.py`. Positive class is remove. User-level scores are precision, recall, F1, and accuracy on that user's 20 pairs, then the mean of those user scores. Post-level scores are the same four metrics on all user-pair rows pooled, plus the baseline remove rate. Party tables repeat user-level scores inside `party_group` `democrat` and `republican`. Toxicity tables repeat post-level scores inside `sample_low_toxicity`, `sample_middle_toxicity`, and `sample_high_toxicity`. Stance tables repeat post-level scores inside `sampled_stance` `left` and `right`. Each table names the scored-row count and the error-row count. Do not add significance tests.
-- Experiment 5 uses existing labels and existing post and user fields only. Rank posts by false-negative rate across models and experiments 1 to 4 (model said keep, gold is remove) and take the top 75. Rank posts by false-positive rate (model said remove, gold is keep) and take the top 75. The issue's second clause repeats the false-negative wording. Complementary errors are the useful split, so use 75 false negatives and 75 false positives. Compare toxicity and stance shares in that set of 150 against the rest of the cohort posts. Rank users by mean user-level F1 across models and experiments 1 to 4, lowest first, and take 100. Describe those users with `party_group`, `political_ideology`, `age`, `education`, and mean gold remove rate. Within-user variance is the variance of per-pair correctness on experiment 1. Report summary statistics of that variance across users, one row per model. Across-model variance is the standard deviation of the four models' experiment 1 remove predictions on each user-pair. Report summary statistics of those standard deviations.
+- Experiment 5 uses existing labels and existing post and user fields only. Rank posts by false-negative rate across models and experiments 1 to 4 (model said keep, gold is remove) and take the top 75. Rank posts by false-positive rate (model said remove, gold is keep) and take the top 75. Complementary errors are the split, so the 150-post set is 75 false negatives plus 75 false positives. Compare toxicity and stance shares in that set of 150 against the rest of the cohort posts. Rank users by mean user-level F1 across models and experiments 1 to 4, lowest first, and take 100. Describe those users with `party_group`, `political_ideology`, `age`, `education`, and mean gold remove rate. Within-user variance is the variance of per-pair correctness on experiment 1. Report summary statistics of that variance across users, one row per model. Across-model variance is the standard deviation of the four models' experiment 1 remove predictions on each user-pair. Report summary statistics of those standard deviations. Required ranked files, local and on S3, are `experiment5/outputs/false_negative_posts.csv`, `experiment5/outputs/false_positive_posts.csv`, and `experiment5/outputs/lowest_f1_users.csv`. `experiment5/RESULTS.md` is also required locally and on S3.
 - After cost approval, launch four Cursor Grok High subagents in parallel, one per experiment 1 to 4. Each subagent runs all four models for its experiment and does not score. Scoring is Step 4. Experiment 5 starts only when all 16 `final.parquet` objects exist. Do not implement a plugin registry, a prompt-strategy interface, or a second schema.
-- Pytest lives under `experiments/ai_simulation_responses_2026_09_11/shared/tests/` and must not call OpenAI, Bedrock, or S3. Cover cohort completeness, pair-order rendering, 1-indexed expansion, and the metric tables. The usual "experiments skip pytest" line in `UNIT_TESTING_STANDARDS.md` does not apply, because a 0-based index bug would invalidate every score.
+- Pytest lives under `experiments/ai_simulation_responses_2026_09_11/shared/tests/` and must not call OpenAI, Bedrock, or S3. Cover cohort completeness, pair-order rendering, 1-indexed expansion, the metric tables, and the mirrored S3 key helper. The usual "experiments skip pytest" line in `UNIT_TESTING_STANDARDS.md` does not apply, because a 0-based index bug would invalidate every score.
 - Do not edit `data_platform/`, `webapp/`, `scripts/export_study_results.py`, `lib/constants.py`, `shared/flip_generation/`, or files under repo-root `tests/`. Do not upload to the study website bucket. `CHANGELOG.md` waits until a live full run has `RESULTS.md` files.
+
+## Artifact paths
+
+Bucket `mirrorview-experimental-artifacts`. The object key equals the path under the repo root. Export `LAB_AWS_ACCESS_KEY_ID` and `LAB_AWS_ACCESS_KEY_SECRET` as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` before any write, the same way the other experiments do.
+
+| Local path | S3 URI |
+| --- | --- |
+| `experiments/ai_simulation_responses_2026_09_11/shared/cohort_users.parquet` | `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/shared/cohort_users.parquet` |
+| `experiments/ai_simulation_responses_2026_09_11/shared/cohort_trials.parquet` | `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/shared/cohort_trials.parquet` |
+| `experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md` | `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md` |
+| `experiments/ai_simulation_responses_2026_09_11/experiment{N}/outputs/{model}/` campaign objects | `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment{N}/outputs/{model}/` |
+| `experiments/ai_simulation_responses_2026_09_11/experiment1/outputs/{model}/smoke/` | `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment1/outputs/{model}/smoke/` |
+| `experiments/ai_simulation_responses_2026_09_11/experiment{N}/RESULTS.md` | `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment{N}/RESULTS.md` |
+| `experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/false_negative_posts.csv` | `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/false_negative_posts.csv` |
+| `experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/false_positive_posts.csv` | `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/false_positive_posts.csv` |
+| `experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/lowest_f1_users.csv` | `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/lowest_f1_users.csv` |
+
+`N` is 1 to 4 for labels and 1 to 5 for `RESULTS.md`. `{model}` is `openai`, `bedrock_micro_nova`, `bedrock_qwen`, or `bedrock_claude`. Git-only files (`*.py`, tests, `README.md`, `SETUP.md`) are not uploaded. Parquet, campaign objects, and experiment 5 CSVs stay out of git. `COST_ESTIMATE.md` and `RESULTS.md` are committed after the live write, and they are also on S3.
 
 ## Steps
 
 ### Step 1: Add the shared cohort, prompts, schema, runner, and tests
 
-Add the folder layout and confirm the September cohort. Implement prompt rendering, the output schema, the four model runners, and the scorer. Upload the cohort parquet. Do not call OpenAI or Bedrock. See [steps/step1.md](steps/step1.md).
+Add the folder layout and confirm the September cohort. Implement prompt rendering, the output schema, the four model runners, the scorer, and the mirrored S3 path helper. Upload the cohort parquet locally and on S3. Do not call OpenAI or Bedrock. See [steps/step1.md](steps/step1.md).
 
 ### Step 2: Smoke 10 users, write the cost table, and print the experiment 2 prompt
 
-Run a 10-user smoke on all four models with the experiment 1 prompt. Scale token estimates to experiments 2 to 4. Write `COST_ESTIMATE.md` and print the experiment 2 template with one filled example. Stop for approval. See [steps/step2.md](steps/step2.md).
+Run a 10-user smoke on all four models with the experiment 1 prompt. Scale token estimates to experiments 2 to 4. Write `COST_ESTIMATE.md` locally and on S3, and print the experiment 2 template with one filled example. Stop for approval. See [steps/step2.md](steps/step2.md).
 
 ### Step 3: Label the full cohort for experiments 1 through 4
 
@@ -83,21 +102,22 @@ After explicit approval of the cost table and the experiment 2 template, run fou
 
 ### Step 4: Score experiments 1 through 4
 
-Join each `final.parquet` to the cohort gold labels. Write the user-level, post-level, party, toxicity, and stance tables into each experiment's `RESULTS.md`. See [steps/step4.md](steps/step4.md).
+Join each `final.parquet` to the cohort gold labels. Write the user-level, post-level, party, toxicity, and stance tables into each experiment's `RESULTS.md`, then upload each `RESULTS.md` to the matching S3 key. See [steps/step4.md](steps/step4.md).
 
 ### Step 5: Analyze error-rate ranks and prediction variance
 
-Read the 16 final parquets. Write the 75 plus 75 post lists, the 100-user list, within-user variance, and across-model variance into `experiments/ai_simulation_responses_2026_09_11/experiment5/RESULTS.md`. See [steps/step5.md](steps/step5.md).
+Read the 16 final parquets. Write the 75 false-negative posts, the 75 false-positive posts, the 100-user list, within-user variance, and across-model variance into `experiments/ai_simulation_responses_2026_09_11/experiment5/RESULTS.md`. Upload that report and the three ranked CSVs to S3. See [steps/step5.md](steps/step5.md).
 
 ## What "done" looks like
 
 1. `experiments/ai_simulation_responses_2026_09_11/` has `shared/`, five experiment folders, parent `README.md`, and `COST_ESTIMATE.md` after Step 2.
-2. Cohort parquet exists on S3 and has at most 1,000 users, each with 20 gold pairs, stored pair order, and a reflection. A second cohort upload fails.
-3. Step 2 wrote a cost table in the issue's column layout, smoked 10 users (or fewer) on four models, and printed the experiment 2 prompt. Full labeling did not run in Step 2.
-4. After approval, each of experiments 1 to 4 has four `final.parquet` files, one per model, plus smoke objects that are separate from those finals.
-5. Each of experiments 1 to 4 has `RESULTS.md` with user-level means, post-level scores including baseline remove rate, party tables, toxicity tables, and stance tables.
-6. Experiment 5 `RESULTS.md` has the 150-post error set, the 100-user set, within-user variance, and across-model variance, using only existing fields.
-7. `PYTHONPATH=. uv run pytest experiments/ai_simulation_responses_2026_09_11/shared/tests -q` exits 0. Product engines, the website, and the September study bucket objects are unchanged.
+2. Cohort parquet exists locally and at `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/shared/` and has at most 1,000 complete participants, each with 20 gold pairs, stored pair order, and a reflection. A second cohort upload fails.
+3. Step 2 wrote a cost table in the issue's column layout, smoked 10 users (or fewer) on four models, printed the experiment 2 prompt, and uploaded `COST_ESTIMATE.md` to `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md`. Full labeling did not run in Step 2.
+4. After approval, each of experiments 1 to 4 has four `final.parquet` files, one per model, at `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment{N}/outputs/{model}/final.parquet`, plus smoke objects that are separate from those finals.
+5. Each of experiments 1 to 4 has `RESULTS.md` locally and at the matching S3 key, with user-level means, post-level scores including baseline remove rate, party tables, toxicity tables, and stance tables.
+6. Experiment 5 `RESULTS.md` and the three ranked CSVs exist locally and on S3, with 75 false-negative posts, 75 false-positive posts, 100 users, within-user variance, and across-model variance, using only existing fields.
+7. Every derived S3 key equals the repo-relative path under `experiments/ai_simulation_responses_2026_09_11/`. Python, tests, README, and SETUP were not uploaded. The study website bucket was not written.
+8. `PYTHONPATH=. uv run pytest experiments/ai_simulation_responses_2026_09_11/shared/tests -q` exits 0. Product engines, the website, and the September study bucket objects are unchanged.
 
 ## Commands
 
@@ -116,7 +136,7 @@ Expected: exit 0.
 PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/shared/run.py --write-cohort
 ```
 
-Expected stdout includes `user_count=` (at most 1000), `trial_rows=` (20 times user count), the two S3 URIs, and both SHA-256 values. A second run exits non-zero because the cohort keys exist.
+Expected stdout includes `user_count=` (at most 1000 complete participants), `trial_rows=` (20 times user count), the two S3 URIs under `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/shared/`, and both SHA-256 values. A second run exits non-zero because the cohort keys exist.
 
 ```bash
 PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/shared/run.py --smoke
@@ -124,7 +144,7 @@ PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/shared
 PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/shared/run.py --estimate-cost
 ```
 
-Each smoke writes 10 labels (or the cohort size if smaller) under each model's `experiment1/outputs/{model}/smoke/` prefix and prints `labeled N of N`. `--estimate-cost` writes `COST_ESTIMATE.md` and prints the four experiment sections plus the total. `--print-experiment-2-prompt` prints the template and one filled user. Full labeling must not start.
+Each smoke writes 10 labels (or the cohort size if smaller) under each model's `experiment1/outputs/{model}/smoke/` prefix on S3, with a gitignored local cache at that same relative path, and prints `labeled N of N`. `--estimate-cost` writes `COST_ESTIMATE.md` locally and on S3, prints `cost_s3_uri=`, and prints the four experiment sections plus the total. `--print-experiment-2-prompt` prints the template and one filled user. Full labeling must not start.
 
 After written approval of the cost table and the experiment 2 prompt, one subagent per experiment runs the four `--model` commands. Scoring is a later command.
 
@@ -141,10 +161,10 @@ Replace `experiment1` with `experiment2`, `experiment3`, or `experiment4`. Each 
 PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/experiment1/run.py --score
 ```
 
-Replace `experiment1` the same way. `--score` writes that experiment's `RESULTS.md`.
+Replace `experiment1` the same way. `--score` writes that experiment's `RESULTS.md` locally and on S3, and prints `results_s3_uri=`.
 
 ```bash
 PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/experiment5/run.py --analyze-errors
 ```
 
-Expected: writes `experiment5/RESULTS.md` and prints the 75, 75, and 100 counts.
+Expected: writes `experiment5/RESULTS.md` and the three ranked CSVs locally and on S3, and prints the 75, 75, and 100 counts plus those S3 URIs.

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/reviews.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/reviews.md
@@ -8,27 +8,29 @@ The reviews below were applied to the draft. The plan in this folder already inc
 
 `acceptable`
 
-Issue 290 already asks for four prompt variants, four models, a cost gate, and an error analysis. The plan keeps that shape and refuses extra machinery. Shared code is one runner. Experiment folders are thin wrappers plus reports.
+Issue 290 already asks for four prompt variants, four models, a cost gate, and an error analysis. The plan keeps that shape and refuses extra machinery. Shared code is one runner. Experiment folders are thin wrappers plus reports. Derived files use the same S3 bucket and path-equals-local-key rule as the other September 2026 experiments.
 
 ### What seems solid
 
 - One cohort, one schema, one scorer.
 - Cost smoke and the experiment 2 prompt are hard gates.
 - Campaign parquet layout is copied from the separability experiment, not redesigned.
-- Experiment 5 uses counts on existing fields.
+- S3 keys copy the local tree under `experiments/ai_simulation_responses_2026_09_11/`. One helper, `put_new_mirrored`, writes both places. No second object store.
+- Experiment 5 uses counts on existing fields. The split is 75 false-negative posts and 75 false-positive posts.
 
 ### What seems unproven or overbuilt
 
 - Sixteen full labeling jobs are expensive, but the issue named those jobs. The plan does not add a fifteenth model or a per-pair call pattern that would multiply cost by 20.
 - Pytest under an experiment folder is an exception to `UNIT_TESTING_STANDARDS.md`. It is there because a 0-based index bug would invalidate every score, not because a test framework was wanted for its own sake.
+- Uploading `COST_ESTIMATE.md` and `RESULTS.md` with `put_new` makes a second write fail. The same immutability already applies to cohort parquet and to presentation parquet in the separability experiment. A later score fix needs a deleted S3 key, which the plan does not add a command for.
 
 ### Simpler version I would ship
 
-Keep the shared-runner design in `plan.md`. Do not add a prompt-strategy interface, a plugin registry, a second schema, or significance tests. Do not spawn 16 implementation subagents for scaffolding. Parallel Cursor Grok High subagents start only in Step 3, after approval, and only one per experiment.
+Keep the shared-runner design in `plan.md`. Do not add a prompt-strategy interface, a plugin registry, a second schema, or significance tests. Do not spawn 16 implementation subagents for scaffolding. Parallel Cursor Grok High subagents start only in Step 3, after approval, and only one per experiment. Do not upload Python, tests, README, or SETUP to S3.
 
 ### Follow-up questions
 
-None that block the plan. The issue's "1,000 rows" is pinned as 1,000 participants. If that was meant as 1,000 trial rows, the cost and the user-level tables change, and the user should say so on this pull request.
+None that block the plan. The cohort target is 1,000 complete participants. Experiment 5 takes 75 false negatives and 75 false positives.
 
 ## Persona used
 
@@ -52,7 +54,7 @@ Recommended fix: keep one call per user, because 20 calls per user times four ex
 
 Impact: early Prolific completers can differ from later ones. External claims should stay inside this cohort.
 
-Recommended fix: record `source_file_epoch_ms` range and drop counts in `SETUP.md`. Do not reweight.
+Recommended fix: record `source_file_epoch_ms` range and drop counts in `SETUP.md`. Do not reweight. The target remains 1,000 complete participants. If fewer complete users exist, take all of them and record the count.
 
 ### Issue: user-level means and pooled post-level scores can disagree
 
@@ -66,23 +68,22 @@ Impact: a higher F1 in experiment 4 does not prove that demographics caused bett
 
 Recommended fix: describe them as prompt ablations. Do not add causal language to `RESULTS.md`.
 
-### Issue: the issue's experiment 5 wording lists false negatives twice
+### Issue: experiment 5 complementary errors
 
 Impact: 150 posts of one error type would duplicate the first list.
 
-Recommended fix: 75 false negatives and 75 false positives, called out in `plan.md` so the user can correct it.
+Recommended fix: 75 false-negative posts and 75 false-positive posts. Confirmed.
 
 ## Open questions / assumptions
 
 - Language, employment, and social-media survey items are not in `columnsToKeep`, so experiment 2 cannot include them.
-- `scripts/export_study_results.py` expects 190 files. The live complete-user count may be under 1,000.
+- `scripts/export_study_results.py` expects 190 files. The live complete-participant count may be under 1,000.
 - Qwen and Claude token prices are pinned from the Bedrock list and Marketplace page. Smoke token counts still drive the dollar table.
 
 ## Suggested next actions
 
-1. Approve or correct the 1,000-participant reading and the 75 / 75 error split on this pull request.
-2. Approve the experiment 2 template in `steps/step1.md` early, so Step 2 is only a filled example plus cost.
-3. After merge, implement Step 1, then stop at the Step 2 gate.
+1. Approve the experiment 2 template in `steps/step1.md` early, so Step 2 is only a filled example plus cost.
+2. After merge, implement Step 1, then stop at the Step 2 gate.
 
 ## Writing cleanup
 

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/reviews.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/reviews.md
@@ -1,0 +1,95 @@
+# Reviews for the issue 290 plan
+
+The reviews below were applied to the draft. The plan in this folder already includes the accepted cuts.
+
+## Simplicity
+
+### Bottom line
+
+`acceptable`
+
+Issue 290 already asks for four prompt variants, four models, a cost gate, and an error analysis. The plan keeps that shape and refuses extra machinery. Shared code is one runner. Experiment folders are thin wrappers plus reports.
+
+### What seems solid
+
+- One cohort, one schema, one scorer.
+- Cost smoke and the experiment 2 prompt are hard gates.
+- Campaign parquet layout is copied from the separability experiment, not redesigned.
+- Experiment 5 uses counts on existing fields.
+
+### What seems unproven or overbuilt
+
+- Sixteen full labeling jobs are expensive, but the issue named those jobs. The plan does not add a fifteenth model or a per-pair call pattern that would multiply cost by 20.
+- Pytest under an experiment folder is an exception to `UNIT_TESTING_STANDARDS.md`. It is there because a 0-based index bug would invalidate every score, not because a test framework was wanted for its own sake.
+
+### Simpler version I would ship
+
+Keep the shared-runner design in `plan.md`. Do not add a prompt-strategy interface, a plugin registry, a second schema, or significance tests. Do not spawn 16 implementation subagents for scaffolding. Parallel Cursor Grok High subagents start only in Step 3, after approval, and only one per experiment.
+
+### Follow-up questions
+
+None that block the plan. The issue's "1,000 rows" is pinned as 1,000 participants. If that was meant as 1,000 trial rows, the cost and the user-level tables change, and the user should say so on this pull request.
+
+## Persona used
+
+### `agents/personas/research/methodology/domain_specific/experimental_design_expert.md`
+
+Selected because issue 290 is a prompt ablation against human keep/remove labels, not an infrastructure ticket.
+
+### `agents/personas/ai_engineering/task_specific/model_performance_analysis_expert.md`
+
+Selected as the second persona because the work is an evaluation: precision, recall, F1, slices, and error analysis.
+
+## Findings (highest severity first)
+
+### Issue: humans judged one pair at a time, the model sees 20 pairs in one prompt
+
+Impact: a model that looks consistent across the 20 pairs is not doing the same task the participant did. Comparing F1 still answers "can this prompt match the labels," but it is not a process match.
+
+Recommended fix: keep one call per user, because 20 calls per user times four experiments times four models would multiply the API bill by 20. State the mismatch in every `SETUP.md`. `plan.md` already records that limit.
+
+### Issue: first 1,000 completers are not a random sample
+
+Impact: early Prolific completers can differ from later ones. External claims should stay inside this cohort.
+
+Recommended fix: record `source_file_epoch_ms` range and drop counts in `SETUP.md`. Do not reweight.
+
+### Issue: user-level means and pooled post-level scores can disagree
+
+Impact: reporting only one of them would hide majority-class behavior or hide users with extreme remove rates.
+
+Recommended fix: keep both tables, and never label pooled F1 as user-level F1. Step 4 states the same rule.
+
+### Issue: experiments 1 to 4 are not a causal test of demographics or reflection
+
+Impact: a higher F1 in experiment 4 does not prove that demographics caused better simulation. The same people and the same posts are reused.
+
+Recommended fix: describe them as prompt ablations. Do not add causal language to `RESULTS.md`.
+
+### Issue: the issue's experiment 5 wording lists false negatives twice
+
+Impact: 150 posts of one error type would duplicate the first list.
+
+Recommended fix: 75 false negatives and 75 false positives, called out in `plan.md` so the user can correct it.
+
+## Open questions / assumptions
+
+- Language, employment, and social-media survey items are not in `columnsToKeep`, so experiment 2 cannot include them.
+- `scripts/export_study_results.py` expects 190 files. The live complete-user count may be under 1,000.
+- Qwen and Claude token prices are pinned from the Bedrock list and Marketplace page. Smoke token counts still drive the dollar table.
+
+## Suggested next actions
+
+1. Approve or correct the 1,000-participant reading and the 75 / 75 error split on this pull request.
+2. Approve the experiment 2 template in `steps/step1.md` early, so Step 2 is only a filled example plus cost.
+3. After merge, implement Step 1, then stop at the Step 2 gate.
+
+## Writing cleanup
+
+Passes run on `plan.md` and `steps/`:
+
+1. Plain writing: everyday words, no dashes, no sentence-initial "This/That", no three-clause sentences.
+2. Anti-slop: removed importance language and parallel "not X but Y" setup.
+3. Humanizer: kept claims, cut staged openers.
+4. Osmani: named actors (operator, subagent, scorer), kept the cost gate as the takeaway.
+5. Vocabulary: "confirm" instead of "freeze", "run" instead of "invoke", "authoritative" instead of "canonical".

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step1.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step1.md
@@ -1,0 +1,385 @@
+# Step 1: Add the shared cohort, prompts, schema, runner, and tests
+
+## Scope
+
+- **Caller:** `experiments/ai_simulation_responses_2026_09_11/shared/run.py` `main` with `--write-cohort`
+- **Task:** Add the experiment folders, download September Prolific CSVs, and confirm up to 1,000 complete users. Upload cohort parquet. Implement prompts, schema, four model runners, scoring helpers, and pytest. Do not call OpenAI or Bedrock.
+- **Out of scope:** smoke, cost estimate, full labeling, `RESULTS.md`, `CHANGELOG.md`, editing product engines, editing the website, editing `scripts/export_study_results.py`
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-12_ai_simulation_responses_a28567/plan.md` | Confirmed decisions, models, gates |
+| `/workspace/scripts/export_study_results.py` | `list_csv_keys`, `download_csvs`, `filter_manual_test_rows`, bucket `jspsych-mirror-view-2026-09-09`, prefix `data/prolific/` |
+| `/workspace/webapp/public/main.js` | Training_assisted instruction copy, reflection question, `columnsToKeep`, `trial_index` |
+| `/workspace/webapp/public/post_surveys.js` | Demographic labels and Likert anchors that are actually exported |
+| `/workspace/webapp/public/plugins/plugin-moderation-trial.js` | `pair_order`, `decision`, linked-fate shuffle |
+| `/workspace/jobs/config/mirrorview_2026_09_09.yaml` | Study id `mirrorview_2026_09_09`, 20 trials, `training_assisted` |
+| `/workspace/experiments/test_separability_original_mirror_posts_2026_09_09/run.py` | Campaign part loop, smoke prefix, `write_batch`, `consolidate_final` |
+| `/workspace/experiments/test_separability_original_mirror_posts_2026_09_09/schema.py` | Split LLM schema vs persisted row, `FeatureSpec` |
+| `/workspace/experiments/test_separability_original_mirror_posts_2026_09_09/bedrock_runner.py` | `label_tasks_collecting_failures` plus raised `max_tokens` |
+| `/workspace/experiments/test_separability_original_mirror_posts_2026_09_09/openai_runner.py` | `build_openai_engine` |
+| `/workspace/data_platform/generate_features/models.py` | `FeatureSpec`, `LabelTask`, `FeatureRunConfig` |
+| `/workspace/data_platform/generate_features/engines/openai_engine.py` | `build_openai_engine`, default model `gpt-5.4-nano` |
+| `/workspace/data_platform/generate_features/engines/bedrock_engine.py` | `label_tasks_collecting_failures`, `create_bedrock_runtime_client`, `BEDROCK_MAX_TOKENS` is 32 |
+| `/workspace/data_platform/generate_features/engines/bedrock_campaign.py` | `BEDROCK_CAMPAIGN_MAX_CONCURRENCY` is 8 |
+| `/workspace/data_platform/generate_features/s3_feature_campaign.py` | `CampaignObjectStore`, `parse_s3_uri`, `FeaturePaths.from_root_uri`, `put_new` |
+| `/workspace/data_platform/generate_features/s3_feature_batches.py` | `write_batch`, `consolidate_final`, `attach_row_metadata` |
+| `/workspace/data_platform/generate_features/campaign_cost_report.py` | OpenAI Batch and Nova Micro rates |
+| `/workspace/lib/constants.py` | `DEFAULT_LLM_MODEL`, `DEFAULT_BEDROCK_NOVA_MICRO`, `DEFAULT_BEDROCK_SONNET_MODEL`, `BEDROCK_REGION` |
+| `/workspace/experiments/predict_keep_remove_2026_07_01/models/llm_finetuning/api_baselines/constants.py` | `qwen.qwen3-32b-v1:0` |
+| `/workspace/experiments/predict_keep_remove_2026_07_01/models/llm_finetuning/api_baselines/prompts.py` | Authoritative study instruction wording |
+| `/workspace/experiments/finetune_qwen_model_2026_08_08/evaluate.py` | `zero_division=0`, remove as positive class |
+| `/workspace/experiments/filter_posts_used_for_stimulus_dataset_2026_09_08/README.md` | Agent read-only banner |
+| `/workspace/.cursor/skills/implement-plan-and-open-pr/UNIT_TESTING_STANDARDS.md` | Arrange-act-assert, one test class per function |
+
+## Files allowed to change
+
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/README.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/__init__.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/constants.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/schema.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/prompts.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/cohort.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/write.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/openai_runner.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/bedrock_runner.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/score.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/run.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/__init__.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/conftest.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/test_build_cohort.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/test_render_prompt.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/test_expand_remove_indexes.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/test_score_predictions.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/README.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/SETUP.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/run.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment2/README.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment2/SETUP.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment2/run.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment3/README.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment3/SETUP.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment3/run.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment4/README.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment4/SETUP.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment4/run.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/README.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/SETUP.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/run.py` (new)
+- `/workspace/.gitignore` (ignore `cache/` and `outputs/` and local parquet under this experiment folder only)
+
+Do not write `RESULTS.md` or `COST_ESTIMATE.md` in this step. `experiment2/SETUP.md` may contain the unfilled prompt template, and Step 2 will add one filled example after the cohort exists.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/**`
+- `/workspace/webapp/**`
+- `/workspace/scripts/export_study_results.py`
+- `/workspace/lib/constants.py`
+- `/workspace/shared/flip_generation/**`
+- `/workspace/shared/data/**`
+- `/workspace/tests/**`
+- `/workspace/CHANGELOG.md`
+- Objects under `s3://jspsych-mirror-view-2026-09-09/`
+
+## README contract
+
+Write the parent README and the five experiment READMEs first, then implement modules to match them.
+
+Parent README must:
+
+1. Start with the agent read-only banner.
+2. Say this folder runs issue 290 on the September 2026 study.
+3. Point at `shared/`, `experiment1` through `experiment5`, `SETUP.md`, and `RESULTS.md`.
+
+Each of experiments 1 to 4 README must:
+
+1. Start with the banner.
+2. State the ablation question in one or two sentences.
+3. Redirect to that folder's `SETUP.md` and `RESULTS.md`.
+
+Experiment 5 README must say it ranks posts and users with the highest error rates from the four labeling experiments and does not call a model.
+
+## Public contracts
+
+Keep functions under 20 lines. Use frozen dataclasses. Do not pass unstructured dictionaries for source identity. Reuse `CampaignObjectStore`, `parse_s3_uri`, `sha256_hex`, `build_openai_engine`, `label_tasks_collecting_failures`, `write_batch`, and `consolidate_final`. Do not copy a new S3 client. Import `list_csv_keys`, `download_csvs`, and `filter_manual_test_rows` from `scripts/export_study_results.py`. Do not edit that script.
+
+### `constants.py`
+
+Pinned values: posts per user 20, cohort cap 1000, smoke user count 10, Bedrock max tokens 256, bucket `jspsych-mirror-view-2026-09-09`, prefix `data/prolific/`, since date 2026-09-09, output bucket `mirrorview-experimental-artifacts`, output prefix `experiments/ai_simulation_responses_2026_09_11/`, model ids from the plan, experiment numbers 1 to 4, model folder names `openai`, `bedrock_micro_nova`, `bedrock_qwen`, `bedrock_claude`.
+
+Frozen dataclasses at least:
+
+- `CohortUser` with `prolific_id`, `participant_id`, `source_file_epoch_ms`, `party_group`, demographic fields, `phase1_pair_reflection_text`, `phase1_pair_influence_rating`
+- `CohortTrial` with `prolific_id`, `pair_index` (1 to 20), `post_id`, `original_text`, `mirror_text`, `pair_order`, `gold_remove`, `sampled_stance`, `sample_toxicity_type`, `trial_index`
+- `ModelSpec` with `folder`, `engine_kind` (`openai` or `bedrock`), `model_id`
+- `CostRow` with `model`, `estimated_tokens_in`, `estimated_tokens_out`, `median_cost_usd`, `low_cost_usd`, `high_cost_usd`
+
+### `cohort.py`
+
+- `list_september_csv_keys(store_or_s3_client)` lists keys using `list_csv_keys` with since date 2026-09-09.
+- `build_cohort(csv_paths)` returns users and trials. Drop `manual-test` / `pid` / `dev` prolific ids using the export script's filters. Require 20 linked-fate keep/remove trials, stored `pair_order`, reflection text, and influence rating. Sort by `source_file_epoch_ms` ascending, then `prolific_id` for ties, and take at most 1,000 users.
+- `pair_index` is 1-indexed in `trial_index` order.
+
+### `prompts.py`
+
+- `STUDY_SYSTEM_PROMPT` is the training_assisted instruction copy plus the 1-indexed remove-list task change from the plan.
+- `render_pairs(trials)` writes `## Post pair {n}` then `Post 1:` and `Post 2:` in `pair_order`.
+- `render_demographics(user)` emits only non-empty exported fields, using the survey labels in the plan.
+- `render_reflection(user)` emits the exact reflection question from `webapp/public/main.js` lines 706 to 722, the written answer, and the 1 to 7 rating with the "Not at all" / "Very much" anchors.
+- `render_user_prompt(experiment_number, user, trials)` returns experiment 1 pairs only, experiment 2 demographics then pairs, experiment 3 reflection then pairs, experiment 4 demographics then reflection then pairs.
+
+### `schema.py`
+
+- `LlmRemoveIndexesModel` with `remove_pair_indexes: list[int]`
+- `RemoveIndexesRow` with `source_record_id`, `label_timestamp`, `remove_pair_indexes`
+- `remove_indexes_spec(engine_type)` returns a `FeatureSpec` whose `system_prompt` is `STUDY_SYSTEM_PROMPT` and whose `llm_output_schema` is `LlmRemoveIndexesModel`
+- `expand_remove_indexes(remove_pair_indexes)` returns a length-20 list of 0/1. Raise `ValueError` on duplicates or values outside 1 to 20.
+
+### `openai_runner.py` / `bedrock_runner.py`
+
+Bodies may stay as `raise NotImplementedError` until Step 2, but signatures must exist.
+
+- `openai_runner.label_tasks(spec, tasks)` calls `build_openai_engine`
+- `bedrock_runner.label_tasks(spec, tasks, model_id)` calls `label_tasks_collecting_failures` with `max_tokens=256`
+
+### `score.py`
+
+- `user_metrics(gold, pred)` returns accuracy, precision, recall, F1 for one user
+- `pooled_metrics(gold, pred)` returns the same four plus `baseline_remove_rate`
+- `slice_tables(...)` builds party, toxicity, and stance tables from the plan
+
+### `write.py`
+
+- `upload_cohort(users, trials, store)` writes both parquet files locally and with `put_new`
+- `require_cohort_keys_absent(store)` raises `FileExistsError` if either key exists
+
+### `run.py`
+
+`parse_args` accepts `--write-cohort`, `--smoke`, `--estimate-cost`, `--print-experiment-2-prompt`, `--experiment`, `--model`, `--score`, `--analyze-errors`. Step 1 only implements `--write-cohort`. Other flags may exist as stubs that raise `NotImplementedError`.
+
+`--write-cohort` prints:
+
+```text
+user_count=
+trial_rows=
+dropped_incomplete=
+dropped_missing_pair_order=
+dropped_missing_reflection=
+users_s3_uri=
+trials_s3_uri=
+users_sha256=
+trials_sha256=
+```
+
+### Thin experiment callers
+
+Each of `experiment1/run.py` through `experiment4/run.py` calls `shared/run.py` with a fixed `--experiment`. `experiment5/run.py` only exposes `--analyze-errors`.
+
+## Prompt template (for experiment 2 approval)
+
+System prompt is `STUDY_SYSTEM_PROMPT`. Experiment 2 user prompt shape:
+
+```text
+## Participant information
+
+The following answers were provided by the participant whose keep/remove choices you are simulating. Use them if they help you match that participant's decisions.
+
+- Age: {age}
+- Gender: {gender}
+- Education: {education}
+- Political affiliation: {political_affiliation}
+- Party lean: {party_lean}
+- Party group: {party_group}
+- Political ideology (1 = Extremely liberal, 7 = Extremely conservative): {political_ideology}
+- How closely do you follow politics (1 = Not closely at all, 7 = Very closely): {political_follow}
+- I identify with the Republican Party (1 = Fully Disagree, 7 = Fully agree): {rep_id}
+- I identify with the Democratic Party (1 = Fully Disagree, 7 = Fully agree): {dem_id}
+- Reducing access to abortion (0 = Strongly Oppose, 100 = Strongly Support): {attitude_reduce_abortion}
+- Providing a path to citizenship for undocumented immigrants (0 to 100): {attitude_citizenship_undocumented}
+- Increasing restrictions on gun ownership (0 to 100): {attitude_restrict_guns}
+- Increasing government regulations to protect the environment (0 to 100): {attitude_regulate_environment}
+- Raising taxes on the wealthiest Americans (0 to 100): {attitude_raise_wealth_taxes}
+- Expanding Medicaid to cover all currently uninsured Americans (0 to 100): {attitude_expand_medicaid}
+
+## Post pair 1
+
+Post 1:
+{first text in pair_order}
+
+Post 2:
+{second text in pair_order}
+
+## Post pair 2
+
+...
+```
+
+Omit any bullet whose value is empty. Experiment 2 labeling waits on approval of this template.
+
+## Pytest files
+
+Tests must not download S3 and must not call a model. Build in-memory frames in `conftest.py`. Use Arrange-Act-Assert. Name classes `Test{FunctionName}`. Use `result` and `expected`. Patch with `unittest.mock`.
+
+### `tests/test_build_cohort.py`
+
+Class `TestBuildCohort`.
+
+```text
+given three complete users with epochs 30, 10, and 20
+when build_cohort
+then user order is epoch 10, then 20, then 30
+and each user has 20 trials
+and pair_index runs 1 through 20
+
+given a user with 19 linked-fate decisions
+when build_cohort
+then that user is dropped
+and dropped_incomplete increments
+
+given a user with 20 trials and missing pair_order
+when build_cohort
+then that user is dropped
+
+given a user with 20 trials and empty reflection text
+when build_cohort
+then that user is dropped
+
+given 1001 complete users
+when build_cohort
+then user_count is 1000
+and the excluded user is the latest epoch
+```
+
+### `tests/test_render_prompt.py`
+
+Class `TestRenderUserPrompt`.
+
+```text
+given pair_order ["mirror", "original"]
+when render_pairs
+then Post 1 is mirror_text and Post 2 is original_text
+and the heading is Post pair {pair_index}
+
+given experiment 1
+when render_user_prompt
+then the prompt has no Participant information heading
+and no Participant reflection heading
+
+given experiment 2 and a missing education value
+when render_user_prompt
+then the education bullet is absent
+and the age bullet is present when age is set
+
+given experiment 3
+when render_user_prompt
+then the prompt contains the reflection question from main.js
+and contains the written answer
+and contains the 1 to 7 rating
+```
+
+### `tests/test_expand_remove_indexes.py`
+
+Class `TestExpandRemoveIndexes`.
+
+```text
+given [1, 20]
+when expand_remove_indexes
+then the length-20 list is 1 at indexes 0 and 19, else 0
+
+given []
+when expand_remove_indexes
+then all 20 values are 0
+
+given [0]
+when expand_remove_indexes
+then raise ValueError
+
+given [1, 1]
+when expand_remove_indexes
+then raise ValueError
+
+given [21]
+when expand_remove_indexes
+then raise ValueError
+```
+
+### `tests/test_score_predictions.py`
+
+Class `TestUserMetrics` and `TestPooledMetrics`.
+
+```text
+given gold [1, 0, 1, 0] and pred [1, 1, 1, 0]
+when user_metrics
+then precision, recall, f1, and accuracy match sklearn with zero_division=0
+and positive class is 1
+
+given two users where user A is all correct and user B is all wrong
+and each user has 20 pairs
+when mean user-level accuracy
+then the mean is 0.5
+and pooled accuracy is also 0.5 because both users have the same pair count
+
+given party_group democrat vs republican
+when slice_tables
+then democrat user-level means use only democrat users
+```
+
+## Main caller
+
+```bash
+PYTHONPATH=. uv run pytest experiments/ai_simulation_responses_2026_09_11/shared/tests -q
+```
+
+Expected: exit 0.
+
+```bash
+export AWS_ACCESS_KEY_ID="$LAB_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$LAB_AWS_ACCESS_KEY_SECRET"
+
+PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/shared/run.py --write-cohort
+```
+
+Expected: prints the `user_count=` block from above. A second run exits non-zero.
+
+## Must pass
+
+- Imports from `shared/run.py` resolve.
+- Parent README and five experiment READMEs exist and carry the banner.
+- `PYTHONPATH=. uv run pytest experiments/ai_simulation_responses_2026_09_11/shared/tests -q` exits 0.
+- `--write-cohort` uploads both parquet objects with `put_new`.
+- Product engines, website files, and `scripts/export_study_results.py` are unchanged.
+
+## Must fail
+
+- Second `--write-cohort` against existing S3 keys.
+- Cohort builder keeping a user with 19 trials, missing `pair_order`, or empty reflection.
+- `expand_remove_indexes` accepting 0 or 21.
+- Experiment 1 prompt containing the demographics heading.
+
+## Implement-from-spec notes
+
+Follow `/implement-from-spec`. Full auto. Do not pause after contracts.
+
+Phase 1 names `shared/run.py` `--write-cohort` as the caller.
+
+Phase 2 scaffolds modules with stub bodies and writes READMEs.
+
+Phase 3 locks dataclasses and public signatures. Bodies stay `raise NotImplementedError`.
+
+Phase 4 writes the pytest files from the given/when/then blocks. Tests must fail for `NotImplementedError` or a wrong result, not for missing imports.
+
+Phase 5 implements in this order, one commit per unit of work:
+
+1. README files and `constants.py`
+2. `expand_remove_indexes` until `test_expand_remove_indexes.py` is green
+3. `render_pairs` / `render_user_prompt` until `test_render_prompt.py` is green
+4. `build_cohort` until `test_build_cohort.py` is green
+5. `user_metrics` / `pooled_metrics` / `slice_tables` until `test_score_predictions.py` is green
+6. local parquet writer
+7. `--write-cohort` wiring, S3 `put_new`, missing-key error
+8. runner signatures and thin experiment `run.py` files
+
+Phase 6 is complete when the pytest command exits 0, `--write-cohort` can run, and Step 2 can smoke without inventing schema or prompt code.

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step1.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step1.md
@@ -3,7 +3,7 @@
 ## Scope
 
 - **Caller:** `experiments/ai_simulation_responses_2026_09_11/shared/run.py` `main` with `--write-cohort`
-- **Task:** Add the experiment folders, download September Prolific CSVs, and confirm up to 1,000 complete users. Upload cohort parquet. Implement prompts, schema, four model runners, scoring helpers, and pytest. Do not call OpenAI or Bedrock.
+- **Task:** Add the experiment folders, download September Prolific CSVs, and confirm up to 1,000 complete participants. Upload cohort parquet locally and to S3 at the matching path. Implement the mirrored-path helper, prompts, schema, four model runners, scoring helpers, and pytest. Do not call OpenAI or Bedrock.
 - **Out of scope:** smoke, cost estimate, full labeling, `RESULTS.md`, `CHANGELOG.md`, editing product engines, editing the website, editing `scripts/export_study_results.py`
 
 ## Files to inspect (read-only)
@@ -25,6 +25,8 @@
 | `/workspace/data_platform/generate_features/engines/bedrock_engine.py` | `label_tasks_collecting_failures`, `create_bedrock_runtime_client`, `BEDROCK_MAX_TOKENS` is 32 |
 | `/workspace/data_platform/generate_features/engines/bedrock_campaign.py` | `BEDROCK_CAMPAIGN_MAX_CONCURRENCY` is 8 |
 | `/workspace/data_platform/generate_features/s3_feature_campaign.py` | `CampaignObjectStore`, `parse_s3_uri`, `FeaturePaths.from_root_uri`, `put_new` |
+| `/workspace/experiments/generate_study_user_assignments_2026_09_08/constants.py` | `OUTPUT_S3_BUCKET` and `OUTPUT_S3_KEY` equal to the local experiment path |
+| `/workspace/experiments/test_separability_original_mirror_posts_2026_09_09/constants.py` | `OUTPUT_S3_BUCKET` and `PRESENTATION_S3_KEY` equal to the local experiment path |
 | `/workspace/data_platform/generate_features/s3_feature_batches.py` | `write_batch`, `consolidate_final`, `attach_row_metadata` |
 | `/workspace/data_platform/generate_features/campaign_cost_report.py` | OpenAI Batch and Nova Micro rates |
 | `/workspace/lib/constants.py` | `DEFAULT_LLM_MODEL`, `DEFAULT_BEDROCK_NOVA_MICRO`, `DEFAULT_BEDROCK_SONNET_MODEL`, `BEDROCK_REGION` |
@@ -53,6 +55,7 @@
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/test_render_prompt.py` (new)
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/test_expand_remove_indexes.py` (new)
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/test_score_predictions.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/test_mirrored_s3_key.py` (new)
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/README.md` (new)
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/SETUP.md` (new)
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/run.py` (new)
@@ -108,7 +111,7 @@ Keep functions under 20 lines. Use frozen dataclasses. Do not pass unstructured 
 
 ### `constants.py`
 
-Pinned values: posts per user 20, cohort cap 1000, smoke user count 10, Bedrock max tokens 256, bucket `jspsych-mirror-view-2026-09-09`, prefix `data/prolific/`, since date 2026-09-09, output bucket `mirrorview-experimental-artifacts`, output prefix `experiments/ai_simulation_responses_2026_09_11/`, model ids from the plan, experiment numbers 1 to 4, model folder names `openai`, `bedrock_micro_nova`, `bedrock_qwen`, `bedrock_claude`.
+Pinned values: posts per user 20, cohort cap 1000 complete participants, smoke user count 10, Bedrock max tokens 256, study bucket `jspsych-mirror-view-2026-09-09`, prefix `data/prolific/`, since date 2026-09-09, output bucket `mirrorview-experimental-artifacts`, output prefix `experiments/ai_simulation_responses_2026_09_11/` (the S3 key equals this local prefix plus the rest of the relative path), model ids from the plan, experiment numbers 1 to 4, model folder names `openai`, `bedrock_micro_nova`, `bedrock_qwen`, `bedrock_claude`. Do not use the older finetune prefix `mirrorview-finetune_qwen_model_2026_08_08/`.
 
 Frozen dataclasses at least:
 
@@ -120,7 +123,7 @@ Frozen dataclasses at least:
 ### `cohort.py`
 
 - `list_september_csv_keys(store_or_s3_client)` lists keys using `list_csv_keys` with since date 2026-09-09.
-- `build_cohort(csv_paths)` returns users and trials. Drop `manual-test` / `pid` / `dev` prolific ids using the export script's filters. Require 20 linked-fate keep/remove trials, stored `pair_order`, reflection text, and influence rating. Sort by `source_file_epoch_ms` ascending, then `prolific_id` for ties, and take at most 1,000 users.
+- `build_cohort(csv_paths)` returns users and trials. Drop `manual-test` / `pid` / `dev` prolific ids using the export script's filters. Require 20 linked-fate keep/remove trials, stored `pair_order`, reflection text, and influence rating. Sort by `source_file_epoch_ms` ascending, then `prolific_id` for ties, and take at most 1,000 complete participants. If fewer complete users exist, return all of them.
 - `pair_index` is 1-indexed in `trial_index` order.
 
 ### `prompts.py`
@@ -153,8 +156,18 @@ Bodies may stay as `raise NotImplementedError` until Step 2, but signatures must
 
 ### `write.py`
 
-- `upload_cohort(users, trials, store)` writes both parquet files locally and with `put_new`
+- `mirrored_s3_key(relative_path)` returns the S3 key, which equals the repo-relative path. The path must start with `experiments/ai_simulation_responses_2026_09_11/`. Raise `ValueError` if it does not, or if it has a leading slash, or if it uses the older finetune prefix.
+- `put_new_mirrored(store, relative_path, body)` writes `REPO_ROOT / relative_path`, then `store.put_new(relative_path, body)`. The store bucket is `mirrorview-experimental-artifacts`, matching `experiments/generate_study_user_assignments_2026_09_08/constants.py` `OUTPUT_S3_BUCKET` and `experiments/test_separability_original_mirror_posts_2026_09_09/constants.py` `OUTPUT_S3_BUCKET`.
+- `upload_cohort(users, trials, store)` writes both parquet files through `put_new_mirrored`
 - `require_cohort_keys_absent(store)` raises `FileExistsError` if either key exists
+- Later steps reuse `put_new_mirrored` for `COST_ESTIMATE.md`, `RESULTS.md`, and experiment 5 CSVs. Step 1 does not write those files.
+
+Cohort keys:
+
+```text
+experiments/ai_simulation_responses_2026_09_11/shared/cohort_users.parquet
+experiments/ai_simulation_responses_2026_09_11/shared/cohort_trials.parquet
+```
 
 ### `run.py`
 
@@ -306,6 +319,35 @@ when expand_remove_indexes
 then raise ValueError
 ```
 
+### `tests/test_mirrored_s3_key.py`
+
+Class `TestMirroredS3Key`.
+
+```text
+given experiments/ai_simulation_responses_2026_09_11/shared/cohort_users.parquet
+when mirrored_s3_key
+then the key equals that path
+and the key does not add another prefix
+
+given experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/false_negative_posts.csv
+when mirrored_s3_key
+then the key equals that path
+
+given shared/cohort_users.parquet
+when mirrored_s3_key
+then raise ValueError
+
+given /experiments/ai_simulation_responses_2026_09_11/shared/cohort_users.parquet
+when mirrored_s3_key
+then raise ValueError
+
+given mirrorview-finetune_qwen_model_2026_08_08/data/x.parquet
+when mirrored_s3_key
+then raise ValueError
+```
+
+Tests must not call S3. `put_new_mirrored` may be tested by patching `CampaignObjectStore.put_new` and a temp directory, or left to the live `--write-cohort` command.
+
 ### `tests/test_score_predictions.py`
 
 Class `TestUserMetrics` and `TestPooledMetrics`.
@@ -349,7 +391,8 @@ Expected: prints the `user_count=` block from above. A second run exits non-zero
 - Imports from `shared/run.py` resolve.
 - Parent README and five experiment READMEs exist and carry the banner.
 - `PYTHONPATH=. uv run pytest experiments/ai_simulation_responses_2026_09_11/shared/tests -q` exits 0.
-- `--write-cohort` uploads both parquet objects with `put_new`.
+- `--write-cohort` writes both parquet files locally and uploads them with `put_new` at keys that equal those relative paths.
+- Printed `users_s3_uri=` and `trials_s3_uri=` start with `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/shared/`.
 - Product engines, website files, and `scripts/export_study_results.py` are unchanged.
 
 ## Must fail
@@ -358,6 +401,7 @@ Expected: prints the `user_count=` block from above. A second run exits non-zero
 - Cohort builder keeping a user with 19 trials, missing `pair_order`, or empty reflection.
 - `expand_remove_indexes` accepting 0 or 21.
 - Experiment 1 prompt containing the demographics heading.
+- `mirrored_s3_key` accepting a path outside `experiments/ai_simulation_responses_2026_09_11/` or the older finetune prefix.
 
 ## Implement-from-spec notes
 
@@ -378,8 +422,9 @@ Phase 5 implements in this order, one commit per unit of work:
 3. `render_pairs` / `render_user_prompt` until `test_render_prompt.py` is green
 4. `build_cohort` until `test_build_cohort.py` is green
 5. `user_metrics` / `pooled_metrics` / `slice_tables` until `test_score_predictions.py` is green
-6. local parquet writer
-7. `--write-cohort` wiring, S3 `put_new`, missing-key error
-8. runner signatures and thin experiment `run.py` files
+6. `mirrored_s3_key` until `test_mirrored_s3_key.py` is green
+7. local parquet writer plus `put_new_mirrored`
+8. `--write-cohort` wiring, S3 `put_new`, missing-key error
+9. runner signatures and thin experiment `run.py` files
 
 Phase 6 is complete when the pytest command exits 0, `--write-cohort` can run, and Step 2 can smoke without inventing schema or prompt code.

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step2.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step2.md
@@ -1,0 +1,134 @@
+# Step 2: Smoke 10 users, write the cost table, and print the experiment 2 prompt
+
+## Scope
+
+- **Caller:** `experiments/ai_simulation_responses_2026_09_11/shared/run.py` `main` with `--smoke`, `--estimate-cost`, and `--print-experiment-2-prompt`
+- **Task:** Label the first 10 cohort users (or the full cohort if smaller) on all four models using the experiment 1 prompt. Write smoke objects under each model's `smoke/` prefix. Scale token estimates to experiments 2 to 4. Write `COST_ESTIMATE.md`. Print the experiment 2 template plus one filled example. Stop. Do not write `final.parquet`. Do not start full labeling.
+- **Out of scope:** experiments 2 to 4 full runs, experiment 5, `RESULTS.md`, `CHANGELOG.md`, editing product engines
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-12_ai_simulation_responses_a28567/plan.md` | Cost table shape, rates, 0.5× / 2× bounds |
+| `/workspace/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step1.md` | Cohort, prompts, runners |
+| `/workspace/experiments/test_separability_original_mirror_posts_2026_09_09/run.py` | `--smoke` path, smoke prefix, no copy into `final.parquet` |
+| `/workspace/data_platform/generate_features/campaign_cost_report.py` | `BatchPricing.cost_usd`, OpenAI Batch and Nova rates |
+| `/workspace/experiments/bedrock_batch_parallelization_2026_09_06/write_cost_estimate.py` | `CEILING_MULTIPLIER` is 2 |
+| `/workspace/data_platform/generate_features/s3_feature_campaign.py` | `FeaturePaths.from_root_uri` for smoke roots |
+
+## Files allowed to change
+
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/run.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/openai_runner.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/bedrock_runner.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/cost.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md` (new, live numbers)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment2/SETUP.md` (add one filled example after the template)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/SETUP.md` (record smoke user count and smoke URIs)
+
+## Files forbidden to change
+
+- `/workspace/data_platform/**`
+- `/workspace/webapp/**`
+- `/workspace/scripts/export_study_results.py`
+- `/workspace/lib/constants.py`
+- `/workspace/tests/**`
+- `/workspace/CHANGELOG.md`
+- Cohort S3 objects from Step 1 (do not overwrite)
+- Any `final.parquet` key
+
+## Smoke contract
+
+Smoke users are the first 10 rows of `cohort_users.parquet` after sorting by `source_file_epoch_ms` then `prolific_id`. If `user_count` is less than 10, smoke every user.
+
+Prompt is experiment 1 only. All four models must run:
+
+1. `openai` through `build_openai_engine`
+2. `bedrock_micro_nova` through `label_tasks_collecting_failures` with `us.amazon.nova-micro-v1:0`
+3. `bedrock_qwen` through `label_tasks_collecting_failures` with `qwen.qwen3-32b-v1:0`
+4. `bedrock_claude` through `label_tasks_collecting_failures` with `us.anthropic.claude-sonnet-4-6`
+
+Bedrock `max_tokens` is 256. Do not send content-filter failures to OpenAI. Record those ids in the smoke `errors.jsonl`.
+
+Smoke root URI pattern:
+
+`s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment1/outputs/{model}/smoke/`
+
+`--smoke` prints, per model:
+
+```text
+model=
+labeled=
+failed=
+input_tokens=
+output_tokens=
+```
+
+## Cost contract
+
+`cost.py` loads smoke token counts per request. Median input and output tokens are the medians across the 10 (or fewer) successful smoke requests for that model. Experiments 2 to 4 estimated input tokens equal that median times `user_count` times (`mean_chars(experiment_n) / mean_chars(experiment_1)`), using rendered prompts on the full cohort with no extra model call. Estimated output tokens equal smoke-median output tokens times `user_count`. Median USD uses the pinned rates in the plan. Low is 0.5 times median. High is 2 times median. Experiment 5 is 0 tokens and 0 USD.
+
+Write `experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md` with this shape:
+
+```markdown
+## Experiment 1
+
+Estimated cost:
+
+| model | estimated tokens in | estimated tokens out | median estimated cost | low/high estimated cost |
+| --- | --- | --- | --- | --- |
+| openai | | | | |
+| bedrock_micro_nova | | | | |
+| bedrock_qwen | | | | |
+| bedrock_claude | | | | |
+
+## Experiment 2
+
+...
+
+## Experiment 3
+
+## Experiment 4
+
+## Experiment 5
+
+Estimated cost: 0 (analysis only)
+
+## Total across experiments
+```
+
+`--estimate-cost` must refuse to run if any of the four smokes is missing, and it must refuse to call a model.
+
+## Experiment 2 prompt dump
+
+`--print-experiment-2-prompt` prints `STUDY_SYSTEM_PROMPT`, then the unfilled template from Step 1, then one filled example for the first cohort user. Append that filled example to `experiment2/SETUP.md`. Do not call a model.
+
+## Must pass
+
+- Four smoke prefixes each have 10 labels, or `user_count` labels if smaller, unless a content filter removed some rows. Print labeled and failed counts.
+- No `final.parquet` exists under any experiment prefix.
+- `COST_ESTIMATE.md` has the column set from the issue and a total section.
+- Experiment 2 filled prompt is visible in stdout and in `experiment2/SETUP.md`.
+- Pytest from Step 1 still exits 0.
+
+## Must fail
+
+- `--smoke` writing into `final.parquet`
+- `--estimate-cost` before all four smokes exist
+- `--smoke` calling `build_bedrock_engine` for Qwen or Claude
+- Full-cohort labeling flags running inside `--smoke`
+
+## Gate
+
+Stop at the end of this step. Do not start Step 3 until the user has approved, in writing, both the cost table and the experiment 2 prompt template.
+
+## Implement-from-spec notes
+
+Follow `/implement-from-spec`. Full auto for the smoke code, then stop for approval.
+
+Phase 1 names `--smoke` as the caller.
+
+Phase 2 to 5 implement `openai_runner.label_tasks`, `bedrock_runner.label_tasks`, smoke I/O, `cost.py`, and the three CLI flags. One commit per unit of work.
+
+Phase 6 is complete when smoke, cost, and the prompt dump have run once live, and the process has not labeled the full cohort.

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step2.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step2.md
@@ -3,7 +3,7 @@
 ## Scope
 
 - **Caller:** `experiments/ai_simulation_responses_2026_09_11/shared/run.py` `main` with `--smoke`, `--estimate-cost`, and `--print-experiment-2-prompt`
-- **Task:** Label the first 10 cohort users (or the full cohort if smaller) on all four models using the experiment 1 prompt. Write smoke objects under each model's `smoke/` prefix. Scale token estimates to experiments 2 to 4. Write `COST_ESTIMATE.md`. Print the experiment 2 template plus one filled example. Stop. Do not write `final.parquet`. Do not start full labeling.
+- **Task:** Label the first 10 cohort users (or the full cohort if smaller) on all four models using the experiment 1 prompt. Write smoke objects under each model's `smoke/` prefix on S3, with a gitignored local cache at the same relative path. Scale token estimates to experiments 2 to 4. Write `COST_ESTIMATE.md` locally and upload it with `put_new_mirrored`. Print the experiment 2 template plus one filled example. Stop. Do not write `final.parquet`. Do not start full labeling.
 - **Out of scope:** experiments 2 to 4 full runs, experiment 5, `RESULTS.md`, `CHANGELOG.md`, editing product engines
 
 ## Files to inspect (read-only)
@@ -23,7 +23,8 @@
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/openai_runner.py`
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/bedrock_runner.py`
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/cost.py` (new)
-- `/workspace/experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md` (new, live numbers)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/write.py` (reuse `put_new_mirrored` for the cost file)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md` (new, live numbers, local and S3)
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment2/SETUP.md` (add one filled example after the template)
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/SETUP.md` (record smoke user count and smoke URIs)
 
@@ -51,9 +52,11 @@ Prompt is experiment 1 only. All four models must run:
 
 Bedrock `max_tokens` is 256. Do not send content-filter failures to OpenAI. Record those ids in the smoke `errors.jsonl`.
 
-Smoke root URI pattern:
+Smoke root URI pattern, which equals the local relative path:
 
 `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment1/outputs/{model}/smoke/`
+
+Call `FeaturePaths.from_root_uri` with root `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment1/outputs/{model}/` and feature `smoke`, so smoke objects land under `experiments/ai_simulation_responses_2026_09_11/experiment1/outputs/{model}/smoke/`.
 
 `--smoke` prints, per model:
 
@@ -69,7 +72,7 @@ output_tokens=
 
 `cost.py` loads smoke token counts per request. Median input and output tokens are the medians across the 10 (or fewer) successful smoke requests for that model. Experiments 2 to 4 estimated input tokens equal that median times `user_count` times (`mean_chars(experiment_n) / mean_chars(experiment_1)`), using rendered prompts on the full cohort with no extra model call. Estimated output tokens equal smoke-median output tokens times `user_count`. Median USD uses the pinned rates in the plan. Low is 0.5 times median. High is 2 times median. Experiment 5 is 0 tokens and 0 USD.
 
-Write `experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md` with this shape:
+Write `experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md` locally, then upload the same bytes with `put_new_mirrored` so the S3 key is `experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md`. Print `cost_s3_uri=s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md`. A second `--estimate-cost` against that existing key raises `FileExistsError`. The markdown body has this shape:
 
 ```markdown
 ## Experiment 1
@@ -108,7 +111,7 @@ Estimated cost: 0 (analysis only)
 
 - Four smoke prefixes each have 10 labels, or `user_count` labels if smaller, unless a content filter removed some rows. Print labeled and failed counts.
 - No `final.parquet` exists under any experiment prefix.
-- `COST_ESTIMATE.md` has the column set from the issue and a total section.
+- `COST_ESTIMATE.md` has the column set from the issue and a total section, locally and at `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md`.
 - Experiment 2 filled prompt is visible in stdout and in `experiment2/SETUP.md`.
 - Pytest from Step 1 still exits 0.
 
@@ -118,6 +121,8 @@ Estimated cost: 0 (analysis only)
 - `--estimate-cost` before all four smokes exist
 - `--smoke` calling `build_bedrock_engine` for Qwen or Claude
 - Full-cohort labeling flags running inside `--smoke`
+- `--estimate-cost` writing `COST_ESTIMATE.md` only locally and skipping S3
+- A second `--estimate-cost` overwriting the existing S3 cost object
 
 ## Gate
 

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step3.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step3.md
@@ -3,7 +3,7 @@
 ## Scope
 
 - **Caller:** `experiments/ai_simulation_responses_2026_09_11/experiment{1,2,3,4}/run.py` with `--model {openai,bedrock_micro_nova,bedrock_qwen,bedrock_claude}`
-- **Task:** After written approval of `COST_ESTIMATE.md` and the experiment 2 prompt, label every cohort user for experiments 1 to 4 on all four models. Write campaign parquet parts and `final.parquet`. Four Cursor Grok High subagents run in parallel, one experiment per subagent.
+- **Task:** After written approval of `COST_ESTIMATE.md` and the experiment 2 prompt, label every cohort user for experiments 1 to 4 on all four models. Write campaign parquet parts and `final.parquet` to S3 at keys that equal `experiments/ai_simulation_responses_2026_09_11/experiment{N}/outputs/{model}/`. Four Cursor Grok High subagents run in parallel, one experiment per subagent.
 - **Out of scope:** scoring tables (`RESULTS.md` is Step 4), experiment 5, overwriting smoke objects, overwriting the cohort, editing product engines
 
 ## Files to inspect (read-only)
@@ -29,7 +29,7 @@
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment3/SETUP.md`
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment4/SETUP.md`
 
-Live parquet lives on S3 and in gitignored local `outputs/`. Do not commit parquet.
+Live parquet lives on S3 at keys that equal the local relative paths, and in gitignored local `outputs/`. Do not commit parquet. Do not overwrite `COST_ESTIMATE.md` on S3.
 
 ## Files forbidden to change
 
@@ -42,6 +42,7 @@ Live parquet lives on S3 and in gitignored local `outputs/`. Do not commit parqu
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/prompts.py` after Step 2 approval (do not silently edit the approved experiment 2 template)
 - Cohort S3 objects
 - Smoke prefixes from Step 2
+- `experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md` on S3
 
 ## Approval gate
 
@@ -67,11 +68,11 @@ Each subagent may run its four models sequentially. Do not start Step 4 scoring 
 
 ## Label contract
 
-Root URI:
+Root URI, which equals the local relative path:
 
 `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment{N}/outputs/{model}/`
 
-Reuse `FeaturePaths.from_root_uri`, `write_batch`, `adopt_unrecorded_batch`, `consolidate_final`, `new_manifest`, `save_manifest`, and `append_errors` the same way `experiments/test_separability_original_mirror_posts_2026_09_09/run.py` does.
+Call `FeaturePaths.from_root_uri` with root `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment{N}/outputs/` and feature `{model}`, so `final.parquet` lands at `experiments/ai_simulation_responses_2026_09_11/experiment{N}/outputs/{model}/final.parquet`. Do not insert an extra feature folder such as `labels/` or `remove_indexes/`. Reuse `write_batch`, `adopt_unrecorded_batch`, `consolidate_final`, `new_manifest`, `save_manifest`, and `append_errors` the same way `experiments/test_separability_original_mirror_posts_2026_09_09/run.py` does.
 
 `LabelTask.uri` is `prolific_id`. `LabelTask.text` is `render_user_prompt(experiment_number, user, trials)`.
 
@@ -91,7 +92,7 @@ final_uri=
 
 ## Must pass
 
-- Sixteen `final.parquet` objects exist after all subagents finish (4 experiments times 4 models), or fewer only when a model is entirely content-filtered, which must be reported.
+- Sixteen `final.parquet` objects exist after all subagents finish (4 experiments times 4 models), or fewer only when a model is entirely content-filtered, which must be reported. Each `final_uri=` starts with `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment`.
 - Smoke prefixes are unchanged.
 - Experiment 2 prompts match the approved template.
 - A rerun of the same `--model` after `final.parquet` exists labels 0 new users.
@@ -102,6 +103,7 @@ final_uri=
 - A Qwen or Claude run that goes through `build_bedrock_engine`
 - Writing experiment 2 labels into experiment 1 prefixes
 - Mixing OpenAI rows into a Bedrock `final.parquet`
+- Writing labels under a prefix that is not `experiments/ai_simulation_responses_2026_09_11/experiment{N}/outputs/{model}/`
 
 ## Implement-from-spec notes
 

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step3.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step3.md
@@ -1,0 +1,114 @@
+# Step 3: Label the full cohort for experiments 1 through 4
+
+## Scope
+
+- **Caller:** `experiments/ai_simulation_responses_2026_09_11/experiment{1,2,3,4}/run.py` with `--model {openai,bedrock_micro_nova,bedrock_qwen,bedrock_claude}`
+- **Task:** After written approval of `COST_ESTIMATE.md` and the experiment 2 prompt, label every cohort user for experiments 1 to 4 on all four models. Write campaign parquet parts and `final.parquet`. Four Cursor Grok High subagents run in parallel, one experiment per subagent.
+- **Out of scope:** scoring tables (`RESULTS.md` is Step 4), experiment 5, overwriting smoke objects, overwriting the cohort, editing product engines
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-12_ai_simulation_responses_a28567/plan.md` | Model list, S3 layout, resume rules |
+| `/workspace/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step1.md` | Shared runner and schema |
+| `/workspace/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step2.md` | Approval gate |
+| `/workspace/experiments/test_separability_original_mirror_posts_2026_09_09/run.py` | Part loop, `write_batch`, `consolidate_final`, skip existing parts |
+| `/workspace/data_platform/generate_features/s3_feature_batches.py` | Immutable parts |
+| `/workspace/data_platform/generate_features/platform_cli.py` | `CAMPAIGN_BATCH_SIZE` is 2000 |
+
+## Files allowed to change
+
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/run.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/run.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment2/run.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment3/run.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment4/run.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/SETUP.md` (record live run ids only)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment2/SETUP.md`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment3/SETUP.md`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment4/SETUP.md`
+
+Live parquet lives on S3 and in gitignored local `outputs/`. Do not commit parquet.
+
+## Files forbidden to change
+
+- `/workspace/data_platform/**`
+- `/workspace/webapp/**`
+- `/workspace/scripts/export_study_results.py`
+- `/workspace/lib/constants.py`
+- `/workspace/tests/**`
+- `/workspace/CHANGELOG.md`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/prompts.py` after Step 2 approval (do not silently edit the approved experiment 2 template)
+- Cohort S3 objects
+- Smoke prefixes from Step 2
+
+## Approval gate
+
+Do not run any command in this step unless the user has approved both of:
+
+1. `experiments/ai_simulation_responses_2026_09_11/COST_ESTIMATE.md`
+2. The experiment 2 prompt printed in Step 2
+
+If either approval is missing, the command exits non-zero with a message that names both files.
+
+## Subagent split
+
+Launch four Cursor Grok High subagents after approval. Each subagent owns one experiment folder and must not label another experiment.
+
+| Subagent | Working directory | Commands |
+|----------|-------------------|----------|
+| Experiment 1 | repo root | `experiment1/run.py --model` for each of the four models |
+| Experiment 2 | repo root | same with `experiment2/run.py` |
+| Experiment 3 | repo root | same with `experiment3/run.py` |
+| Experiment 4 | repo root | same with `experiment4/run.py` |
+
+Each subagent may run its four models sequentially. Do not start Step 4 scoring inside these subagents. Do not start experiment 5.
+
+## Label contract
+
+Root URI:
+
+`s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment{N}/outputs/{model}/`
+
+Reuse `FeaturePaths.from_root_uri`, `write_batch`, `adopt_unrecorded_batch`, `consolidate_final`, `new_manifest`, `save_manifest`, and `append_errors` the same way `experiments/test_separability_original_mirror_posts_2026_09_09/run.py` does.
+
+`LabelTask.uri` is `prolific_id`. `LabelTask.text` is `render_user_prompt(experiment_number, user, trials)`.
+
+Part size is `CAMPAIGN_BATCH_SIZE` (2000). One thousand users become `part-00000` only. Resume skips parts listed in `manifest.json`. If `final.parquet` already exists for that experiment and model, print `final exists` and return 0 without labeling.
+
+OpenAI uses `build_openai_engine`. Bedrock models use `label_tasks_collecting_failures` with the model id from the plan and `max_tokens=256`. Do not retry Bedrock content-filter failures through OpenAI.
+
+Print:
+
+```text
+experiment=
+model=
+labeled=
+failed=
+final_uri=
+```
+
+## Must pass
+
+- Sixteen `final.parquet` objects exist after all subagents finish (4 experiments times 4 models), or fewer only when a model is entirely content-filtered, which must be reported.
+- Smoke prefixes are unchanged.
+- Experiment 2 prompts match the approved template.
+- A rerun of the same `--model` after `final.parquet` exists labels 0 new users.
+
+## Must fail
+
+- Labeling without the approval gate
+- A Qwen or Claude run that goes through `build_bedrock_engine`
+- Writing experiment 2 labels into experiment 1 prefixes
+- Mixing OpenAI rows into a Bedrock `final.parquet`
+
+## Implement-from-spec notes
+
+Follow `/implement-from-spec`. Full auto after the approval gate.
+
+Phase 1 names `experiment1/run.py --model openai` as the first caller. The other 15 commands reuse the same shared path.
+
+Phase 5 implements one model path until it writes a real `final.parquet` on smoke-sized data already covered, then the remaining models. Do not batch all 16 commands into one commit of business logic. Shared resume loop is one unit of work. Each model id wiring is one unit of work.
+
+Phase 6 is complete when the 16 finals exist or the failed-count printout explains any shortfall.

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step4.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step4.md
@@ -3,7 +3,7 @@
 ## Scope
 
 - **Caller:** `experiments/ai_simulation_responses_2026_09_11/experiment{1,2,3,4}/run.py --score`
-- **Task:** Join each model's `final.parquet` to `cohort_trials.parquet`. Expand `remove_pair_indexes` into 20 binary predictions. Write user-level, post-level, party, toxicity, and stance tables into that experiment's `RESULTS.md`.
+- **Task:** Join each model's `final.parquet` to `cohort_trials.parquet`. Expand `remove_pair_indexes` into 20 binary predictions. Write user-level, post-level, party, toxicity, and stance tables into that experiment's `RESULTS.md`, then upload the same bytes with `put_new_mirrored`.
 - **Out of scope:** experiment 5, new model calls, changing gold labels, editing product engines
 
 ## Files to inspect (read-only)
@@ -19,10 +19,11 @@
 
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/score.py`
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/run.py`
-- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/RESULTS.md` (new)
-- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment2/RESULTS.md` (new)
-- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment3/RESULTS.md` (new)
-- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment4/RESULTS.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/write.py` (reuse `put_new_mirrored` for each RESULTS file)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/RESULTS.md` (new, local and S3)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment2/RESULTS.md` (new, local and S3)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment3/RESULTS.md` (new, local and S3)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment4/RESULTS.md` (new, local and S3)
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/test_score_predictions.py` (add table-shape cases if missing)
 
 ## Files forbidden to change
@@ -66,11 +67,13 @@ Two blocks: `sampled_stance=left` and `sampled_stance=right`. Same columns as th
 
 Each table states `scored_users` or `scored_pairs` and `failed_users`. Do not add p-values.
 
-`--score` also prints the user-level table and the post-level table to stdout.
+`--score` also prints the user-level table and the post-level table to stdout, plus `results_s3_uri=` for that experiment.
+
+Each `RESULTS.md` is uploaded with `put_new_mirrored` so the S3 key equals `experiments/ai_simulation_responses_2026_09_11/experiment{N}/RESULTS.md`. A second `--score` for the same experiment raises `FileExistsError` if that key exists.
 
 ## Must pass
 
-- Four `RESULTS.md` files exist, one per experiment 1 to 4.
+- Four `RESULTS.md` files exist, one per experiment 1 to 4, locally and at `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment{N}/RESULTS.md`.
 - User-level mean accuracy is the mean of per-user accuracies, not the pooled accuracy relabeled as user-level.
 - Baseline remove rate appears in every post-level table.
 - Pytest still exits 0.
@@ -80,6 +83,7 @@ Each table states `scored_users` or `scored_pairs` and `failed_users`. Do not ad
 - `--score` when a model `final.parquet` is missing
 - Treating user-level F1 as pooled F1
 - Counting `errors.jsonl` users as correct
+- `--score` writing `RESULTS.md` only locally and skipping S3
 
 ## Implement-from-spec notes
 

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step4.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step4.md
@@ -1,0 +1,94 @@
+# Step 4: Score experiments 1 through 4
+
+## Scope
+
+- **Caller:** `experiments/ai_simulation_responses_2026_09_11/experiment{1,2,3,4}/run.py --score`
+- **Task:** Join each model's `final.parquet` to `cohort_trials.parquet`. Expand `remove_pair_indexes` into 20 binary predictions. Write user-level, post-level, party, toxicity, and stance tables into that experiment's `RESULTS.md`.
+- **Out of scope:** experiment 5, new model calls, changing gold labels, editing product engines
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-12_ai_simulation_responses_a28567/plan.md` | Metric tables and positive class |
+| `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/score.py` | `user_metrics`, `pooled_metrics`, `slice_tables` |
+| `/workspace/experiments/finetune_qwen_model_2026_08_08/evaluate.py` | sklearn `zero_division=0` |
+| `/workspace/experiments/test_separability_original_mirror_posts_2026_09_09/RESULTS.md` | Table tone for an experiment RESULTS file |
+
+## Files allowed to change
+
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/score.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/run.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment1/RESULTS.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment2/RESULTS.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment3/RESULTS.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment4/RESULTS.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/test_score_predictions.py` (add table-shape cases if missing)
+
+## Files forbidden to change
+
+- `/workspace/data_platform/**`
+- `/workspace/webapp/**`
+- `/workspace/CHANGELOG.md` until Step 5 has experiment 5 `RESULTS.md`
+- Cohort parquet
+- Any `final.parquet` or smoke object
+- `shared/prompts.py`
+
+## Scoring contract
+
+`--score` requires `final.parquet` for all four models of that experiment. If one is missing, exit non-zero and name the URI.
+
+Join key is `prolific_id` = `source_record_id`. Users in `errors.jsonl` are omitted from that model's scores and counted as `failed_users`.
+
+`expand_remove_indexes` must not raise on a stored row. Rows that would raise should already be in `errors.jsonl`. If a stored list is invalid, count it as failed rather than crashing the whole score run.
+
+Positive class is remove (1). Use sklearn accuracy, precision, recall, and F1 with `zero_division=0`.
+
+### User-level table
+
+One row per model. Columns: model, n_users, mean accuracy, mean precision, mean recall, mean F1.
+
+### Post-level table
+
+One row per model. Columns: model, n_pairs, baseline remove rate, accuracy, precision, recall, F1.
+
+### By political stance (user-level)
+
+Two blocks, `party_group=democrat` and `party_group=republican`. Same columns as the user-level table. Users with empty `party_group` are omitted from these blocks only.
+
+### By toxicity tier of the original post (post-level)
+
+Three blocks: `sample_low_toxicity`, `sample_middle_toxicity`, `sample_high_toxicity`. Same columns as the post-level table.
+
+### By political lean of the original post (post-level)
+
+Two blocks: `sampled_stance=left` and `sampled_stance=right`. Same columns as the post-level table.
+
+Each table states `scored_users` or `scored_pairs` and `failed_users`. Do not add p-values.
+
+`--score` also prints the user-level table and the post-level table to stdout.
+
+## Must pass
+
+- Four `RESULTS.md` files exist, one per experiment 1 to 4.
+- User-level mean accuracy is the mean of per-user accuracies, not the pooled accuracy relabeled as user-level.
+- Baseline remove rate appears in every post-level table.
+- Pytest still exits 0.
+
+## Must fail
+
+- `--score` when a model `final.parquet` is missing
+- Treating user-level F1 as pooled F1
+- Counting `errors.jsonl` users as correct
+
+## Implement-from-spec notes
+
+Follow `/implement-from-spec`. Full auto.
+
+Phase 1 names `experiment1/run.py --score` as the caller.
+
+Phase 4 adds any missing pytest cases for party, toxicity, and stance slices on in-memory frames.
+
+Phase 5 implements `write_results_md` then wires `--score`. One commit per unit of work.
+
+Phase 6 is complete when all four `RESULTS.md` files exist and stdout printed both overall tables for experiment 1.

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step5.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step5.md
@@ -1,0 +1,92 @@
+# Step 5: Analyze error-rate ranks and prediction variance
+
+## Scope
+
+- **Caller:** `experiments/ai_simulation_responses_2026_09_11/experiment5/run.py --analyze-errors`
+- **Task:** Read the 16 `final.parquet` files from experiments 1 to 4. Write the 75 false-negative posts, the 75 false-positive posts, the 100 lowest-F1 users, within-user variance, and across-model variance into `experiment5/RESULTS.md`. Do not call a model. Do not train a classifier.
+- **Out of scope:** new prompts, new labels, editing experiments 1 to 4 `RESULTS.md`, editing product engines
+
+## Files to inspect (read-only)
+
+| Path | Why |
+|------|-----|
+| `/workspace/docs/plans/2026-09-12_ai_simulation_responses_a28567/plan.md` | Experiment 5 ranking rules |
+| `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/score.py` | User-level F1 helper |
+| `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/cohort.py` | Trial fields `sampled_stance`, `sample_toxicity_type` |
+
+## Files allowed to change
+
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/error_analysis.py` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/run.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/run.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/RESULTS.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/SETUP.md` (record input URIs)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/test_error_analysis.py` (new)
+- `/workspace/CHANGELOG.md` (one line after live `RESULTS.md` exists)
+
+## Files forbidden to change
+
+- `/workspace/data_platform/**`
+- `/workspace/webapp/**`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/prompts.py`
+- Cohort parquet
+- The 16 `final.parquet` files
+- Experiments 1 to 4 `RESULTS.md`
+
+## Analysis contract
+
+`--analyze-errors` exits non-zero if any of the 16 finals is missing, and names the URI.
+
+Pool predictions across experiments 1 to 4 and all four models. For each `prolific_id` plus `pair_index` plus `post_id`, false-negative rate is the share of scored model-experiment cells where gold is 1 and prediction is 0. False-positive rate is the share where gold is 0 and prediction is 1. Ties break by `post_id` ascending.
+
+Write two post lists of 75. If fewer than 75 posts have a nonzero rate, take all of them and print the shortfall. For the combined 150, print counts of `sample_toxicity_type` and `sampled_stance` next to the same counts on all other cohort posts.
+
+User rank: mean of user-level F1 across the 16 model-experiment cells that scored that user. Lowest mean F1 first. Take 100. Describe `party_group`, `political_ideology`, `age`, `education`, and that user's gold remove rate. No extra classifier.
+
+Within-user variance: for experiment 1 only, for each model, per user compute the variance of the 20 per-pair correctness indicators (1 if prediction equals gold). Then report mean, median, 25th percentile, and 75th percentile of those user variances, one row per model.
+
+Across-model variance: for experiment 1 only, for each user-pair, compute the standard deviation of the four models' remove predictions. Then report mean, median, 25th percentile, and 75th percentile of those standard deviations.
+
+Upload optional CSV lists to `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/` with `put_new` if they do not exist. `RESULTS.md` is the required artifact.
+
+## Pytest
+
+Class `TestRankFalseNegativePosts` and `TestRankWorstUsers`.
+
+```text
+given two posts where post A is a false negative on every model-experiment cell and post B is never a false negative
+when rank false-negative posts
+then post A ranks above post B
+
+given 10 users with distinct mean F1
+when rank worst users with k=3
+then the three lowest F1 users are returned in increasing F1 order
+```
+
+Tests use in-memory frames. They must not read S3.
+
+## Must pass
+
+- `experiment5/RESULTS.md` exists and names 75, 75, and 100 (or the shortfall).
+- Toxicity and stance shares appear for the 150-post set and for the remaining posts.
+- No language model is called.
+- `PYTHONPATH=. uv run pytest experiments/ai_simulation_responses_2026_09_11/shared/tests -q` exits 0.
+- `CHANGELOG.md` has one line that names issue 290 and the user count.
+
+## Must fail
+
+- `--analyze-errors` with a missing `final.parquet`
+- Adding a new LLM or a trained classifier
+- Ranking posts by toxicity instead of error rate
+
+## Implement-from-spec notes
+
+Follow `/implement-from-spec`. Full auto.
+
+Phase 1 names `experiment5/run.py --analyze-errors` as the caller.
+
+Phase 4 writes `test_error_analysis.py` before the rankers.
+
+Phase 5 implements false-negative ranking, false-positive ranking, user ranking, then variance summaries, then `RESULTS.md`. One commit per unit of work.
+
+Phase 6 is complete when `RESULTS.md` exists, pytest is green, and `CHANGELOG.md` has the live user count.

--- a/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step5.md
+++ b/docs/plans/2026-09-12_ai_simulation_responses_a28567/steps/step5.md
@@ -3,7 +3,7 @@
 ## Scope
 
 - **Caller:** `experiments/ai_simulation_responses_2026_09_11/experiment5/run.py --analyze-errors`
-- **Task:** Read the 16 `final.parquet` files from experiments 1 to 4. Write the 75 false-negative posts, the 75 false-positive posts, the 100 lowest-F1 users, within-user variance, and across-model variance into `experiment5/RESULTS.md`. Do not call a model. Do not train a classifier.
+- **Task:** Read the 16 `final.parquet` files from experiments 1 to 4. Write the 75 false-negative posts, the 75 false-positive posts, the 100 lowest-F1 users, within-user variance, and across-model variance into `experiment5/RESULTS.md`. Upload that report and the three ranked CSVs with `put_new_mirrored`. Do not call a model. Do not train a classifier.
 - **Out of scope:** new prompts, new labels, editing experiments 1 to 4 `RESULTS.md`, editing product engines
 
 ## Files to inspect (read-only)
@@ -18,8 +18,12 @@
 
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/error_analysis.py` (new)
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/run.py`
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/write.py` (reuse `put_new_mirrored`)
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/run.py`
-- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/RESULTS.md` (new)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/RESULTS.md` (new, local and S3)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/false_negative_posts.csv` (new, local and S3)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/false_positive_posts.csv` (new, local and S3)
+- `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/lowest_f1_users.csv` (new, local and S3)
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/experiment5/SETUP.md` (record input URIs)
 - `/workspace/experiments/ai_simulation_responses_2026_09_11/shared/tests/test_error_analysis.py` (new)
 - `/workspace/CHANGELOG.md` (one line after live `RESULTS.md` exists)
@@ -41,13 +45,22 @@ Pool predictions across experiments 1 to 4 and all four models. For each `prolif
 
 Write two post lists of 75. If fewer than 75 posts have a nonzero rate, take all of them and print the shortfall. For the combined 150, print counts of `sample_toxicity_type` and `sampled_stance` next to the same counts on all other cohort posts.
 
+Required ranked files, written locally and uploaded with `put_new_mirrored`:
+
+```text
+experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/false_negative_posts.csv
+experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/false_positive_posts.csv
+experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/lowest_f1_users.csv
+experiments/ai_simulation_responses_2026_09_11/experiment5/RESULTS.md
+```
+
+Print those four S3 URIs. A second `--analyze-errors` against existing keys raises `FileExistsError`. Experiment 5 has no model `final.parquet` folders. The ranked CSVs live under `experiment5/outputs/` as analysis files, not as campaign labels.
+
 User rank: mean of user-level F1 across the 16 model-experiment cells that scored that user. Lowest mean F1 first. Take 100. Describe `party_group`, `political_ideology`, `age`, `education`, and that user's gold remove rate. No extra classifier.
 
 Within-user variance: for experiment 1 only, for each model, per user compute the variance of the 20 per-pair correctness indicators (1 if prediction equals gold). Then report mean, median, 25th percentile, and 75th percentile of those user variances, one row per model.
 
 Across-model variance: for experiment 1 only, for each user-pair, compute the standard deviation of the four models' remove predictions. Then report mean, median, 25th percentile, and 75th percentile of those standard deviations.
-
-Upload optional CSV lists to `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment5/outputs/` with `put_new` if they do not exist. `RESULTS.md` is the required artifact.
 
 ## Pytest
 
@@ -67,17 +80,20 @@ Tests use in-memory frames. They must not read S3.
 
 ## Must pass
 
-- `experiment5/RESULTS.md` exists and names 75, 75, and 100 (or the shortfall).
+- `experiment5/RESULTS.md` exists locally and at `s3://mirrorview-experimental-artifacts/experiments/ai_simulation_responses_2026_09_11/experiment5/RESULTS.md`, and names 75 false-negative posts, 75 false-positive posts, and 100 users (or the shortfall).
+- The three ranked CSVs exist locally and at the matching S3 keys under `experiment5/outputs/`.
 - Toxicity and stance shares appear for the 150-post set and for the remaining posts.
 - No language model is called.
 - `PYTHONPATH=. uv run pytest experiments/ai_simulation_responses_2026_09_11/shared/tests -q` exits 0.
-- `CHANGELOG.md` has one line that names issue 290 and the user count.
+- `CHANGELOG.md` has one line that names issue 290 and the complete-participant count.
 
 ## Must fail
 
 - `--analyze-errors` with a missing `final.parquet`
 - Adding a new LLM or a trained classifier
 - Ranking posts by toxicity instead of error rate
+- `--analyze-errors` writing reports only locally and skipping S3
+- Taking 150 posts of one error type instead of 75 false negatives plus 75 false positives
 
 ## Implement-from-spec notes
 
@@ -87,6 +103,6 @@ Phase 1 names `experiment5/run.py --analyze-errors` as the caller.
 
 Phase 4 writes `test_error_analysis.py` before the rankers.
 
-Phase 5 implements false-negative ranking, false-positive ranking, user ranking, then variance summaries, then `RESULTS.md`. One commit per unit of work.
+Phase 5 implements false-negative ranking, false-positive ranking, user ranking, then variance summaries, then `RESULTS.md` and the three CSV uploads. One commit per unit of work.
 
-Phase 6 is complete when `RESULTS.md` exists, pytest is green, and `CHANGELOG.md` has the live user count.
+Phase 6 is complete when `RESULTS.md` and the three CSVs exist locally and on S3, pytest is green, and `CHANGELOG.md` has the live complete-participant count.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The September 2026 MirrorView study has human keep/remove labels on 20 linked-fate pairs, and the repo still has no plan for matching those labels with language models. [Issue 290 ](https://github.com/METResearchGroup/mirrorView-task/issues/290) asked for four prompt variants, four models, a cost table before any full run, and a later error analysis. A sixth experiment was then confirmed. Experiment 6 repeats experiment 1 with one unnumbered pair per call, so the model judges the way participants did on the website.

## Solution

The packet is `docs/plans/2026-09-12_ai_simulation_responses_a28567/`. `plan.md` is the overview. Step files name callers, files, commands, and pass/fail checks. `reviews.md` records the simplicity and persona notes that were folded into the plan. Step 6 is the one-pair process match.

### Shared setup

- Live study: `mirrorview_2026_09_09` in bucket `jspsych-mirror-view-2026-09-09`.
- Work folder: `experiments/ai_simulation_responses_2026_09_11/`.
- Cohort target: 1,000 complete participants, not 1,000 trial rows. If fewer complete users exist, take all of them and record the count. Experiment 6 reuses unique `prolific_id` values from that cohort (998 in the live write) and does not rebuild it.
- Pair presentation follows stored `pair_order`. Gold label is remove = 1.
- Derived files also live on S3. Bucket `mirrorview-experimental-artifacts`. The object key equals the repo-relative path. Writer is `CampaignObjectStore.put_new`. Python, tests, README, and SETUP stay in git only.

### Experiments 1 to 4

Experiments 1 to 4 are prompt variants. One call per user. JSON list `remove_pair_indexes`. Models are OpenAI Batch `gpt-5.4-nano`, Bedrock Nova Micro, Bedrock Qwen3 32B, and Claude Sonnet 4.6. Do not use `build_bedrock_engine`. Do not use `generate_campaign_feature`. Bedrock `max_tokens=256`, concurrency 8.

1. Posts only (20 pairs in one prompt).
2. Demographics then posts. Full labeling waits on prompt-template approval.
3. Reflection then posts.
4. Demographics, then reflection, then posts.

### Experiment 5

Error analysis only. Rank 75 false-negative posts, 75 false-positive posts, and 100 lowest-F1 users. No new model calls. Do not include experiment 6 labels.

### Experiment 6

Same posts-only content as experiment 1, except one unnumbered pair per call. The user message is only `Post 1:` and `Post 2:` for that trial. Output is `{"remove": "yes"}` or `{"remove": "no"}`. Claude is excluded. After 20 successful pair calls, stitch answers onto the experiment 1 remove-list shape. If any pair call fails, drop that user. Compare experiment 6 to experiment 1 on the intersection of scored users. Predicted remove rate is required. Separate cost file and approval live under `experiment6/`. Do not fold into experiment 5.

Full labeling for experiments 1 to 4 waits on the parent smoke cost table and the experiment 2 prompt. Full labeling for experiment 6 waits on `experiment6/COST_ESTIMATE.md` and `experiment6/APPROVAL.md`.

## Purpose

Pin the six-experiment setup, the cohort rule, the S3 path map, the 1-indexed remove-index schema, the yes/no pair schema, the two cost gates, and the experiment 5 ranking rules before anyone spends API budget. Out of scope for the pull request: running models, writing live `RESULTS.md`, and editing product engines.

## How to run

The pull request has no live experiment command. Read `docs/plans/2026-09-12_ai_simulation_responses_a28567/plan.md`, then the files under `steps/`.

After the plan is approved, implementation starts at Step 1:

```bash
PYTHONPATH=. uv run pytest experiments/ai_simulation_responses_2026_09_11/shared/tests -q
PYTHONPATH=. uv run python experiments/ai_simulation_responses_2026_09_11/shared/run.py --write-cohort
```

The commands do not exist until Step 1 is implemented. The expected outputs are listed in the plan.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aeb16c65-9708-4864-a515-af9923e46d1e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aeb16c65-9708-4864-a515-af9923e46d1e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

